### PR TITLE
[ re #21 ] Fix ordering function to work with more than two repeating names

### DIFF
--- a/src/Test/DepTyCheck/Gen/Auto/Core/ConsEntry.idr
+++ b/src/Test/DepTyCheck/Gen/Auto/Core/ConsEntry.idr
@@ -108,12 +108,12 @@ canonicConsBody sig name con = do
 
         -- Order pairs by the first element like they are present in the constructor's signature
         orderLikeInCon : Foldable f => f (String, String) -> List (String, String)
-        orderLikeInCon m = do
-          let m = insertFrom m empty
+        orderLikeInCon = do
           let conArgStrNames = mapMaybe argStrName con.args
-          let present = mapMaybe (\n => SortedMap.lookup n m <&> (n,)) conArgStrNames
-          let notPresent = foldl (flip SortedMap.delete) m conArgStrNames
-          present ++ SortedMap.toList notPresent
+          let conNameToIdx : SortedMap _ $ Fin conArgStrNames.length := fromList $ mapI' conArgStrNames $ flip (,)
+          let [AsInCon] Ord (String, String) where
+                compare (origL, renL) (origR, renR) = comparing (flip lookup conNameToIdx) origL origR <+> compare renL renR
+          SortedSet.toList . foldl (flip insert) (empty @{AsInCon})
           where
             argStrName : NamedArg -> Maybe String
             argStrName $ MkArg {name=UN (Basic n), _} = Just n

--- a/tests/gen-derivation/derivation/infra/empty-cons print 013/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 013/expected
@@ -92,20 +92,49 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                    $ IBindVar to_be_deceqed^^n1)
                                               MW
                                               (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^n1
+                                                   $ IVar to_be_deceqed^^n0
                                                    $ IVar n)
 
                                               []
-                                              [ PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ (IApp. IVar Prelude.Types.S
-                                                                      $ IBindVar to_be_deceqed^^n0)
-                                                               $ IBindVar m
-                                                               $ IBindVar n
-                                                               $ (IApp. IVar Prelude.Yes
-                                                                      $ IVar Builtin.Refl))
-                                                          (IVar empty)
+                                              [ WithClause (IApp. IVar <<DerivedGen.XE>>
+                                                                $ IBindVar ^cons_fuel^
+                                                                $ IBindVar n
+                                                                $ (IApp. IVar Prelude.Types.S
+                                                                       $ IBindVar n)
+                                                                $ IBindVar m
+                                                                $ IBindVar to_be_deceqed^^n1
+                                                                $ (IApp. IVar Prelude.Yes
+                                                                       $ IVar Builtin.Refl))
+                                                           MW
+                                                           (IApp. IVar Decidable.Equality.decEq
+                                                                $ IVar to_be_deceqed^^n1
+                                                                $ IVar n)
+
+                                                           []
+                                                           [ PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ (IApp. IVar Prelude.Types.S
+                                                                                   $ IBindVar n)
+                                                                            $ IBindVar m
+                                                                            $ IBindVar n
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl))
+                                                                       (IVar empty)
+                                                           , PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ (IApp. IVar Prelude.Types.S
+                                                                                   $ IBindVar n)
+                                                                            $ IBindVar m
+                                                                            $ IBindVar to_be_deceqed^^n1
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.No
+                                                                                   $ Implicit True))
+                                                                       (IVar empty) ]
                                               , PatClause (IApp. IVar <<DerivedGen.XE>>
                                                                $ IBindVar ^cons_fuel^
                                                                $ IBindVar n

--- a/tests/gen-derivation/derivation/infra/empty-cons print 014/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 014/expected
@@ -95,20 +95,49 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                    $ IBindVar to_be_deceqed^^n1)
                                               MW
                                               (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^n1
+                                                   $ IVar to_be_deceqed^^n0
                                                    $ IVar n)
 
                                               []
-                                              [ PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ (IApp. IVar Prelude.Types.S
-                                                                      $ IBindVar to_be_deceqed^^n0)
-                                                               $ IBindVar m
-                                                               $ IBindVar n
-                                                               $ (IApp. IVar Prelude.Yes
-                                                                      $ IVar Builtin.Refl))
-                                                          (IVar empty)
+                                              [ WithClause (IApp. IVar <<DerivedGen.XE>>
+                                                                $ IBindVar ^cons_fuel^
+                                                                $ IBindVar n
+                                                                $ (IApp. IVar Prelude.Types.S
+                                                                       $ IBindVar n)
+                                                                $ IBindVar m
+                                                                $ IBindVar to_be_deceqed^^n1
+                                                                $ (IApp. IVar Prelude.Yes
+                                                                       $ IVar Builtin.Refl))
+                                                           MW
+                                                           (IApp. IVar Decidable.Equality.decEq
+                                                                $ IVar to_be_deceqed^^n1
+                                                                $ IVar n)
+
+                                                           []
+                                                           [ PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ (IApp. IVar Prelude.Types.S
+                                                                                   $ IBindVar n)
+                                                                            $ IBindVar m
+                                                                            $ IBindVar n
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl))
+                                                                       (IVar empty)
+                                                           , PatClause (IApp. IVar <<DerivedGen.XE>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ (IApp. IVar Prelude.Types.S
+                                                                                   $ IBindVar n)
+                                                                            $ IBindVar m
+                                                                            $ IBindVar to_be_deceqed^^n1
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.No
+                                                                                   $ Implicit True))
+                                                                       (IVar empty) ]
                                               , PatClause (IApp. IVar <<DerivedGen.XE>>
                                                                $ IBindVar ^cons_fuel^
                                                                $ IBindVar n

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/AlternativeCore.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/AlternativeCore.idr
@@ -1,0 +1,1 @@
+../_common/AlternativeCore.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/DerivedGen.idr
@@ -1,0 +1,13 @@
+module DerivedGen
+
+import AlternativeCore
+import PrintDerivation
+
+%default total
+
+data X : Nat -> Nat -> Nat -> Nat -> Type where
+  MkX : X n n n n
+
+%language ElabReflection
+
+%runElab printDerived @{MainCoreDerivator @{LeastEffort}} $ Fuel -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> (x4 : Nat) -> Gen $ X x1 x2 x3 x4

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/PrintDerivation.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/PrintDerivation.idr
@@ -1,0 +1,1 @@
+../_common/PrintDerivation.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/RunDerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/depends
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/depends
@@ -1,0 +1,1 @@
+../_common/depends/

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/derive.ipkg
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/expected
@@ -1,0 +1,151 @@
+1/3: Building AlternativeCore (AlternativeCore.idr)
+2/3: Building PrintDerivation (PrintDerivation.idr)
+3/3: Building DerivedGen (DerivedGen.idr)
+LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> (x4 : Nat) -> Gen (X x1 x2 x3 x4)
+LOG gen.auto.derive.infra:0: 
+ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
+    => (MW ExplicitArg x1 : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg x2 : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg x3 : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg x4 : IVar Prelude.Types.Nat)
+    => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
+                   $ IVar ^outmost-fuel^
+                   $ IVar x1
+                   $ IVar x2
+                   $ IVar x3
+                   $ IVar x4)
+         IClaim MW
+                Export
+                []
+                (MkTy <DerivedGen.X>[0, 1, 2, 3]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (MW ExplicitArg {arg:830} : IVar Prelude.Types.Nat)
+                          -> (MW ExplicitArg {arg:833} : IVar Prelude.Types.Nat)
+                          -> (MW ExplicitArg {arg:836} : IVar Prelude.Types.Nat)
+                          -> (MW ExplicitArg {arg:839} : IVar Prelude.Types.Nat)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ (IApp. IVar DerivedGen.X
+                                         $ IVar {arg:830}
+                                         $ IVar {arg:833}
+                                         $ IVar {arg:836}
+                                         $ IVar {arg:839}))))
+         IDef <DerivedGen.X>[0, 1, 2, 3]
+              [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar {arg:830}
+                               $ IBindVar {arg:833}
+                               $ IBindVar {arg:836}
+                               $ IBindVar {arg:839})
+                          (ILocal (IApp. IVar <<DerivedGen.MkX>>
+                                       $ IVar ^fuel_arg^
+                                       $ IVar {arg:830}
+                                       $ IVar {arg:833}
+                                       $ IVar {arg:836}
+                                       $ IVar {arg:839}))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:830} : IVar Prelude.Types.Nat)
+                                             -> (MW ExplicitArg {arg:833} : IVar Prelude.Types.Nat)
+                                             -> (MW ExplicitArg {arg:836} : IVar Prelude.Types.Nat)
+                                             -> (MW ExplicitArg {arg:839} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ (IApp. IVar DerivedGen.X
+                                                            $ IVar {arg:830}
+                                                            $ IVar {arg:833}
+                                                            $ IVar {arg:836}
+                                                            $ IVar {arg:839}))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ WithClause (IApp. IVar <<DerivedGen.MkX>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar n
+                                                   $ IBindVar to_be_deceqed^^n0
+                                                   $ IBindVar to_be_deceqed^^n1
+                                                   $ IBindVar to_be_deceqed^^n2)
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^n0
+                                                   $ IVar n)
+
+                                              []
+                                              [ WithClause (IApp. IVar <<DerivedGen.MkX>>
+                                                                $ IBindVar ^cons_fuel^
+                                                                $ IBindVar n
+                                                                $ IBindVar n
+                                                                $ IBindVar to_be_deceqed^^n1
+                                                                $ IBindVar to_be_deceqed^^n2
+                                                                $ (IApp. IVar Prelude.Yes
+                                                                       $ IVar Builtin.Refl))
+                                                           MW
+                                                           (IApp. IVar Decidable.Equality.decEq
+                                                                $ IVar to_be_deceqed^^n1
+                                                                $ IVar n)
+
+                                                           []
+                                                           [ WithClause (IApp. IVar <<DerivedGen.MkX>>
+                                                                             $ IBindVar ^cons_fuel^
+                                                                             $ IBindVar n
+                                                                             $ IBindVar n
+                                                                             $ IBindVar n
+                                                                             $ IBindVar to_be_deceqed^^n2
+                                                                             $ (IApp. IVar Prelude.Yes
+                                                                                    $ IVar Builtin.Refl)
+                                                                             $ (IApp. IVar Prelude.Yes
+                                                                                    $ IVar Builtin.Refl))
+                                                                        MW
+                                                                        (IApp. IVar Decidable.Equality.decEq
+                                                                             $ IVar to_be_deceqed^^n2
+                                                                             $ IVar n)
+
+                                                                        []
+                                                                        [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                                                         $ IBindVar ^cons_fuel^
+                                                                                         $ IBindVar n
+                                                                                         $ IBindVar n
+                                                                                         $ IBindVar n
+                                                                                         $ IBindVar n
+                                                                                         $ (IApp. IVar Prelude.Yes
+                                                                                                $ IVar Builtin.Refl)
+                                                                                         $ (IApp. IVar Prelude.Yes
+                                                                                                $ IVar Builtin.Refl)
+                                                                                         $ (IApp. IVar Prelude.Yes
+                                                                                                $ IVar Builtin.Refl))
+                                                                                    (IApp. (INamedApp. IVar Prelude.pure
+                                                                                                     $ IVar Test.DepTyCheck.Gen.Gen)
+                                                                                         $ (INamedApp. IVar DerivedGen.MkX
+                                                                                                     $ IVar n))
+                                                                        , PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                                                         $ IBindVar ^cons_fuel^
+                                                                                         $ IBindVar n
+                                                                                         $ IBindVar n
+                                                                                         $ IBindVar n
+                                                                                         $ IBindVar to_be_deceqed^^n2
+                                                                                         $ (IApp. IVar Prelude.Yes
+                                                                                                $ IVar Builtin.Refl)
+                                                                                         $ (IApp. IVar Prelude.Yes
+                                                                                                $ IVar Builtin.Refl)
+                                                                                         $ (IApp. IVar Prelude.No
+                                                                                                $ Implicit True))
+                                                                                    (IVar empty) ]
+                                                           , PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ IBindVar n
+                                                                            $ IBindVar to_be_deceqed^^n1
+                                                                            $ IBindVar to_be_deceqed^^n2
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.No
+                                                                                   $ Implicit True))
+                                                                       (IVar empty) ]
+                                              , PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ IBindVar to_be_deceqed^^n0
+                                                               $ IBindVar to_be_deceqed^^n1
+                                                               $ IBindVar to_be_deceqed^^n2
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ] ] ]

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/run
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/AlternativeCore.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/AlternativeCore.idr
@@ -1,0 +1,1 @@
+../_common/AlternativeCore.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/DerivedGen.idr
@@ -1,0 +1,13 @@
+module DerivedGen
+
+import AlternativeCore
+import PrintDerivation
+
+%default total
+
+data X : Nat -> Nat -> Nat -> Type where
+  MkX : X n n n
+
+%language ElabReflection
+
+%runElab printDerived @{MainCoreDerivator @{LeastEffort}} $ Fuel -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> Gen $ X x1 x2 x3

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/PrintDerivation.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/PrintDerivation.idr
@@ -1,0 +1,1 @@
+../_common/PrintDerivation.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/RunDerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/depends
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/depends
@@ -1,0 +1,1 @@
+../_common/depends/

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/derive.ipkg
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/expected
@@ -1,0 +1,107 @@
+1/3: Building AlternativeCore (AlternativeCore.idr)
+2/3: Building PrintDerivation (PrintDerivation.idr)
+3/3: Building DerivedGen (DerivedGen.idr)
+LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> Gen (X x1 x2 x3)
+LOG gen.auto.derive.infra:0: 
+ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
+    => (MW ExplicitArg x1 : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg x2 : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg x3 : IVar Prelude.Types.Nat)
+    => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2]
+                   $ IVar ^outmost-fuel^
+                   $ IVar x1
+                   $ IVar x2
+                   $ IVar x3)
+         IClaim MW
+                Export
+                []
+                (MkTy <DerivedGen.X>[0, 1, 2]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (MW ExplicitArg {arg:830} : IVar Prelude.Types.Nat)
+                          -> (MW ExplicitArg {arg:833} : IVar Prelude.Types.Nat)
+                          -> (MW ExplicitArg {arg:836} : IVar Prelude.Types.Nat)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ (IApp. IVar DerivedGen.X
+                                         $ IVar {arg:830}
+                                         $ IVar {arg:833}
+                                         $ IVar {arg:836}))))
+         IDef <DerivedGen.X>[0, 1, 2]
+              [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar {arg:830}
+                               $ IBindVar {arg:833}
+                               $ IBindVar {arg:836})
+                          (ILocal (IApp. IVar <<DerivedGen.MkX>>
+                                       $ IVar ^fuel_arg^
+                                       $ IVar {arg:830}
+                                       $ IVar {arg:833}
+                                       $ IVar {arg:836}))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:830} : IVar Prelude.Types.Nat)
+                                             -> (MW ExplicitArg {arg:833} : IVar Prelude.Types.Nat)
+                                             -> (MW ExplicitArg {arg:836} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ (IApp. IVar DerivedGen.X
+                                                            $ IVar {arg:830}
+                                                            $ IVar {arg:833}
+                                                            $ IVar {arg:836}))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ WithClause (IApp. IVar <<DerivedGen.MkX>>
+                                                   $ IBindVar ^cons_fuel^
+                                                   $ IBindVar n
+                                                   $ IBindVar to_be_deceqed^^n0
+                                                   $ IBindVar to_be_deceqed^^n1)
+                                              MW
+                                              (IApp. IVar Decidable.Equality.decEq
+                                                   $ IVar to_be_deceqed^^n0
+                                                   $ IVar n)
+
+                                              []
+                                              [ WithClause (IApp. IVar <<DerivedGen.MkX>>
+                                                                $ IBindVar ^cons_fuel^
+                                                                $ IBindVar n
+                                                                $ IBindVar n
+                                                                $ IBindVar to_be_deceqed^^n1
+                                                                $ (IApp. IVar Prelude.Yes
+                                                                       $ IVar Builtin.Refl))
+                                                           MW
+                                                           (IApp. IVar Decidable.Equality.decEq
+                                                                $ IVar to_be_deceqed^^n1
+                                                                $ IVar n)
+
+                                                           []
+                                                           [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ IBindVar n
+                                                                            $ IBindVar n
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl))
+                                                                       (IApp. (INamedApp. IVar Prelude.pure
+                                                                                        $ IVar Test.DepTyCheck.Gen.Gen)
+                                                                            $ (INamedApp. IVar DerivedGen.MkX
+                                                                                        $ IVar n))
+                                                           , PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                                            $ IBindVar ^cons_fuel^
+                                                                            $ IBindVar n
+                                                                            $ IBindVar n
+                                                                            $ IBindVar to_be_deceqed^^n1
+                                                                            $ (IApp. IVar Prelude.Yes
+                                                                                   $ IVar Builtin.Refl)
+                                                                            $ (IApp. IVar Prelude.No
+                                                                                   $ Implicit True))
+                                                                       (IVar empty) ]
+                                              , PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                               $ IBindVar ^cons_fuel^
+                                                               $ IBindVar n
+                                                               $ IBindVar to_be_deceqed^^n0
+                                                               $ IBindVar to_be_deceqed^^n1
+                                                               $ (IApp. IVar Prelude.No
+                                                                      $ Implicit True))
+                                                          (IVar empty) ] ] ]

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/run
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/DerivedGen.idr
@@ -17,5 +17,5 @@ checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
 
 main : IO ()
 main = runGs
-  [ G $ \fl => checkedGen fl Z Z Z
+  [ G $ \fl => checkedGen fl Z Z Z Z
   ]

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/DerivedGen.idr
@@ -1,0 +1,21 @@
+module DerivedGen
+
+import RunDerivedGen
+
+%default total
+
+data X : Nat -> Nat -> Nat -> Nat -> Type where
+  MkX : X n n n n
+
+Show (X n m k l) where
+  show MkX = "MkX"
+
+%language ElabReflection
+
+checkedGen : Fuel -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> (x4 : Nat) -> Gen $ X x1 x2 x3 x4
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl Z Z Z
+  ]

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/RunDerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/depends
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/depends
@@ -1,0 +1,1 @@
+../_common/depends/

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/derive.ipkg
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/expected
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/expected
@@ -1,0 +1,6 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Generated values:
+-----
+-----
+MkX

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/run
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-four-occurences/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/DerivedGen.idr
@@ -1,0 +1,21 @@
+module DerivedGen
+
+import RunDerivedGen
+
+%default total
+
+data X : Nat -> Nat -> Nat -> Type where
+  MkX : X n n n
+
+Show (X n m k) where
+  show MkX = "MkX"
+
+%language ElabReflection
+
+checkedGen : Fuel -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> Gen $ X x1 x2 x3
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl Z Z Z
+  ]

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/RunDerivedGen.idr
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/depends
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/depends
@@ -1,0 +1,1 @@
+../_common/depends/

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/derive.ipkg
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/expected
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/expected
@@ -1,0 +1,6 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Generated values:
+-----
+-----
+MkX

--- a/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/run
+++ b/tests/gen-derivation/derivation/least-effort/run/regression/lost-deceq-three-occurences/run
@@ -1,0 +1,1 @@
+../_common/run


### PR DESCRIPTION
This bug was introduced in the bugfux #21, reordering lost renames if the original name appeared more than once, thus leading to deriving bad generators when a name was present in a constructor three times or more.