### PR TITLE
[ re #58 ] Add one more non-mutual-recursion no-fuel-spend test

### DIFF
--- a/tests/gen-derivation/derivation/distribution/vect-nat-001/CheckDistribution.idr
+++ b/tests/gen-derivation/derivation/distribution/vect-nat-001/CheckDistribution.idr
@@ -1,0 +1,41 @@
+module CheckDistribution
+
+import Deriving.DepTyCheck.Gen
+
+import DistrCheckCommon
+
+%default total
+
+%language ElabReflection
+
+%hint DA : ConstructorDerivator; DA = LeastEffort
+
+data VectNat : Nat -> Type where
+  Nil  : VectNat Z
+  (::) : Nat -> VectNat n -> VectNat (S n)
+
+index : Fin n -> VectNat n -> Nat
+index FZ     (x::_ ) = x
+index (FS k) (_::xs) = index k xs
+
+vectNats : Fuel -> (Fuel -> Gen Nat) => (n : Nat) -> Gen $ VectNat n
+vectNats = deriveGen
+
+nats : Fuel -> Gen Nat
+nats = deriveGen
+
+-- Check that every number in every position is uniformly distributed
+
+mainFor : (len : Nat) -> (depth : Nat) -> IO ()
+mainFor len depth = printVerdict (vectNats @{nats} (limit depth) len) $ fromList
+                      [ coverWith (ratio 1 (S depth)) ((== n) . index idx) | n <- [0 .. depth], idx <- allFins len ]
+
+-- NOTE: A separate test is when for this derived generator we pass `depth` test.
+--       Now, since we still spend fuel even when `given` argument descreases, when we set high `len` > `depth`,
+--       no statistics can be searched for.
+
+main : IO ()
+main = do
+  mainFor 1 4
+  mainFor 4 5
+  mainFor 8 10

--- a/tests/gen-derivation/derivation/distribution/vect-nat-001/DistrCheckCommon.idr
+++ b/tests/gen-derivation/derivation/distribution/vect-nat-001/DistrCheckCommon.idr
@@ -1,0 +1,1 @@
+../_common/DistrCheckCommon.idr

--- a/tests/gen-derivation/derivation/distribution/vect-nat-001/expected
+++ b/tests/gen-derivation/derivation/distribution/vect-nat-001/expected
@@ -1,0 +1,3 @@
+Just [ok, ok, ok, ok, ok]
+Just [ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok]
+Just [ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok, ok]

--- a/tests/gen-derivation/derivation/distribution/vect-nat-001/run
+++ b/tests/gen-derivation/derivation/distribution/vect-nat-001/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/gen-derivation/derivation/distribution/vect-nat-001/test.ipkg
+++ b/tests/gen-derivation/derivation/distribution/vect-nat-001/test.ipkg
@@ -1,0 +1,1 @@
+../_common/test.ipkg


### PR DESCRIPTION
This test is, actually, trickier that it looks ;-) If the given fuel is less than the given length, then no values could be generated, since we spend fuel in this recursive calls in the current state of derived generators.