### PR TITLE
[ fix ] Use `with` for matching propositionally equal type indices

### DIFF
--- a/src/Test/DepTyCheck/Gen/Auto/Core/ConsDerive.idr
+++ b/src/Test/DepTyCheck/Gen/Auto/Core/ConsDerive.idr
@@ -60,12 +60,12 @@ namespace NonObligatoryExts
               lhs                => failAt (getFC lhs) "Only applications to a name is supported, given \{lhs}"
             let Yes lengthCorrect = decEq ty.args.length args.length
               | No _ => failAt (getFC lhs) "INTERNAL ERROR: wrong count of unapp when analysing type application"
-            pure $ MkTypeApp ty $ rewrite lengthCorrect in Vect.fromList args <&> \arg => case getExpr arg of
+            pure $ MkTypeApp ty $ rewrite lengthCorrect in args.asVect <&> \arg => case getExpr arg of
               expr@(IVar _ n) => mirror . maybeToEither expr $ lookup n conArgIdxs
               expr            => Right expr
 
       -- Compute left-to-right need of generation when there are non-trivial types at the left
-      argsTypeApps <- for .| Vect.fromList con.args .| analyseTypeApp . type
+      argsTypeApps <- for con.args.asVect $ analyseTypeApp . type
 
       -- Decide how constructor arguments would be named during generation
       let bindNames : Vect (con.args.length) String

--- a/src/Test/DepTyCheck/Gen/Auto/Core/ConsDerive.idr
+++ b/src/Test/DepTyCheck/Gen/Auto/Core/ConsDerive.idr
@@ -108,7 +108,7 @@ namespace NonObligatoryExts
               modify $ insert genedArg . union (fromList subgeneratedArgs)
 
               -- Form a task for subgen
-              let (subgivensLength ** subgivens) = mapMaybe (\(ie, idx) => (idx,) <$> getRight ie) $ depArgs `zip` allFins'
+              let (subgivensLength ** subgivens) = mapMaybe (\(ie, idx) => (idx,) <$> getRight ie) $ depArgs `zip` Fin.range
               let subsig : GenSignature := MkGenSignature typeOfGened $ fromList $ fst <$> toList subgivens
               let Yes Refl = decEq subsig.givenParams.size subgivensLength
                 | No _ => fail "INTERNAL ERROR: error in given params set length computation"
@@ -166,7 +166,7 @@ namespace NonObligatoryExts
       ---------------------------------------------------------------------------------
 
       -- Arguments that no other argument depends on
-      let rightmostArgs = fromFoldable {f=Vect _} allFins' `difference` (givs `union` concat deps)
+      let rightmostArgs = fromFoldable {f=Vect _} range `difference` (givs `union` concat deps)
 
       ---------------------------------------------------------------
       -- Manage different possible variants of generation ordering --

--- a/src/Test/DepTyCheck/Gen/Auto/Core/ConsEntry.idr
+++ b/src/Test/DepTyCheck/Gen/Auto/Core/ConsEntry.idr
@@ -92,7 +92,7 @@ canonicConsBody sig name con = do
             Prelude.Yes Builtin.Refl => ~(subexpr)
         )
       deceqise : TTImp -> TTImp
-      deceqise = foldr (\ss, f => enrich1WithDecEq ss . f) id decEqedNames
+      deceqise = foldl (\f, ss => enrich1WithDecEq ss . f) id decEqedNames
 
   -- Form the declaration cases of a function generating values of particular constructor
   let fuelArg = "^cons_fuel^" -- I'm using a name containing chars that cannot be present in the code parsed from the Idris frontend

--- a/src/Test/DepTyCheck/Gen/Auto/Core/ConsEntry.idr
+++ b/src/Test/DepTyCheck/Gen/Auto/Core/ConsEntry.idr
@@ -104,13 +104,10 @@ canonicConsBody sig name con = do
         -- match results of `decEq`s
         step decEqsCnt _ [] = do
           let happyCase = patClauseWith rhs .| lhs originalBindExprs .| replicate _ `(Prelude.Yes Builtin.Refl)
-          let negativeCases = patClauseWith `(empty) (lhs renamedBindExprs) . noAtIdx <$> Fin.range {len=decEqsCnt}
-          happyCase :: toList negativeCases
+          let emptyCase = patClauseWith `(empty) .| lhs renamedBindExprs .| replicate _ `(_)
+          [ happyCase, emptyCase ]
 
           where
-
-            noAtIdx : Fin decEqsCnt -> Vect decEqsCnt TTImp
-            noAtIdx pointedIdx = Fin.tabulate $ \idx => if idx == pointedIdx then `(Prelude.No _) else `(_)
 
             patClauseWith : (rhs : TTImp) -> (mainLHS : TTImp) -> (decEqMatches : Vect decEqsCnt TTImp) -> Clause
             patClauseWith rhs mainLHS decEqMatches = PatClause EmptyFC (foldl (.$) mainLHS decEqMatches) rhs

--- a/src/Test/DepTyCheck/Gen/Auto/Core/Util.idr
+++ b/src/Test/DepTyCheck/Gen/Auto/Core/Util.idr
@@ -93,7 +93,7 @@ analyseDeepConsApp ccdi freeNames = catch . isD where
       | Nothing => fail "INTERNAL ERROR: cannot reorder formal determ info along with a call to a constructor"
 
     -- Analyze deeply all the arguments
-    deepArgs <- for (Vect.fromList args `zip` typeDetermInfo) $
+    deepArgs <- for (args.asVect `zip` typeDetermInfo) $
       \(anyApp, typeDetermined) => do
         subResult <- isD $ assert_smaller e $ getExpr anyApp
         let subResult = if ccdi then mapSnd (<+> typeDetermined) `mapLstDPair` subResult else subResult

--- a/src/Test/DepTyCheck/Gen/Auto/Util/Collections.idr
+++ b/src/Test/DepTyCheck/Gen/Auto/Util/Collections.idr
@@ -128,7 +128,7 @@ partitionEithersPos = map @{Compose} fromList . p where
 export
 joinEithersPos : (as : List a) -> (bs : List b) -> SortedSet (Fin $ as.length + bs.length) -> Maybe $ Vect (as.length + bs.length) $ Either a b
 joinEithersPos as bs lefts =
-  evalState (as, bs) $ for @{Compose} allFins' $ \idx => if contains idx lefts
+  evalState (as, bs) $ for @{Compose} range $ \idx => if contains idx lefts
     then do
       (x::as, bs) <- get
         | ([], _) => pure $ Nothing

--- a/src/Test/DepTyCheck/Gen/Auto/Util/Fin.idr
+++ b/src/Test/DepTyCheck/Gen/Auto/Util/Fin.idr
@@ -24,11 +24,6 @@ minus_last_gives_0 (S k) = minus_last_gives_0 k
 --- Collections of `Fin`s ---
 
 public export
-allFins' : {n : Nat} -> Vect n (Fin n)
-allFins' {n=Z  } = []
-allFins' {n=S k} = FZ :: map FS allFins'
-
-public export
 rangeFrom0To : Fin n -> List (Fin n)
 rangeFrom0To FZ     = [FZ]
 rangeFrom0To (FS x) = FZ :: (FS <$> rangeFrom0To x)

--- a/src/Test/DepTyCheck/Gen/Auto/Util/Reflection.idr
+++ b/src/Test/DepTyCheck/Gen/Auto/Util/Reflection.idr
@@ -276,7 +276,7 @@ export
 argDeps : Elaboration m => (args : List NamedArg) -> m $ DVect args.length $ SortedSet . Fin . Fin.finToNat
 argDeps args = do
   ignore $ check {expected=Type} $ fullSig defaultRet -- we can't return trustful result if given arguments do not form a nice Pi type
-  concatMap depsOfOne allFins'
+  concatMap depsOfOne range
 
   where
 

--- a/tests/gen-derivation/derivation/infra/empty-cons print 012/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 012/expected
@@ -61,36 +61,58 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                             $ IVar {arg:830}
                                                             $ IVar {arg:833}))))
                             IDef <<DerivedGen.XE>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n
-                                                  $ IBindVar to_be_deceqed^^n0)
-                                             (ICase (IApp. IVar Decidable.Equality.decEq
-                                                         $ IVar n
-                                                         $ IVar to_be_deceqed^^n0)
-                                                    (Implicit False)
-                                                    [ PatClause (IApp. IVar Prelude.No
-                                                                     $ Implicit True)
-                                                                (IVar Prelude.empty)
-                                                    , PatClause (IApp. IVar Prelude.Yes
-                                                                     $ IVar Builtin.Refl)
-                                                                (IVar empty) ]) ]
+                                 [ WithClause (IApp. IVar <<DerivedGen.XE>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar n
+                                                   $ IBindVar to_be_deceqed^^n0)
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^n0
+                                                   $ IVar n)
+
+                                              []
+                                              [ PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ IBindVar n
+                                                               $ (IApp. IVar Prelude.Yes
+                                                                      $ IVar Builtin.Refl))
+                                                          (IVar empty)
+                                              , PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ IBindVar to_be_deceqed^^n0
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ] ]
                             IDef <<DerivedGen.XS>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar to_be_deceqed^^n0))
-                                             (ICase (IApp. IVar Decidable.Equality.decEq
-                                                         $ IVar n
-                                                         $ IVar to_be_deceqed^^n0)
-                                                    (Implicit False)
-                                                    [ PatClause (IApp. IVar Prelude.No
-                                                                     $ Implicit True)
-                                                                (IVar Prelude.empty)
-                                                    , PatClause (IApp. IVar Prelude.Yes
-                                                                     $ IVar Builtin.Refl)
-                                                                (IVar empty) ])
+                                 [ WithClause (IApp. IVar <<DerivedGen.XS>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar n
+                                                   $ (IApp. IVar Prelude.Types.S
+                                                          $ IBindVar to_be_deceqed^^n0))
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^n0
+                                                   $ IVar n)
+
+                                              []
+                                              [ PatClause (IApp. IVar <<DerivedGen.XS>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ (IApp. IVar Prelude.Types.S
+                                                                      $ IBindVar n)
+                                                               $ (IApp. IVar Prelude.Yes
+                                                                      $ IVar Builtin.Refl))
+                                                          (IVar empty)
+                                              , PatClause (IApp. IVar <<DerivedGen.XS>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ (IApp. IVar Prelude.Types.S
+                                                                      $ IBindVar to_be_deceqed^^n0)
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ]
                                  , PatClause (IApp. IVar <<DerivedGen.XS>>
                                                   $ Implicit True
                                                   $ Implicit True

--- a/tests/gen-derivation/derivation/infra/empty-cons print 013/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 013/expected
@@ -83,32 +83,39 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                             $ IVar {arg:836}
                                                             $ IVar {arg:839}))))
                             IDef <<DerivedGen.XE>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar to_be_deceqed^^n0)
-                                                  $ IBindVar m
-                                                  $ IBindVar to_be_deceqed^^n1)
-                                             (ICase (IApp. IVar Decidable.Equality.decEq
-                                                         $ IVar n
-                                                         $ IVar to_be_deceqed^^n0)
-                                                    (Implicit False)
-                                                    [ PatClause (IApp. IVar Prelude.No
-                                                                     $ Implicit True)
-                                                                (IVar Prelude.empty)
-                                                    , PatClause (IApp. IVar Prelude.Yes
-                                                                     $ IVar Builtin.Refl)
-                                                                (ICase (IApp. IVar Decidable.Equality.decEq
-                                                                            $ IVar n
-                                                                            $ IVar to_be_deceqed^^n1)
-                                                                       (Implicit False)
-                                                                       [ PatClause (IApp. IVar Prelude.No
-                                                                                        $ Implicit True)
-                                                                                   (IVar Prelude.empty)
-                                                                       , PatClause (IApp. IVar Prelude.Yes
-                                                                                        $ IVar Builtin.Refl)
-                                                                                   (IVar empty) ]) ])
+                                 [ WithClause (IApp. IVar <<DerivedGen.XE>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar n
+                                                   $ (IApp. IVar Prelude.Types.S
+                                                          $ IBindVar to_be_deceqed^^n0)
+                                                   $ IBindVar m
+                                                   $ IBindVar to_be_deceqed^^n1)
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^n1
+                                                   $ IVar n)
+
+                                              []
+                                              [ PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ (IApp. IVar Prelude.Types.S
+                                                                      $ IBindVar to_be_deceqed^^n0)
+                                                               $ IBindVar m
+                                                               $ IBindVar n
+                                                               $ (IApp. IVar Prelude.Yes
+                                                                      $ IVar Builtin.Refl))
+                                                          (IVar empty)
+                                              , PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ (IApp. IVar Prelude.Types.S
+                                                                      $ IBindVar to_be_deceqed^^n0)
+                                                               $ IBindVar m
+                                                               $ IBindVar to_be_deceqed^^n1
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ]
                                  , PatClause (IApp. IVar <<DerivedGen.XE>>
                                                   $ Implicit True
                                                   $ Implicit True
@@ -117,28 +124,60 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                   $ Implicit True)
                                              (IVar empty) ]
                             IDef <<DerivedGen.XS>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n
-                                                  $ IBindVar to_be_deceqed^^n0
-                                                  $ IBindVar m
-                                                  $ IBindVar to_be_deceqed^^m1)
-                                             (ICase (IApp. IVar Decidable.Equality.decEq
-                                                         $ IVar m
-                                                         $ IVar to_be_deceqed^^m1)
-                                                    (Implicit False)
-                                                    [ PatClause (IApp. IVar Prelude.No
-                                                                     $ Implicit True)
-                                                                (IVar Prelude.empty)
-                                                    , PatClause (IApp. IVar Prelude.Yes
-                                                                     $ IVar Builtin.Refl)
-                                                                (ICase (IApp. IVar Decidable.Equality.decEq
-                                                                            $ IVar n
-                                                                            $ IVar to_be_deceqed^^n0)
-                                                                       (Implicit False)
-                                                                       [ PatClause (IApp. IVar Prelude.No
-                                                                                        $ Implicit True)
-                                                                                   (IVar Prelude.empty)
-                                                                       , PatClause (IApp. IVar Prelude.Yes
-                                                                                        $ IVar Builtin.Refl)
-                                                                                   (IVar empty) ]) ]) ] ]
+                                 [ WithClause (IApp. IVar <<DerivedGen.XS>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar n
+                                                   $ IBindVar to_be_deceqed^^n0
+                                                   $ IBindVar m
+                                                   $ IBindVar to_be_deceqed^^m1)
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^m1
+                                                   $ IVar m)
+
+                                              []
+                                              [ WithClause (IApp. IVar <<DerivedGen.XS>>
+                                                                $ IBindVar ^cons_fuel^
+                                                                $ IBindVar n
+                                                                $ IBindVar to_be_deceqed^^n0
+                                                                $ IBindVar m
+                                                                $ IBindVar m
+                                                                $ (IApp. IVar Prelude.Yes
+                                                                       $ IVar Builtin.Refl))
+                                                           MW
+                                                           (IApp. IVar Decidable.Equality.decEq
+                                                                $ IVar to_be_deceqed^^n0
+                                                                $ IVar n)
+
+                                                           []
+                                                           [ PatClause (IApp. IVar <<DerivedGen.XS>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ IBindVar n
+                                                                            $ IBindVar m
+                                                                            $ IBindVar m
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl))
+                                                                       (IVar empty)
+                                                           , PatClause (IApp. IVar <<DerivedGen.XS>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ IBindVar to_be_deceqed^^n0
+                                                                            $ IBindVar m
+                                                                            $ IBindVar m
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.No
+                                                                                   $ Implicit True))
+                                                                       (IVar empty) ]
+                                              , PatClause (IApp. IVar <<DerivedGen.XS>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ IBindVar to_be_deceqed^^n0
+                                                               $ IBindVar m
+                                                               $ IBindVar to_be_deceqed^^m1
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ] ] ]

--- a/tests/gen-derivation/derivation/infra/empty-cons print 014/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 014/expected
@@ -86,32 +86,39 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                             $ IVar {arg:836}
                                                             $ IVar {arg:839}))))
                             IDef <<DerivedGen.XE>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar to_be_deceqed^^n0)
-                                                  $ IBindVar m
-                                                  $ IBindVar to_be_deceqed^^n1)
-                                             (ICase (IApp. IVar Decidable.Equality.decEq
-                                                         $ IVar n
-                                                         $ IVar to_be_deceqed^^n0)
-                                                    (Implicit False)
-                                                    [ PatClause (IApp. IVar Prelude.No
-                                                                     $ Implicit True)
-                                                                (IVar Prelude.empty)
-                                                    , PatClause (IApp. IVar Prelude.Yes
-                                                                     $ IVar Builtin.Refl)
-                                                                (ICase (IApp. IVar Decidable.Equality.decEq
-                                                                            $ IVar n
-                                                                            $ IVar to_be_deceqed^^n1)
-                                                                       (Implicit False)
-                                                                       [ PatClause (IApp. IVar Prelude.No
-                                                                                        $ Implicit True)
-                                                                                   (IVar Prelude.empty)
-                                                                       , PatClause (IApp. IVar Prelude.Yes
-                                                                                        $ IVar Builtin.Refl)
-                                                                                   (IVar empty) ]) ])
+                                 [ WithClause (IApp. IVar <<DerivedGen.XE>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar n
+                                                   $ (IApp. IVar Prelude.Types.S
+                                                          $ IBindVar to_be_deceqed^^n0)
+                                                   $ IBindVar m
+                                                   $ IBindVar to_be_deceqed^^n1)
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^n1
+                                                   $ IVar n)
+
+                                              []
+                                              [ PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ (IApp. IVar Prelude.Types.S
+                                                                      $ IBindVar to_be_deceqed^^n0)
+                                                               $ IBindVar m
+                                                               $ IBindVar n
+                                                               $ (IApp. IVar Prelude.Yes
+                                                                      $ IVar Builtin.Refl))
+                                                          (IVar empty)
+                                              , PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ (IApp. IVar Prelude.Types.S
+                                                                      $ IBindVar to_be_deceqed^^n0)
+                                                               $ IBindVar m
+                                                               $ IBindVar to_be_deceqed^^n1
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ]
                                  , PatClause (IApp. IVar <<DerivedGen.XE>>
                                                   $ Implicit True
                                                   $ Implicit True
@@ -120,28 +127,60 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                   $ Implicit True)
                                              (IVar empty) ]
                             IDef <<DerivedGen.XS>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n
-                                                  $ IBindVar to_be_deceqed^^n0
-                                                  $ IBindVar m
-                                                  $ IBindVar to_be_deceqed^^m1)
-                                             (ICase (IApp. IVar Decidable.Equality.decEq
-                                                         $ IVar m
-                                                         $ IVar to_be_deceqed^^m1)
-                                                    (Implicit False)
-                                                    [ PatClause (IApp. IVar Prelude.No
-                                                                     $ Implicit True)
-                                                                (IVar Prelude.empty)
-                                                    , PatClause (IApp. IVar Prelude.Yes
-                                                                     $ IVar Builtin.Refl)
-                                                                (ICase (IApp. IVar Decidable.Equality.decEq
-                                                                            $ IVar n
-                                                                            $ IVar to_be_deceqed^^n0)
-                                                                       (Implicit False)
-                                                                       [ PatClause (IApp. IVar Prelude.No
-                                                                                        $ Implicit True)
-                                                                                   (IVar Prelude.empty)
-                                                                       , PatClause (IApp. IVar Prelude.Yes
-                                                                                        $ IVar Builtin.Refl)
-                                                                                   (IVar empty) ]) ]) ] ]
+                                 [ WithClause (IApp. IVar <<DerivedGen.XS>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar n
+                                                   $ IBindVar to_be_deceqed^^n0
+                                                   $ IBindVar m
+                                                   $ IBindVar to_be_deceqed^^m1)
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^m1
+                                                   $ IVar m)
+
+                                              []
+                                              [ WithClause (IApp. IVar <<DerivedGen.XS>>
+                                                                $ IBindVar ^cons_fuel^
+                                                                $ IBindVar n
+                                                                $ IBindVar to_be_deceqed^^n0
+                                                                $ IBindVar m
+                                                                $ IBindVar m
+                                                                $ (IApp. IVar Prelude.Yes
+                                                                       $ IVar Builtin.Refl))
+                                                           MW
+                                                           (IApp. IVar Decidable.Equality.decEq
+                                                                $ IVar to_be_deceqed^^n0
+                                                                $ IVar n)
+
+                                                           []
+                                                           [ PatClause (IApp. IVar <<DerivedGen.XS>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ IBindVar n
+                                                                            $ IBindVar m
+                                                                            $ IBindVar m
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl))
+                                                                       (IVar empty)
+                                                           , PatClause (IApp. IVar <<DerivedGen.XS>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ IBindVar to_be_deceqed^^n0
+                                                                            $ IBindVar m
+                                                                            $ IBindVar m
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.No
+                                                                                   $ Implicit True))
+                                                                       (IVar empty) ]
+                                              , PatClause (IApp. IVar <<DerivedGen.XS>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ IBindVar to_be_deceqed^^n0
+                                                               $ IBindVar m
+                                                               $ IBindVar to_be_deceqed^^m1
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ] ] ]

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/010 eq-n/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/010 eq-n/expected
@@ -42,20 +42,30 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                             $ IVar {arg:830}
                                                             $ IVar {arg:833}))))
                             IDef <<DerivedGen.ReflN>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.ReflN>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar x
-                                                  $ IBindVar to_be_deceqed^^x0)
-                                             (ICase (IApp. IVar Decidable.Equality.decEq
-                                                         $ IVar x
-                                                         $ IVar to_be_deceqed^^x0)
-                                                    (Implicit False)
-                                                    [ PatClause (IApp. IVar Prelude.No
-                                                                     $ Implicit True)
-                                                                (IVar Prelude.empty)
-                                                    , PatClause (IApp. IVar Prelude.Yes
-                                                                     $ IVar Builtin.Refl)
-                                                                (IApp. (INamedApp. IVar Prelude.pure
-                                                                                 $ IVar Test.DepTyCheck.Gen.Gen)
-                                                                     $ (INamedApp. IVar DerivedGen.ReflN
-                                                                                 $ IVar x)) ]) ] ]
+                                 [ WithClause (IApp. IVar <<DerivedGen.ReflN>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar x
+                                                   $ IBindVar to_be_deceqed^^x0)
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^x0
+                                                   $ IVar x)
+
+                                              []
+                                              [ PatClause (IApp. IVar <<DerivedGen.ReflN>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar x
+                                                               $ IBindVar x
+                                                               $ (IApp. IVar Prelude.Yes
+                                                                      $ IVar Builtin.Refl))
+                                                          (IApp. (INamedApp. IVar Prelude.pure
+                                                                           $ IVar Test.DepTyCheck.Gen.Gen)
+                                                               $ (INamedApp. IVar DerivedGen.ReflN
+                                                                           $ IVar x))
+                                              , PatClause (IApp. IVar <<DerivedGen.ReflN>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar x
+                                                               $ IBindVar to_be_deceqed^^x0
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ] ] ]

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/014 eq deepcons/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/014 eq deepcons/expected
@@ -70,25 +70,39 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                             $ IVar {arg:830}
                                                             $ IVar {arg:833}))))
                             IDef <<DerivedGen.Base>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.Base>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar x
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ IBindVar to_be_deceqed^^x0)))
-                                             (ICase (IApp. IVar Decidable.Equality.decEq
-                                                         $ IVar x
-                                                         $ IVar to_be_deceqed^^x0)
-                                                    (Implicit False)
-                                                    [ PatClause (IApp. IVar Prelude.No
-                                                                     $ Implicit True)
-                                                                (IVar Prelude.empty)
-                                                    , PatClause (IApp. IVar Prelude.Yes
-                                                                     $ IVar Builtin.Refl)
-                                                                (IApp. (INamedApp. IVar Prelude.pure
-                                                                                 $ IVar Test.DepTyCheck.Gen.Gen)
-                                                                     $ (INamedApp. IVar DerivedGen.Base
-                                                                                 $ IVar x)) ])
+                                 [ WithClause (IApp. IVar <<DerivedGen.Base>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar x
+                                                   $ (IApp. IVar Prelude.Types.S
+                                                          $ (IApp. IVar Prelude.Types.S
+                                                                 $ IBindVar to_be_deceqed^^x0)))
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^x0
+                                                   $ IVar x)
+
+                                              []
+                                              [ PatClause (IApp. IVar <<DerivedGen.Base>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar x
+                                                               $ (IApp. IVar Prelude.Types.S
+                                                                      $ (IApp. IVar Prelude.Types.S
+                                                                             $ IBindVar x))
+                                                               $ (IApp. IVar Prelude.Yes
+                                                                      $ IVar Builtin.Refl))
+                                                          (IApp. (INamedApp. IVar Prelude.pure
+                                                                           $ IVar Test.DepTyCheck.Gen.Gen)
+                                                               $ (INamedApp. IVar DerivedGen.Base
+                                                                           $ IVar x))
+                                              , PatClause (IApp. IVar <<DerivedGen.Base>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar x
+                                                               $ (IApp. IVar Prelude.Types.S
+                                                                      $ (IApp. IVar Prelude.Types.S
+                                                                             $ IBindVar to_be_deceqed^^x0))
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ]
                                  , PatClause (IApp. IVar <<DerivedGen.Base>>
                                                   $ Implicit True
                                                   $ Implicit True

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/AlternativeCore.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/AlternativeCore.idr
@@ -1,0 +1,1 @@
+../_common/AlternativeCore.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/DerivedGen.idr
@@ -1,0 +1,24 @@
+module DerivedGen
+
+import AlternativeCore
+import PrintDerivation
+
+import Data.Fin
+
+%default total
+
+data X : Type
+
+data Y : X -> Type where
+  MkY : Y x
+
+data X : Type where
+  Nil  : X
+  Cons : (x : X) -> Y x -> X
+
+data Z : X -> X -> Type where
+  MkZ : (prf : Y x) -> Z (Cons x prf) (Cons x prf)
+
+%language ElabReflection
+
+%runElab printDerived @{MainCoreDerivator @{LeastEffort}} $ Fuel -> (x : X) -> (x' : X) -> Gen $ Z x x'

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/PrintDerivation.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/PrintDerivation.idr
@@ -1,0 +1,1 @@
+../_common/PrintDerivation.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/RunDerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/depends
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/depends
@@ -1,0 +1,1 @@
+../_common/depends/

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/derive.ipkg
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/expected
@@ -1,0 +1,120 @@
+1/3: Building AlternativeCore (AlternativeCore.idr)
+2/3: Building PrintDerivation (PrintDerivation.idr)
+3/3: Building DerivedGen (DerivedGen.idr)
+LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (x : X) -> (x' : X) -> Gen (Z x x')
+LOG gen.auto.derive.infra:0: 
+ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
+    => (MW ExplicitArg x : IVar DerivedGen.X)
+    => (MW ExplicitArg x' : IVar DerivedGen.X)
+    => ILocal (IApp. IVar <DerivedGen.Z>[0, 1]
+                   $ IVar ^outmost-fuel^
+                   $ IVar x
+                   $ IVar x')
+         IClaim MW
+                Export
+                []
+                (MkTy <DerivedGen.Z>[0, 1]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (MW ExplicitArg {arg:850} : IVar DerivedGen.X)
+                          -> (MW ExplicitArg {arg:853} : IVar DerivedGen.X)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ (IApp. IVar DerivedGen.Z
+                                         $ IVar {arg:850}
+                                         $ IVar {arg:853}))))
+         IDef <DerivedGen.Z>[0, 1]
+              [ PatClause (IApp. IVar <DerivedGen.Z>[0, 1]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar {arg:850}
+                               $ IBindVar {arg:853})
+                          (ILocal (IApp. IVar <<DerivedGen.MkZ>>
+                                       $ IVar ^fuel_arg^
+                                       $ IVar {arg:850}
+                                       $ IVar {arg:853}))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkZ>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:850} : IVar DerivedGen.X)
+                                             -> (MW ExplicitArg {arg:853} : IVar DerivedGen.X)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ (IApp. IVar DerivedGen.Z
+                                                            $ IVar {arg:850}
+                                                            $ IVar {arg:853}))))
+                            IDef <<DerivedGen.MkZ>>
+                                 [ WithClause (IApp. IVar <<DerivedGen.MkZ>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ (IApp. IVar DerivedGen.Cons
+                                                          $ IBindVar x
+                                                          $ IBindVar prf)
+                                                   $ (IApp. IVar DerivedGen.Cons
+                                                          $ IBindVar to_be_deceqed^^x0
+                                                          $ IBindVar to_be_deceqed^^prf1))
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^x0
+                                                   $ IVar x)
+
+                                              []
+                                              [ WithClause (IApp. IVar <<DerivedGen.MkZ>>
+                                                                $ IBindVar ^cons_fuel^
+                                                                $ (IApp. IVar DerivedGen.Cons
+                                                                       $ IBindVar x
+                                                                       $ IBindVar prf)
+                                                                $ (IApp. IVar DerivedGen.Cons
+                                                                       $ IBindVar x
+                                                                       $ IBindVar to_be_deceqed^^prf1)
+                                                                $ (IApp. IVar Prelude.Yes
+                                                                       $ IVar Builtin.Refl))
+                                                           MW
+                                                           (IApp. IVar Decidable.Equality.decEq
+                                                                $ IVar to_be_deceqed^^prf1
+                                                                $ IVar prf)
+
+                                                           []
+                                                           [ PatClause (IApp. IVar <<DerivedGen.MkZ>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ (IApp. IVar DerivedGen.Cons
+                                                                                   $ IBindVar x
+                                                                                   $ IBindVar prf)
+                                                                            $ (IApp. IVar DerivedGen.Cons
+                                                                                   $ IBindVar x
+                                                                                   $ IBindVar prf)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl))
+                                                                       (IApp. (INamedApp. IVar Prelude.pure
+                                                                                        $ IVar Test.DepTyCheck.Gen.Gen)
+                                                                            $ (IApp. (INamedApp. IVar DerivedGen.MkZ
+                                                                                               $ IVar x)
+                                                                                   $ IVar prf))
+                                                           , PatClause (IApp. IVar <<DerivedGen.MkZ>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ (IApp. IVar DerivedGen.Cons
+                                                                                   $ IBindVar x
+                                                                                   $ IBindVar prf)
+                                                                            $ (IApp. IVar DerivedGen.Cons
+                                                                                   $ IBindVar x
+                                                                                   $ IBindVar to_be_deceqed^^prf1)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.No
+                                                                                   $ Implicit True))
+                                                                       (IVar empty) ]
+                                              , PatClause (IApp. IVar <<DerivedGen.MkZ>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ (IApp. IVar DerivedGen.Cons
+                                                                      $ IBindVar x
+                                                                      $ IBindVar prf)
+                                                               $ (IApp. IVar DerivedGen.Cons
+                                                                      $ IBindVar to_be_deceqed^^x0
+                                                                      $ IBindVar to_be_deceqed^^prf1)
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ]
+                                 , PatClause (IApp. IVar <<DerivedGen.MkZ>>
+                                                  $ Implicit True
+                                                  $ Implicit True
+                                                  $ Implicit True)
+                                             (IVar empty) ] ]

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/run
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/AlternativeCore.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/AlternativeCore.idr
@@ -1,0 +1,1 @@
+../_common/AlternativeCore.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/DerivedGen.idr
@@ -1,0 +1,30 @@
+module DerivedGen
+
+import AlternativeCore
+import PrintDerivation
+
+%default total
+
+%language ElabReflection
+
+%hint
+UsedConstructorDerivator : ConstructorDerivator
+UsedConstructorDerivator = LeastEffort
+
+data X : Type where
+  Nil : X
+  (::) : Unit -> X -> X
+
+DecEq X where
+  [] `decEq` [] = Yes Refl
+  [] `decEq` (y :: ys) = No $ \case Refl impossible
+  (x :: xs) `decEq` [] = No $ \case Refl impossible
+  (() :: xs) `decEq` (() :: ys) = case xs `decEq` ys of
+                                    (Yes prf) => rewrite prf in Yes Refl
+                                    (No contra) => No $ \prf => ?wut
+
+data Y : (xs : X) -> (ys : X) -> Type where
+  A : Y (x :: xs) (x :: xs)
+  B : Y xs ys -> Y (x :: xs) (y :: ys)
+
+%runElab printDerived $ Fuel -> (xs : X) -> (ys : X) -> Gen $ Y xs ys

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/DerivedGen.idr
@@ -15,14 +15,6 @@ data X : Type where
   Nil : X
   (::) : Unit -> X -> X
 
-DecEq X where
-  [] `decEq` [] = Yes Refl
-  [] `decEq` (y :: ys) = No $ \case Refl impossible
-  (x :: xs) `decEq` [] = No $ \case Refl impossible
-  (() :: xs) `decEq` (() :: ys) = case xs `decEq` ys of
-                                    (Yes prf) => rewrite prf in Yes Refl
-                                    (No contra) => No $ \prf => ?wut
-
 data Y : (xs : X) -> (ys : X) -> Type where
   A : Y (x :: xs) (x :: xs)
   B : Y xs ys -> Y (x :: xs) (y :: ys)

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/PrintDerivation.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/PrintDerivation.idr
@@ -1,0 +1,1 @@
+../_common/PrintDerivation.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/RunDerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/depends
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/depends
@@ -1,0 +1,1 @@
+../_common/depends

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/derive.ipkg
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/expected
@@ -1,0 +1,176 @@
+1/3: Building AlternativeCore (AlternativeCore.idr)
+2/3: Building PrintDerivation (PrintDerivation.idr)
+3/3: Building DerivedGen (DerivedGen.idr)
+LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (xs : X) -> (ys : X) -> Gen (Y xs ys)
+LOG gen.auto.derive.infra:0: 
+ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
+    => (MW ExplicitArg xs : IVar DerivedGen.X)
+    => (MW ExplicitArg ys : IVar DerivedGen.X)
+    => ILocal (IApp. IVar <DerivedGen.Y>[0, 1]
+                   $ IVar ^outmost-fuel^
+                   $ IVar xs
+                   $ IVar ys)
+         IClaim MW
+                Export
+                []
+                (MkTy <DerivedGen.Y>[0, 1]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (MW ExplicitArg xs : IVar DerivedGen.X)
+                          -> (MW ExplicitArg ys : IVar DerivedGen.X)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ (IApp. IVar DerivedGen.Y
+                                         $ IVar xs
+                                         $ IVar ys))))
+         IDef <DerivedGen.Y>[0, 1]
+              [ PatClause (IApp. IVar <DerivedGen.Y>[0, 1]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar xs
+                               $ IBindVar ys)
+                          (ILocal (ICase (IVar ^fuel_arg^)
+                                         (IVar Data.Fuel.Fuel)
+                                         [ PatClause (IVar Data.Fuel.Dry)
+                                                     (IApp. IVar <<DerivedGen.A>>
+                                                          $ IVar Data.Fuel.Dry
+                                                          $ IVar xs
+                                                          $ IVar ys)
+                                         , PatClause (IApp. IVar Data.Fuel.More
+                                                          $ IBindVar ^sub^fuel_arg^)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.oneOf
+                                                          $ (IApp. IVar ::
+                                                                 $ (IApp. IVar <<DerivedGen.A>>
+                                                                        $ IVar ^fuel_arg^
+                                                                        $ IVar xs
+                                                                        $ IVar ys)
+                                                                 $ (IApp. IVar ::
+                                                                        $ (IApp. IVar <<DerivedGen.B>>
+                                                                               $ IVar ^sub^fuel_arg^
+                                                                               $ IVar xs
+                                                                               $ IVar ys)
+                                                                        $ IVar Nil))) ]))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.A>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg xs : IVar DerivedGen.X)
+                                             -> (MW ExplicitArg ys : IVar DerivedGen.X)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ (IApp. IVar DerivedGen.Y
+                                                            $ IVar xs
+                                                            $ IVar ys))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.B>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg xs : IVar DerivedGen.X)
+                                             -> (MW ExplicitArg ys : IVar DerivedGen.X)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ (IApp. IVar DerivedGen.Y
+                                                            $ IVar xs
+                                                            $ IVar ys))))
+                            IDef <<DerivedGen.A>>
+                                 [ WithClause (IApp. IVar <<DerivedGen.A>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ (IApp. IVar DerivedGen.(::)
+                                                          $ IBindVar x
+                                                          $ IBindVar xs)
+                                                   $ (IApp. IVar DerivedGen.(::)
+                                                          $ IBindVar to_be_deceqed^^x0
+                                                          $ IBindVar to_be_deceqed^^xs1))
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^xs1
+                                                   $ IVar xs)
+
+                                              []
+                                              [ WithClause (IApp. IVar <<DerivedGen.A>>
+                                                                $ IBindVar ^cons_fuel^
+                                                                $ (IApp. IVar DerivedGen.(::)
+                                                                       $ IBindVar x
+                                                                       $ IBindVar xs)
+                                                                $ (IApp. IVar DerivedGen.(::)
+                                                                       $ IBindVar to_be_deceqed^^x0
+                                                                       $ IBindVar xs)
+                                                                $ (IApp. IVar Prelude.Yes
+                                                                       $ IVar Builtin.Refl))
+                                                           MW
+                                                           (IApp. IVar Decidable.Equality.decEq
+                                                                $ IVar to_be_deceqed^^x0
+                                                                $ IVar x)
+
+                                                           []
+                                                           [ PatClause (IApp. IVar <<DerivedGen.A>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ (IApp. IVar DerivedGen.(::)
+                                                                                   $ IBindVar x
+                                                                                   $ IBindVar xs)
+                                                                            $ (IApp. IVar DerivedGen.(::)
+                                                                                   $ IBindVar x
+                                                                                   $ IBindVar xs)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl))
+                                                                       (IApp. (INamedApp. IVar Prelude.pure
+                                                                                        $ IVar Test.DepTyCheck.Gen.Gen)
+                                                                            $ (INamedApp. IVar DerivedGen.A
+                                                                                        $ IVar xs
+                                                                                        $ IVar x))
+                                                           , PatClause (IApp. IVar <<DerivedGen.A>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ (IApp. IVar DerivedGen.(::)
+                                                                                   $ IBindVar x
+                                                                                   $ IBindVar xs)
+                                                                            $ (IApp. IVar DerivedGen.(::)
+                                                                                   $ IBindVar to_be_deceqed^^x0
+                                                                                   $ IBindVar xs)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.No
+                                                                                   $ Implicit True))
+                                                                       (IVar empty) ]
+                                              , PatClause (IApp. IVar <<DerivedGen.A>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ (IApp. IVar DerivedGen.(::)
+                                                                      $ IBindVar x
+                                                                      $ IBindVar xs)
+                                                               $ (IApp. IVar DerivedGen.(::)
+                                                                      $ IBindVar to_be_deceqed^^x0
+                                                                      $ IBindVar to_be_deceqed^^xs1)
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ]
+                                 , PatClause (IApp. IVar <<DerivedGen.A>>
+                                                  $ Implicit True
+                                                  $ Implicit True
+                                                  $ Implicit True)
+                                             (IVar empty) ]
+                            IDef <<DerivedGen.B>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.B>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ (IApp. IVar DerivedGen.(::)
+                                                         $ IBindVar x
+                                                         $ IBindVar xs)
+                                                  $ (IApp. IVar DerivedGen.(::)
+                                                         $ IBindVar y
+                                                         $ IBindVar ys))
+                                             (IApp. IVar >>=
+                                                  $ (IApp. IVar <DerivedGen.Y>[0, 1]
+                                                         $ IVar ^cons_fuel^
+                                                         $ IVar xs
+                                                         $ IVar ys)
+                                                  $ (ILam.  (MW ExplicitArg ^bnd^{arg:854} : Implicit False)
+                                                         => (IApp. (INamedApp. IVar Prelude.pure
+                                                                             $ IVar Test.DepTyCheck.Gen.Gen)
+                                                                 $ (IApp. (INamedApp. IVar DerivedGen.B
+                                                                                    $ IVar x
+                                                                                    $ IVar y
+                                                                                    $ IVar ys
+                                                                                    $ IVar xs)
+                                                                        $ IVar ^bnd^{arg:854}))))
+                                 , PatClause (IApp. IVar <<DerivedGen.B>>
+                                                  $ Implicit True
+                                                  $ Implicit True
+                                                  $ Implicit True)
+                                             (IVar empty) ] ]

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/run
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/DerivedGen.idr
@@ -1,0 +1,55 @@
+module DerivedGen
+
+import RunDerivedGen
+
+import Data.Fin
+
+%default total
+
+data X : Type
+
+data Y : X -> Type where
+  MkY : Y x
+
+data X : Type where
+  Nil : X
+  Cons : (x : X) -> Y x -> X
+
+data Z : X -> X -> Type where
+  MkZ : (prf : Y x) -> Z (Cons x prf) (Cons x prf)
+
+Show (Y x) where
+  show MkY = "MkY"
+
+Show X where
+  show Nil = "Nil"
+  show (Cons x y) = "Cons (\{show x}) (\{show y})"
+
+Show (Z a b) where
+  show (MkZ prf) = "MkZ (\{show prf})"
+
+DecEq (Y x) where
+  decEq MkY MkY = Yes Refl
+
+DecEq X where
+  decEq Nil Nil = Yes Refl
+  decEq Nil (Cons _ _) = No $ \case Refl impossible
+  decEq (Cons _ _) Nil = No $ \case Refl impossible
+  decEq (Cons x xs) (Cons y ys) with (decEq x y)
+    _                             | No c     = No $ \Refl => c Refl
+    decEq (Cons x xs) (Cons x ys) | Yes Refl with (decEq xs ys)
+      decEq (Cons x xs) (Cons x xs) | Yes Refl | Yes Refl = Yes Refl
+      decEq (Cons x xs) (Cons x ys) | Yes Refl | No c     = No $ \Refl => c Refl
+
+%language ElabReflection
+
+checkedGen : Fuel -> (x : X) -> (x' : X) -> Gen $ Z x x'
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl Nil Nil
+  , G $ \fl => checkedGen fl Nil (Cons Nil MkY)
+  , G $ \fl => checkedGen fl (Cons Nil MkY) (Cons Nil MkY)
+  , G $ \fl => checkedGen fl ((Nil `Cons` MkY) `Cons` MkY) ((Nil `Cons` MkY) `Cons` MkY)
+  ]

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/RunDerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/depends
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/depends
@@ -1,0 +1,1 @@
+../_common/depends/

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/derive.ipkg
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/expected
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/expected
@@ -1,0 +1,11 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Generated values:
+-----
+-----
+-----
+-----
+MkZ (MkY)
+-----
+-----
+MkZ (MkY)

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/run
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-mismatch-dependent/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/DerivedGen.idr
@@ -14,13 +14,13 @@ Show X where
   show Nil = "[]"
   show (x :: xs) = "()::" ++ show xs
 
+Injective (DerivedGen.(::) ()) where injective Refl = Refl
+
 DecEq X where
   [] `decEq` [] = Yes Refl
   [] `decEq` (y :: ys) = No $ \case Refl impossible
   (x :: xs) `decEq` [] = No $ \case Refl impossible
-  (() :: xs) `decEq` (() :: ys) = case xs `decEq` ys of
-                                    (Yes prf) => rewrite prf in Yes Refl
-                                    (No contra) => No $ \case Refl => contra Refl
+  (() :: xs) `decEq` (() :: ys) = decEqCong $ decEq xs ys
 
 data Y : (xs : X) -> (ys : X) -> Type where
   A : Y (x :: xs) (x :: xs)

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/DerivedGen.idr
@@ -1,0 +1,42 @@
+module DerivedGen
+
+import RunDerivedGen
+
+%default total
+
+%language ElabReflection
+
+data X : Type where
+  Nil : X
+  (::) : Unit -> X -> X
+
+Show X where
+  show Nil = "[]"
+  show (x :: xs) = "()::" ++ show xs
+
+DecEq X where
+  [] `decEq` [] = Yes Refl
+  [] `decEq` (y :: ys) = No $ \case Refl impossible
+  (x :: xs) `decEq` [] = No $ \case Refl impossible
+  (() :: xs) `decEq` (() :: ys) = case xs `decEq` ys of
+                                    (Yes prf) => rewrite prf in Yes Refl
+                                    (No contra) => No $ \case Refl => contra Refl
+
+data Y : (xs : X) -> (ys : X) -> Type where
+  A : Y (x :: xs) (x :: xs)
+  B : Y xs ys -> Y (x :: xs) (x :: ys)
+
+Show (Y xs ys) where
+  show A = "A"
+  show (B x) = "B (" ++ show x ++ ")"
+
+checkedGen : Fuel ->
+             (xs : X) ->
+             (ys : X) ->
+             Gen $ Y xs ys
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl [()] [()]
+  ]

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/RunDerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/depends
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/depends
@@ -1,0 +1,1 @@
+../_common/depends

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/derive.ipkg
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/expected
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/expected
@@ -1,0 +1,6 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Generated values:
+-----
+-----
+A

--- a/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/run
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/unification-name-mismatch/run
@@ -1,0 +1,1 @@
+../_common/run


### PR DESCRIPTION
Fixes #20, resolves #9, closes #18 as a better solution.