### PR TITLE
[ test ] Speed up print tests, `declare` main with elab script

### DIFF
--- a/tests/gen-derivation/derivation/_common/PrintDerivation.idr
+++ b/tests/gen-derivation/derivation/_common/PrintDerivation.idr
@@ -9,4 +9,12 @@ printDerived : DerivatorCore => Type -> Elab Unit
 printDerived ty = do
   ty <- quote ty
   logSugaredTerm "gen.auto.derive.infra" 0 "type" ty
-  logMsg "gen.auto.derive.infra" 0 "\n\{!(deriveGenExpr ty)}"
+  expr <- deriveGenExpr ty
+  expr <- quote expr
+  declare `[
+    main : IO Unit
+    main = do
+      putStrLn "LOG gen.auto.derive.infra:0: " -- mimic the original logging behaviour
+      putStr $ interpolate ~(expr)
+      putStrLn ""
+  ]

--- a/tests/gen-derivation/derivation/_common/run
+++ b/tests/gen-derivation/derivation/_common/run
@@ -2,7 +2,6 @@ rm -rf build
 
 flock "$1" pack -q install-deps derive.ipkg && \
 idris2 --check --no-color --console-width 0 --no-banner --find-ipkg DerivedGen.idr && \
-grep 'main : IO' DerivedGen.idr >/dev/null && \
 pack exec DerivedGen.idr
 
 rm -rf build


### PR DESCRIPTION
This is an alternative solution to #65, which does not rely on idris-lang/Idris2#2977 or a new core, since the script is still run in the top-level mode, not in an expression mode.

Closes #65