### PR TITLE
[ upstream ] Workaround the bug of wrong shadowing in `where` block

### DIFF
--- a/src/Deriving/DepTyCheck/Gen/Core.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core.idr
@@ -57,13 +57,17 @@ ConstructorDerivator => DerivatorCore where
     let outmostRHS = fuelDecisionExpr fuelArg consRecs
 
     -- return function definition
-    pure [ canonicDefaultLHS sig n fuelArg .= local (consClaims ++ consBodies) outmostRHS ]
+    pure [ canonicDefaultLHS' namesWrapper sig n fuelArg .= local (consClaims ++ consBodies) outmostRHS ]
 
   where
 
     consGenName : Con -> Name
     consGenName con = UN $ Basic $ "<<\{show con.name}>>"
     -- I'm using `UN` but containing chars that cannot be present in the code parsed from the Idris frontend
+
+    -- this is a workarond for Idris compiler bug #2983
+    namesWrapper : String -> String
+    namesWrapper s = "inter^<\{s}>"
 
     fuelDecisionExpr : (fuelArg : String) -> List (Con, Recursiveness) -> TTImp
     fuelDecisionExpr fuelAr consRecs = do
@@ -96,7 +100,7 @@ ConstructorDerivator => DerivatorCore where
       where
 
         callConsGen : (fuel : TTImp) -> Con -> TTImp
-        callConsGen fuel con = canonicDefaultRHS sig .| consGenName con .| fuel
+        callConsGen fuel con = canonicDefaultRHS' namesWrapper sig .| consGenName con .| fuel
 
     toRec : Bool -> Recursiveness
     toRec True  = Recursive

--- a/src/Deriving/DepTyCheck/Gen/Derive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Derive.idr
@@ -95,12 +95,20 @@ defArgNames : {sig : GenSignature} -> Vect sig.givenParams.size String
 defArgNames = sig.givenParams.asVect <&> show . name . index' sig.targetType.args
 
 export %inline
+canonicDefaultLHS' : (namesFun : String -> String) -> GenSignature -> Name -> (fuel : String) -> TTImp
+canonicDefaultLHS' nmf sig n fuel = callCanonic sig n .| bindVar fuel .| bindVar . nmf <$> defArgNames
+
+export %inline
+canonicDefaultRHS' : (namesFun : String -> String) -> GenSignature -> Name -> (fuel : TTImp) -> TTImp
+canonicDefaultRHS' nmf sig n fuel = callCanonic sig n fuel .| varStr . nmf <$> defArgNames
+
+export %inline
 canonicDefaultLHS : GenSignature -> Name -> (fuel : String) -> TTImp
-canonicDefaultLHS sig n fuel = callCanonic sig n .| bindVar fuel .| bindVar <$> defArgNames
+canonicDefaultLHS = canonicDefaultLHS' id
 
 export %inline
 canonicDefaultRHS : GenSignature -> Name -> (fuel : TTImp) -> TTImp
-canonicDefaultRHS sig n fuel = callCanonic sig n fuel .| varStr <$> defArgNames
+canonicDefaultRHS = canonicDefaultRHS' id
 
 ---------------------------------
 --- External-facing functions ---

--- a/tests/gen-derivation/derivation/core/upstream-2983/DerivedGen.idr
+++ b/tests/gen-derivation/derivation/core/upstream-2983/DerivedGen.idr
@@ -1,0 +1,26 @@
+module DerivedGen
+
+import RunDerivedGen
+
+%default total
+
+%language ElabReflection
+
+data VectMaybeAnyType : Nat -> Type where
+  Nil  : VectMaybeAnyType Z
+  (::) : Bool -> VectMaybeAnyType n -> VectMaybeAnyType (S n)
+
+data AtIndex : (n : Nat) -> Bool -> VectMaybeAnyType n -> Type where
+  Here  : AtIndex (S n) x (x::xs)
+
+Show (AtIndex n v xs) where
+  show _ = "Here"
+
+checkedGen : Fuel -> (n : Nat) -> (b : Bool) -> (v : VectMaybeAnyType n) -> Gen $ AtIndex n b v
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl 3 True  [ False, True, True ]
+  , G $ \fl => checkedGen fl 3 False [ False, True, True ]
+  ]

--- a/tests/gen-derivation/derivation/core/upstream-2983/RunDerivedGen.idr
+++ b/tests/gen-derivation/derivation/core/upstream-2983/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/gen-derivation/derivation/core/upstream-2983/derive.ipkg
+++ b/tests/gen-derivation/derivation/core/upstream-2983/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/gen-derivation/derivation/core/upstream-2983/expected
+++ b/tests/gen-derivation/derivation/core/upstream-2983/expected
@@ -1,0 +1,25 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Generated values:
+-----
+-----
+-----
+Here
+-----
+Here
+-----
+Here
+-----
+Here
+-----
+Here
+-----
+Here
+-----
+Here
+-----
+Here
+-----
+Here
+-----
+Here

--- a/tests/gen-derivation/derivation/core/upstream-2983/run
+++ b/tests/gen-derivation/derivation/core/upstream-2983/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/gen-derivation/derivation/infra/empty-body print 002/expected
+++ b/tests/gen-derivation/derivation/infra/empty-body print 002/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (a : Type) -> Gen (Vect n a)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg a : IType)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => (MW ExplicitArg outer^<a> : Implicit True)
     => ILocal (IApp. IVar <Data.Vect.Vect>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar n
-                   $ IVar a)
+                   $ IVar outer^<n>
+                   $ IVar outer^<a>)
          IClaim MW
                 Export
                 []

--- a/tests/gen-derivation/derivation/infra/empty-body print 004/expected
+++ b/tests/gen-derivation/derivation/infra/empty-body print 004/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen (X n)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => ILocal (IApp. IVar <DerivedGen.X>[0] $ IVar ^outmost-fuel^ $ IVar n)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => ILocal (IApp. IVar <DerivedGen.X>[0]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<n>)
          IClaim MW
                 Export
                 []

--- a/tests/gen-derivation/derivation/infra/empty-body print 006/expected
+++ b/tests/gen-derivation/derivation/infra/empty-body print 006/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Type) -> Gen (n : Nat ** Vect n a)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IType)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[1] $ IVar ^outmost-fuel^ $ IVar a)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => ILocal (IApp. IVar <Data.Vect.Vect>[1]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<a>)
          IClaim MW
                 Export
                 []

--- a/tests/gen-derivation/derivation/infra/empty-cons print 002/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 002/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (a : Type) -> Gen (Vect n a)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg a : IType)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => (MW ExplicitArg outer^<a> : Implicit True)
     => ILocal (IApp. IVar <Data.Vect.Vect>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar n
-                   $ IVar a)
+                   $ IVar outer^<n>
+                   $ IVar outer^<a>)
          IClaim MW
                 Export
                 []
@@ -24,15 +24,15 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <Data.Vect.Vect>[0, 1]
               [ PatClause (IApp. IVar <Data.Vect.Vect>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar len
-                               $ IBindVar elem)
+                               $ IBindVar inter^<len>
+                               $ IBindVar inter^<elem>)
                           (ILocal (ICase (IVar ^fuel_arg^)
                                          (IVar Data.Fuel.Fuel)
                                          [ PatClause (IVar Data.Fuel.Dry)
                                                      (IApp. IVar <<Data.Vect.Nil>>
                                                           $ IVar Data.Fuel.Dry
-                                                          $ IVar len
-                                                          $ IVar elem)
+                                                          $ IVar inter^<len>
+                                                          $ IVar inter^<elem>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
                                                      (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
@@ -45,16 +45,16 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                $ IPrimVal 1)
                                                                         $ (IApp. IVar <<Data.Vect.Nil>>
                                                                                $ IVar ^fuel_arg^
-                                                                               $ IVar len
-                                                                               $ IVar elem))
+                                                                               $ IVar inter^<len>
+                                                                               $ IVar inter^<elem>))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
                                                                                $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                       $ IVar ^sub^fuel_arg^)
                                                                                $ (IApp. IVar <<Data.Vect.(::)>>
                                                                                       $ IVar ^sub^fuel_arg^
-                                                                                      $ IVar len
-                                                                                      $ IVar elem))
+                                                                                      $ IVar inter^<len>
+                                                                                      $ IVar inter^<elem>))
                                                                         $ IVar Nil))) ]))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/infra/empty-cons print 004/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 004/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen (X n)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => ILocal (IApp. IVar <DerivedGen.X>[0] $ IVar ^outmost-fuel^ $ IVar n)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => ILocal (IApp. IVar <DerivedGen.X>[0]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<n>)
          IClaim MW
                 Export
                 []
@@ -18,10 +20,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0]
               [ PatClause (IApp. IVar <DerivedGen.X>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3630}))
+                                       $ IVar inter^<{arg:3630}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/infra/empty-cons print 006/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 006/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Type) -> Gen (n : Nat ** Vect n a)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IType)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[1] $ IVar ^outmost-fuel^ $ IVar a)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => ILocal (IApp. IVar <Data.Vect.Vect>[1]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<a>)
          IClaim MW
                 Export
                 []
@@ -22,13 +24,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <Data.Vect.Vect>[1]
               [ PatClause (IApp. IVar <Data.Vect.Vect>[1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar elem)
+                               $ IBindVar inter^<elem>)
                           (ILocal (ICase (IVar ^fuel_arg^)
                                          (IVar Data.Fuel.Fuel)
                                          [ PatClause (IVar Data.Fuel.Dry)
                                                      (IApp. IVar <<Data.Vect.Nil>>
                                                           $ IVar Data.Fuel.Dry
-                                                          $ IVar elem)
+                                                          $ IVar inter^<elem>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
                                                      (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
@@ -41,14 +43,14 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                $ IPrimVal 1)
                                                                         $ (IApp. IVar <<Data.Vect.Nil>>
                                                                                $ IVar ^fuel_arg^
-                                                                               $ IVar elem))
+                                                                               $ IVar inter^<elem>))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
                                                                                $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                       $ IVar ^sub^fuel_arg^)
                                                                                $ (IApp. IVar <<Data.Vect.(::)>>
                                                                                       $ IVar ^sub^fuel_arg^
-                                                                                      $ IVar elem))
+                                                                                      $ IVar inter^<elem>))
                                                                         $ IVar Nil))) ]))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/infra/empty-cons print 012/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 012/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (m : Nat) -> Gen (X n m)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg m : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => (MW ExplicitArg outer^<m> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.X>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar n
-                   $ IVar m)
+                   $ IVar outer^<n>
+                   $ IVar outer^<m>)
          IClaim MW
                 Export
                 []
@@ -24,8 +24,8 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.X>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630}
-                               $ IBindVar {arg:3633})
+                               $ IBindVar inter^<{arg:3630}>
+                               $ IBindVar inter^<{arg:3633}>)
                           (ILocal (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
                                                    description
                                                    (IApp. IVar Just
@@ -33,13 +33,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                        $ (IApp. IVar ::
                                               $ (IApp. IVar <<DerivedGen.XE>>
                                                      $ IVar ^fuel_arg^
-                                                     $ IVar {arg:3630}
-                                                     $ IVar {arg:3633})
+                                                     $ IVar inter^<{arg:3630}>
+                                                     $ IVar inter^<{arg:3633}>)
                                               $ (IApp. IVar ::
                                                      $ (IApp. IVar <<DerivedGen.XS>>
                                                             $ IVar ^fuel_arg^
-                                                            $ IVar {arg:3630}
-                                                            $ IVar {arg:3633})
+                                                            $ IVar inter^<{arg:3630}>
+                                                            $ IVar inter^<{arg:3633}>)
                                                      $ IVar Nil))))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/infra/empty-cons print 013/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 013/expected
@@ -4,16 +4,16 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (m : Nat) -> (p : Nat) -> (k : Nat) -> Gen (X n m p k)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg m : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg p : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg k : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => (MW ExplicitArg outer^<m> : Implicit True)
+    => (MW ExplicitArg outer^<p> : Implicit True)
+    => (MW ExplicitArg outer^<k> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
                    $ IVar ^outmost-fuel^
-                   $ IVar n
-                   $ IVar m
-                   $ IVar p
-                   $ IVar k)
+                   $ IVar outer^<n>
+                   $ IVar outer^<m>
+                   $ IVar outer^<p>
+                   $ IVar outer^<k>)
          IClaim MW
                 Export
                 []
@@ -32,10 +32,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0, 1, 2, 3]
               [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630}
-                               $ IBindVar {arg:3633}
-                               $ IBindVar {arg:3636}
-                               $ IBindVar {arg:3639})
+                               $ IBindVar inter^<{arg:3630}>
+                               $ IBindVar inter^<{arg:3633}>
+                               $ IBindVar inter^<{arg:3636}>
+                               $ IBindVar inter^<{arg:3639}>)
                           (ILocal (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
                                                    description
                                                    (IApp. IVar Just
@@ -43,17 +43,17 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                        $ (IApp. IVar ::
                                               $ (IApp. IVar <<DerivedGen.XE>>
                                                      $ IVar ^fuel_arg^
-                                                     $ IVar {arg:3630}
-                                                     $ IVar {arg:3633}
-                                                     $ IVar {arg:3636}
-                                                     $ IVar {arg:3639})
+                                                     $ IVar inter^<{arg:3630}>
+                                                     $ IVar inter^<{arg:3633}>
+                                                     $ IVar inter^<{arg:3636}>
+                                                     $ IVar inter^<{arg:3639}>)
                                               $ (IApp. IVar ::
                                                      $ (IApp. IVar <<DerivedGen.XS>>
                                                             $ IVar ^fuel_arg^
-                                                            $ IVar {arg:3630}
-                                                            $ IVar {arg:3633}
-                                                            $ IVar {arg:3636}
-                                                            $ IVar {arg:3639})
+                                                            $ IVar inter^<{arg:3630}>
+                                                            $ IVar inter^<{arg:3633}>
+                                                            $ IVar inter^<{arg:3636}>
+                                                            $ IVar inter^<{arg:3639}>)
                                                      $ IVar Nil))))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/infra/empty-cons print 014/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 014/expected
@@ -4,19 +4,19 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (m : Nat) -> (p : Nat) -> (k : Nat) -> {auto conArg : ((arg : Fuel) -> Gen String)} -> Gen (X n m p k)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg m : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg p : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg k : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => (MW ExplicitArg outer^<m> : Implicit True)
+    => (MW ExplicitArg outer^<p> : Implicit True)
+    => (MW ExplicitArg outer^<k> : Implicit True)
     => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:3662} : IVar Data.Fuel.Fuel)
                                                         -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                                                 $ IPrimVal String))
     => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
                    $ IVar ^outmost-fuel^
-                   $ IVar n
-                   $ IVar m
-                   $ IVar p
-                   $ IVar k)
+                   $ IVar outer^<n>
+                   $ IVar outer^<m>
+                   $ IVar outer^<p>
+                   $ IVar outer^<k>)
          IClaim MW
                 Export
                 []
@@ -35,10 +35,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0, 1, 2, 3]
               [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630}
-                               $ IBindVar {arg:3633}
-                               $ IBindVar {arg:3636}
-                               $ IBindVar {arg:3639})
+                               $ IBindVar inter^<{arg:3630}>
+                               $ IBindVar inter^<{arg:3633}>
+                               $ IBindVar inter^<{arg:3636}>
+                               $ IBindVar inter^<{arg:3639}>)
                           (ILocal (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
                                                    description
                                                    (IApp. IVar Just
@@ -46,17 +46,17 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                        $ (IApp. IVar ::
                                               $ (IApp. IVar <<DerivedGen.XE>>
                                                      $ IVar ^fuel_arg^
-                                                     $ IVar {arg:3630}
-                                                     $ IVar {arg:3633}
-                                                     $ IVar {arg:3636}
-                                                     $ IVar {arg:3639})
+                                                     $ IVar inter^<{arg:3630}>
+                                                     $ IVar inter^<{arg:3633}>
+                                                     $ IVar inter^<{arg:3636}>
+                                                     $ IVar inter^<{arg:3639}>)
                                               $ (IApp. IVar ::
                                                      $ (IApp. IVar <<DerivedGen.XS>>
                                                             $ IVar ^fuel_arg^
-                                                            $ IVar {arg:3630}
-                                                            $ IVar {arg:3633}
-                                                            $ IVar {arg:3636}
-                                                            $ IVar {arg:3639})
+                                                            $ IVar inter^<{arg:3630}>
+                                                            $ IVar inter^<{arg:3633}>
+                                                            $ IVar inter^<{arg:3636}>
+                                                            $ IVar inter^<{arg:3639}>)
                                                      $ IVar Nil))))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/infra/ext print 004/expected
+++ b/tests/gen-derivation/derivation/infra/ext print 004/expected
@@ -7,10 +7,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
     => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:3634} : IVar Data.Fuel.Fuel)
                                                         -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                                                 $ IPrimVal String))
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg outer^<n> : Implicit True)
     => ILocal (IApp. IVar <AlternativeCore.X'S>[0]
                    $ IVar ^outmost-fuel^
-                   $ IVar n)
+                   $ IVar outer^<n>)
          IClaim MW
                 Export
                 []

--- a/tests/gen-derivation/derivation/infra/self print 002/expected
+++ b/tests/gen-derivation/derivation/infra/self print 002/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (a : Type) -> Gen (Vect n a)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg a : IType)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => (MW ExplicitArg outer^<a> : Implicit True)
     => ILocal (IApp. IVar <Data.Vect.Vect>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar n
-                   $ IVar a)
+                   $ IVar outer^<n>
+                   $ IVar outer^<a>)
          IClaim MW
                 Export
                 []

--- a/tests/gen-derivation/derivation/infra/self print 004/expected
+++ b/tests/gen-derivation/derivation/infra/self print 004/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen (X n)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => ILocal (IApp. IVar <DerivedGen.X>[0] $ IVar ^outmost-fuel^ $ IVar n)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => ILocal (IApp. IVar <DerivedGen.X>[0]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<n>)
          IClaim MW
                 Export
                 []

--- a/tests/gen-derivation/derivation/infra/self print 006/expected
+++ b/tests/gen-derivation/derivation/infra/self print 006/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Type) -> Gen (n : Nat ** Vect n a)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IType)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[1] $ IVar ^outmost-fuel^ $ IVar a)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => ILocal (IApp. IVar <Data.Vect.Vect>[1]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<a>)
          IClaim MW
                 Export
                 []

--- a/tests/gen-derivation/derivation/least-effort/print/adt/005 param/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/005 param/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen (X n)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => ILocal (IApp. IVar <DerivedGen.X>[0] $ IVar ^outmost-fuel^ $ IVar n)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => ILocal (IApp. IVar <DerivedGen.X>[0]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<n>)
          IClaim MW
                 Export
                 []
@@ -18,10 +20,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0]
               [ PatClause (IApp. IVar <DerivedGen.X>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3630}))
+                                       $ IVar inter^<{arg:3630}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/adt/009 left-to-right/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/009 left-to-right/expected
@@ -91,10 +91,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0]
               [ PatClause (IApp. IVar <DerivedGen.X>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3630}))
+                                       $ IVar inter^<{arg:3630}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/adt/013 right-to-left nondet/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/013 right-to-left nondet/expected
@@ -152,10 +152,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0]
               [ PatClause (IApp. IVar <DerivedGen.X>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3630}))
+                                       $ IVar inter^<{arg:3630}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/adt/014 right-to-left nondet ext/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/014 right-to-left nondet ext/expected
@@ -89,10 +89,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0]
               [ PatClause (IApp. IVar <DerivedGen.X>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3630}))
+                                       $ IVar inter^<{arg:3630}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/001 gadt/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/001 gadt/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen (Fin n)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => ILocal (IApp. IVar <Data.Fin.Fin>[0] $ IVar ^outmost-fuel^ $ IVar n)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => ILocal (IApp. IVar <Data.Fin.Fin>[0]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<n>)
          IClaim MW
                 Export
                 []
@@ -17,13 +19,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <Data.Fin.Fin>[0]
               [ PatClause (IApp. IVar <Data.Fin.Fin>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar n)
+                               $ IBindVar inter^<n>)
                           (ILocal (ICase (IVar ^fuel_arg^)
                                          (IVar Data.Fuel.Fuel)
                                          [ PatClause (IVar Data.Fuel.Dry)
                                                      (IApp. IVar <<Data.Fin.FZ>>
                                                           $ IVar Data.Fuel.Dry
-                                                          $ IVar n)
+                                                          $ IVar inter^<n>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
                                                      (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
@@ -36,14 +38,14 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                $ IPrimVal 1)
                                                                         $ (IApp. IVar <<Data.Fin.FZ>>
                                                                                $ IVar ^fuel_arg^
-                                                                               $ IVar n))
+                                                                               $ IVar inter^<n>))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
                                                                                $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                       $ IVar ^sub^fuel_arg^)
                                                                                $ (IApp. IVar <<Data.Fin.FS>>
                                                                                       $ IVar ^sub^fuel_arg^
-                                                                                      $ IVar n))
+                                                                                      $ IVar inter^<n>))
                                                                         $ IVar Nil))) ]))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
@@ -195,7 +195,7 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X_GADT>[0]
               [ PatClause (IApp. IVar <DerivedGen.X_GADT>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
                                                    description
                                                    (IApp. IVar Just
@@ -203,11 +203,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                        $ (IApp. IVar ::
                                               $ (IApp. IVar <<DerivedGen.MkXG_4>>
                                                      $ IVar ^fuel_arg^
-                                                     $ IVar {arg:3630})
+                                                     $ IVar inter^<{arg:3630}>)
                                               $ (IApp. IVar ::
                                                      $ (IApp. IVar <<DerivedGen.MkXG_5>>
                                                             $ IVar ^fuel_arg^
-                                                            $ IVar {arg:3630})
+                                                            $ IVar inter^<{arg:3630}>)
                                                      $ IVar Nil))))
                             IClaim MW
                                    Export
@@ -281,7 +281,7 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X_GADT>[1]
               [ PatClause (IApp. IVar <DerivedGen.X_GADT>[1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3633})
+                               $ IBindVar inter^<{arg:3633}>)
                           (ILocal (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
                                                    description
                                                    (IApp. IVar Just
@@ -289,11 +289,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                        $ (IApp. IVar ::
                                               $ (IApp. IVar <<DerivedGen.MkXG_4>>
                                                      $ IVar ^fuel_arg^
-                                                     $ IVar {arg:3633})
+                                                     $ IVar inter^<{arg:3633}>)
                                               $ (IApp. IVar ::
                                                      $ (IApp. IVar <<DerivedGen.MkXG_5>>
                                                             $ IVar ^fuel_arg^
-                                                            $ IVar {arg:3633})
+                                                            $ IVar inter^<{arg:3633}>)
                                                      $ IVar Nil))))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/004 right-to-left det/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/004 right-to-left det/expected
@@ -179,7 +179,7 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X_GADT>[0]
               [ PatClause (IApp. IVar <DerivedGen.X_GADT>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
                                                    description
                                                    (IApp. IVar Just
@@ -187,11 +187,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                        $ (IApp. IVar ::
                                               $ (IApp. IVar <<DerivedGen.MkXG_4>>
                                                      $ IVar ^fuel_arg^
-                                                     $ IVar {arg:3630})
+                                                     $ IVar inter^<{arg:3630}>)
                                               $ (IApp. IVar ::
                                                      $ (IApp. IVar <<DerivedGen.MkXG_5>>
                                                             $ IVar ^fuel_arg^
-                                                            $ IVar {arg:3630})
+                                                            $ IVar inter^<{arg:3630}>)
                                                      $ IVar Nil))))
                             IClaim MW
                                    Export
@@ -337,10 +337,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X_ADT>[0]
               [ PatClause (IApp. IVar <DerivedGen.X_ADT>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3651})
+                               $ IBindVar inter^<{arg:3651}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3651}))
+                                       $ IVar inter^<{arg:3651}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/006 gadt/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/006 gadt/expected
@@ -10,8 +10,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
     => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:3679} : IVar Data.Fuel.Fuel)
                                                         -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                                                 $ IPrimVal String))
-    => (MW ExplicitArg b : IVar Prelude.Basics.Bool)
-    => ILocal (IApp. IVar <DerivedGen.D>[0] $ IVar ^outmost-fuel^ $ IVar b)
+    => (MW ExplicitArg outer^<b> : Implicit True)
+    => ILocal (IApp. IVar <DerivedGen.D>[0]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<b>)
          IClaim MW
                 Export
                 []
@@ -266,7 +268,7 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.D>[0]
               [ PatClause (IApp. IVar <DerivedGen.D>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (ICase (IVar ^fuel_arg^)
                                          (IVar Data.Fuel.Fuel)
                                          [ PatClause (IVar Data.Fuel.Dry)
@@ -277,11 +279,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar <<DerivedGen.JJ>>
                                                                         $ IVar Data.Fuel.Dry
-                                                                        $ IVar {arg:3630})
+                                                                        $ IVar inter^<{arg:3630}>)
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar <<DerivedGen.TL>>
                                                                                $ IVar Data.Fuel.Dry
-                                                                               $ IVar {arg:3630})
+                                                                               $ IVar inter^<{arg:3630}>)
                                                                         $ IVar Nil)))
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
@@ -295,28 +297,28 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                $ IPrimVal 1)
                                                                         $ (IApp. IVar <<DerivedGen.JJ>>
                                                                                $ IVar ^fuel_arg^
-                                                                               $ IVar {arg:3630}))
+                                                                               $ IVar inter^<{arg:3630}>))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
                                                                                $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                       $ IVar ^sub^fuel_arg^)
                                                                                $ (IApp. IVar <<DerivedGen.FN>>
                                                                                       $ IVar ^sub^fuel_arg^
-                                                                                      $ IVar {arg:3630}))
+                                                                                      $ IVar inter^<{arg:3630}>))
                                                                         $ (IApp. IVar ::
                                                                                $ (IApp. IVar Builtin.MkPair
                                                                                       $ (IApp. IVar Prelude.integerToNat
                                                                                              $ IPrimVal 1)
                                                                                       $ (IApp. IVar <<DerivedGen.TL>>
                                                                                              $ IVar ^fuel_arg^
-                                                                                             $ IVar {arg:3630}))
+                                                                                             $ IVar inter^<{arg:3630}>))
                                                                                $ (IApp. IVar ::
                                                                                       $ (IApp. IVar Builtin.MkPair
                                                                                              $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                                     $ IVar ^sub^fuel_arg^)
                                                                                              $ (IApp. IVar <<DerivedGen.TR>>
                                                                                                     $ IVar ^sub^fuel_arg^
-                                                                                                    $ IVar {arg:3630}))
+                                                                                                    $ IVar inter^<{arg:3630}>))
                                                                                       $ IVar Nil))))) ]))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/008 eq-n/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/008 eq-n/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Nat) -> Gen (b : Nat ** EqualN a b)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IVar Prelude.Types.Nat)
-    => ILocal (IApp. IVar <DerivedGen.EqualN>[0] $ IVar ^outmost-fuel^ $ IVar a)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => ILocal (IApp. IVar <DerivedGen.EqualN>[0]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<a>)
          IClaim MW
                 Export
                 []
@@ -22,10 +24,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.EqualN>[0]
               [ PatClause (IApp. IVar <DerivedGen.EqualN>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (IApp. IVar <<DerivedGen.ReflN>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3630}))
+                                       $ IVar inter^<{arg:3630}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/009 eq-n/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/009 eq-n/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (b : Nat) -> Gen (a : Nat ** EqualN a b)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg b : IVar Prelude.Types.Nat)
-    => ILocal (IApp. IVar <DerivedGen.EqualN>[1] $ IVar ^outmost-fuel^ $ IVar b)
+    => (MW ExplicitArg outer^<b> : Implicit True)
+    => ILocal (IApp. IVar <DerivedGen.EqualN>[1]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<b>)
          IClaim MW
                 Export
                 []
@@ -22,10 +24,10 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.EqualN>[1]
               [ PatClause (IApp. IVar <DerivedGen.EqualN>[1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3633})
+                               $ IBindVar inter^<{arg:3633}>)
                           (ILocal (IApp. IVar <<DerivedGen.ReflN>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3633}))
+                                       $ IVar inter^<{arg:3633}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/010 eq-n/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/010 eq-n/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Nat) -> (b : Nat) -> Gen (EqualN a b)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg b : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => (MW ExplicitArg outer^<b> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.EqualN>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar a
-                   $ IVar b)
+                   $ IVar outer^<a>
+                   $ IVar outer^<b>)
          IClaim MW
                 Export
                 []
@@ -24,12 +24,12 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.EqualN>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.EqualN>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630}
-                               $ IBindVar {arg:3633})
+                               $ IBindVar inter^<{arg:3630}>
+                               $ IBindVar inter^<{arg:3633}>)
                           (ILocal (IApp. IVar <<DerivedGen.ReflN>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3630}
-                                       $ IVar {arg:3633}))
+                                       $ IVar inter^<{arg:3630}>
+                                       $ IVar inter^<{arg:3633}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/012 eq deepcons/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/012 eq deepcons/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Nat) -> Gen (b : Nat ** LT2 a b)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IVar Prelude.Types.Nat)
-    => ILocal (IApp. IVar <DerivedGen.LT2>[0] $ IVar ^outmost-fuel^ $ IVar a)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => ILocal (IApp. IVar <DerivedGen.LT2>[0]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<a>)
          IClaim MW
                 Export
                 []
@@ -22,13 +24,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.LT2>[0]
               [ PatClause (IApp. IVar <DerivedGen.LT2>[0]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630})
+                               $ IBindVar inter^<{arg:3630}>)
                           (ILocal (ICase (IVar ^fuel_arg^)
                                          (IVar Data.Fuel.Fuel)
                                          [ PatClause (IVar Data.Fuel.Dry)
                                                      (IApp. IVar <<DerivedGen.Base>>
                                                           $ IVar Data.Fuel.Dry
-                                                          $ IVar {arg:3630})
+                                                          $ IVar inter^<{arg:3630}>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
                                                      (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
@@ -41,14 +43,14 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                $ IPrimVal 1)
                                                                         $ (IApp. IVar <<DerivedGen.Base>>
                                                                                $ IVar ^fuel_arg^
-                                                                               $ IVar {arg:3630}))
+                                                                               $ IVar inter^<{arg:3630}>))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
                                                                                $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                       $ IVar ^sub^fuel_arg^)
                                                                                $ (IApp. IVar <<DerivedGen.Step>>
                                                                                       $ IVar ^sub^fuel_arg^
-                                                                                      $ IVar {arg:3630}))
+                                                                                      $ IVar inter^<{arg:3630}>))
                                                                         $ IVar Nil))) ]))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/013 eq deepcons/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/013 eq deepcons/expected
@@ -4,8 +4,10 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (b : Nat) -> Gen (a : Nat ** LT2 a b)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg b : IVar Prelude.Types.Nat)
-    => ILocal (IApp. IVar <DerivedGen.LT2>[1] $ IVar ^outmost-fuel^ $ IVar b)
+    => (MW ExplicitArg outer^<b> : Implicit True)
+    => ILocal (IApp. IVar <DerivedGen.LT2>[1]
+                   $ IVar ^outmost-fuel^
+                   $ IVar outer^<b>)
          IClaim MW
                 Export
                 []
@@ -22,13 +24,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.LT2>[1]
               [ PatClause (IApp. IVar <DerivedGen.LT2>[1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3633})
+                               $ IBindVar inter^<{arg:3633}>)
                           (ILocal (ICase (IVar ^fuel_arg^)
                                          (IVar Data.Fuel.Fuel)
                                          [ PatClause (IVar Data.Fuel.Dry)
                                                      (IApp. IVar <<DerivedGen.Base>>
                                                           $ IVar Data.Fuel.Dry
-                                                          $ IVar {arg:3633})
+                                                          $ IVar inter^<{arg:3633}>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
                                                      (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
@@ -41,14 +43,14 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                $ IPrimVal 1)
                                                                         $ (IApp. IVar <<DerivedGen.Base>>
                                                                                $ IVar ^fuel_arg^
-                                                                               $ IVar {arg:3633}))
+                                                                               $ IVar inter^<{arg:3633}>))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
                                                                                $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                       $ IVar ^sub^fuel_arg^)
                                                                                $ (IApp. IVar <<DerivedGen.Step>>
                                                                                       $ IVar ^sub^fuel_arg^
-                                                                                      $ IVar {arg:3633}))
+                                                                                      $ IVar inter^<{arg:3633}>))
                                                                         $ IVar Nil))) ]))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/014 eq deepcons/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/014 eq deepcons/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Nat) -> (b : Nat) -> Gen (LT2 a b)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg b : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => (MW ExplicitArg outer^<b> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.LT2>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar a
-                   $ IVar b)
+                   $ IVar outer^<a>
+                   $ IVar outer^<b>)
          IClaim MW
                 Export
                 []
@@ -24,15 +24,15 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.LT2>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.LT2>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630}
-                               $ IBindVar {arg:3633})
+                               $ IBindVar inter^<{arg:3630}>
+                               $ IBindVar inter^<{arg:3633}>)
                           (ILocal (ICase (IVar ^fuel_arg^)
                                          (IVar Data.Fuel.Fuel)
                                          [ PatClause (IVar Data.Fuel.Dry)
                                                      (IApp. IVar <<DerivedGen.Base>>
                                                           $ IVar Data.Fuel.Dry
-                                                          $ IVar {arg:3630}
-                                                          $ IVar {arg:3633})
+                                                          $ IVar inter^<{arg:3630}>
+                                                          $ IVar inter^<{arg:3633}>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
                                                      (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
@@ -45,16 +45,16 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                $ IPrimVal 1)
                                                                         $ (IApp. IVar <<DerivedGen.Base>>
                                                                                $ IVar ^fuel_arg^
-                                                                               $ IVar {arg:3630}
-                                                                               $ IVar {arg:3633}))
+                                                                               $ IVar inter^<{arg:3630}>
+                                                                               $ IVar inter^<{arg:3633}>))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
                                                                                $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                       $ IVar ^sub^fuel_arg^)
                                                                                $ (IApp. IVar <<DerivedGen.Step>>
                                                                                       $ IVar ^sub^fuel_arg^
-                                                                                      $ IVar {arg:3630}
-                                                                                      $ IVar {arg:3633}))
+                                                                                      $ IVar inter^<{arg:3630}>
+                                                                                      $ IVar inter^<{arg:3633}>))
                                                                         $ IVar Nil))) ]))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/least-effort/print/regression/dependent-givens-big/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/dependent-givens-big/expected
@@ -4,13 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (v : VectMaybeAnyType n) -> Gen (i : Fin n ** (t : MaybeAnyType ** AtIndex n i t v))
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg v : IApp. IVar DerivedGen.VectMaybeAnyType.VectMaybeAnyType
-                               $ IVar n)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => (MW ExplicitArg outer^<v> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]
                    $ IVar ^outmost-fuel^
-                   $ IVar n
-                   $ IVar v)
+                   $ IVar outer^<n>
+                   $ IVar outer^<v>)
          IClaim MW
                 Export
                 []
@@ -35,15 +34,15 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]
               [ PatClause (IApp. IVar <DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar n
-                               $ IBindVar {arg:4011})
+                               $ IBindVar inter^<n>
+                               $ IBindVar inter^<{arg:4011}>)
                           (ILocal (ICase (IVar ^fuel_arg^)
                                          (IVar Data.Fuel.Fuel)
                                          [ PatClause (IVar Data.Fuel.Dry)
                                                      (IApp. IVar <<DerivedGen.VectMaybeAnyType.Here>>
                                                           $ IVar Data.Fuel.Dry
-                                                          $ IVar n
-                                                          $ IVar {arg:4011})
+                                                          $ IVar inter^<n>
+                                                          $ IVar inter^<{arg:4011}>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
                                                      (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
@@ -56,16 +55,16 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                $ IPrimVal 1)
                                                                         $ (IApp. IVar <<DerivedGen.VectMaybeAnyType.Here>>
                                                                                $ IVar ^fuel_arg^
-                                                                               $ IVar n
-                                                                               $ IVar {arg:4011}))
+                                                                               $ IVar inter^<n>
+                                                                               $ IVar inter^<{arg:4011}>))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
                                                                                $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                       $ IVar ^sub^fuel_arg^)
                                                                                $ (IApp. IVar <<DerivedGen.VectMaybeAnyType.There>>
                                                                                       $ IVar ^sub^fuel_arg^
-                                                                                      $ IVar n
-                                                                                      $ IVar {arg:4011}))
+                                                                                      $ IVar inter^<n>
+                                                                                      $ IVar inter^<{arg:4011}>))
                                                                         $ IVar Nil))) ]))
                             IClaim MW
                                    Export

--- a/tests/gen-derivation/derivation/least-effort/print/regression/dependent-givens-small-deep/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/dependent-givens-small-deep/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (f : Fin n) -> Gen (X n f)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg f : IApp. IVar Data.Fin.Fin $ IVar n)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => (MW ExplicitArg outer^<f> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.X>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar n
-                   $ IVar f)
+                   $ IVar outer^<n>
+                   $ IVar outer^<f>)
          IClaim MW
                 Export
                 []
@@ -25,12 +25,12 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.X>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar n
-                               $ IBindVar {arg:3632})
+                               $ IBindVar inter^<n>
+                               $ IBindVar inter^<{arg:3632}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar n
-                                       $ IVar {arg:3632}))
+                                       $ IVar inter^<n>
+                                       $ IVar inter^<{arg:3632}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/regression/dependent-givens-small-shallow/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/dependent-givens-small-shallow/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (f : Fin n) -> Gen (X n f)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg n : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg f : IApp. IVar Data.Fin.Fin $ IVar n)
+    => (MW ExplicitArg outer^<n> : Implicit True)
+    => (MW ExplicitArg outer^<f> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.X>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar n
-                   $ IVar f)
+                   $ IVar outer^<n>
+                   $ IVar outer^<f>)
          IClaim MW
                 Export
                 []
@@ -25,12 +25,12 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.X>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar n
-                               $ IBindVar {arg:3632})
+                               $ IBindVar inter^<n>
+                               $ IBindVar inter^<{arg:3632}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar n
-                                       $ IVar {arg:3632}))
+                                       $ IVar inter^<n>
+                                       $ IVar inter^<{arg:3632}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-four-occurences/expected
@@ -4,16 +4,16 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> (x4 : Nat) -> Gen (X x1 x2 x3 x4)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg x1 : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg x2 : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg x3 : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg x4 : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg outer^<x1> : Implicit True)
+    => (MW ExplicitArg outer^<x2> : Implicit True)
+    => (MW ExplicitArg outer^<x3> : Implicit True)
+    => (MW ExplicitArg outer^<x4> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
                    $ IVar ^outmost-fuel^
-                   $ IVar x1
-                   $ IVar x2
-                   $ IVar x3
-                   $ IVar x4)
+                   $ IVar outer^<x1>
+                   $ IVar outer^<x2>
+                   $ IVar outer^<x3>
+                   $ IVar outer^<x4>)
          IClaim MW
                 Export
                 []
@@ -32,16 +32,16 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0, 1, 2, 3]
               [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630}
-                               $ IBindVar {arg:3633}
-                               $ IBindVar {arg:3636}
-                               $ IBindVar {arg:3639})
+                               $ IBindVar inter^<{arg:3630}>
+                               $ IBindVar inter^<{arg:3633}>
+                               $ IBindVar inter^<{arg:3636}>
+                               $ IBindVar inter^<{arg:3639}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3630}
-                                       $ IVar {arg:3633}
-                                       $ IVar {arg:3636}
-                                       $ IVar {arg:3639}))
+                                       $ IVar inter^<{arg:3630}>
+                                       $ IVar inter^<{arg:3633}>
+                                       $ IVar inter^<{arg:3636}>
+                                       $ IVar inter^<{arg:3639}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/lost-deceq-three-occurences/expected
@@ -4,14 +4,14 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> Gen (X x1 x2 x3)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg x1 : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg x2 : IVar Prelude.Types.Nat)
-    => (MW ExplicitArg x3 : IVar Prelude.Types.Nat)
+    => (MW ExplicitArg outer^<x1> : Implicit True)
+    => (MW ExplicitArg outer^<x2> : Implicit True)
+    => (MW ExplicitArg outer^<x3> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2]
                    $ IVar ^outmost-fuel^
-                   $ IVar x1
-                   $ IVar x2
-                   $ IVar x3)
+                   $ IVar outer^<x1>
+                   $ IVar outer^<x2>
+                   $ IVar outer^<x3>)
          IClaim MW
                 Export
                 []
@@ -28,14 +28,14 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.X>[0, 1, 2]
               [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3630}
-                               $ IBindVar {arg:3633}
-                               $ IBindVar {arg:3636})
+                               $ IBindVar inter^<{arg:3630}>
+                               $ IBindVar inter^<{arg:3633}>
+                               $ IBindVar inter^<{arg:3636}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkX>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3630}
-                                       $ IVar {arg:3633}
-                                       $ IVar {arg:3636}))
+                                       $ IVar inter^<{arg:3630}>
+                                       $ IVar inter^<{arg:3633}>
+                                       $ IVar inter^<{arg:3636}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/regression/too-early-rename-multiple-complex/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/too-early-rename-multiple-complex/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Z) -> (b : Z) -> Gen (W a b)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IVar DerivedGen.Z)
-    => (MW ExplicitArg b : IVar DerivedGen.Z)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => (MW ExplicitArg outer^<b> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.W>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar a
-                   $ IVar b)
+                   $ IVar outer^<a>
+                   $ IVar outer^<b>)
          IClaim MW
                 Export
                 []
@@ -24,12 +24,12 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.W>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.W>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3665}
-                               $ IBindVar {arg:3668})
+                               $ IBindVar inter^<{arg:3665}>
+                               $ IBindVar inter^<{arg:3668}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkW>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3665}
-                                       $ IVar {arg:3668}))
+                                       $ IVar inter^<{arg:3665}>
+                                       $ IVar inter^<{arg:3668}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/regression/too-early-rename-multiple-simple/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/too-early-rename-multiple-simple/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Z) -> (b : Z) -> Gen (W a b)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IVar DerivedGen.Z)
-    => (MW ExplicitArg b : IVar DerivedGen.Z)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => (MW ExplicitArg outer^<b> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.W>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar a
-                   $ IVar b)
+                   $ IVar outer^<a>
+                   $ IVar outer^<b>)
          IClaim MW
                 Export
                 []
@@ -24,12 +24,12 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.W>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.W>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3662}
-                               $ IBindVar {arg:3665})
+                               $ IBindVar inter^<{arg:3662}>
+                               $ IBindVar inter^<{arg:3665}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkW>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3662}
-                                       $ IVar {arg:3665}))
+                                       $ IVar inter^<{arg:3662}>
+                                       $ IVar inter^<{arg:3665}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/regression/too-early-rename-single-dependency/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/too-early-rename-single-dependency/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Z) -> (b : Z) -> Gen (W a b)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg a : IVar DerivedGen.Z)
-    => (MW ExplicitArg b : IVar DerivedGen.Z)
+    => (MW ExplicitArg outer^<a> : Implicit True)
+    => (MW ExplicitArg outer^<b> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.W>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar a
-                   $ IVar b)
+                   $ IVar outer^<a>
+                   $ IVar outer^<b>)
          IClaim MW
                 Export
                 []
@@ -24,12 +24,12 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.W>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.W>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3658}
-                               $ IBindVar {arg:3661})
+                               $ IBindVar inter^<{arg:3658}>
+                               $ IBindVar inter^<{arg:3661}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkW>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3658}
-                                       $ IVar {arg:3661}))
+                                       $ IVar inter^<{arg:3658}>
+                                       $ IVar inter^<{arg:3661}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-mismatch-dependent/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (x : X) -> (x' : X) -> Gen (Z x x')
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg x : IVar DerivedGen.X)
-    => (MW ExplicitArg x' : IVar DerivedGen.X)
+    => (MW ExplicitArg outer^<x> : Implicit True)
+    => (MW ExplicitArg outer^<x'> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.Z>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar x
-                   $ IVar x')
+                   $ IVar outer^<x>
+                   $ IVar outer^<x'>)
          IClaim MW
                 Export
                 []
@@ -24,12 +24,12 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.Z>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.Z>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar {arg:3650}
-                               $ IBindVar {arg:3653})
+                               $ IBindVar inter^<{arg:3650}>
+                               $ IBindVar inter^<{arg:3653}>)
                           (ILocal (IApp. IVar <<DerivedGen.MkZ>>
                                        $ IVar ^fuel_arg^
-                                       $ IVar {arg:3650}
-                                       $ IVar {arg:3653}))
+                                       $ IVar inter^<{arg:3650}>
+                                       $ IVar inter^<{arg:3653}>))
                             IClaim MW
                                    Export
                                    []

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/expected
@@ -4,12 +4,12 @@
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (xs : X) -> (ys : X) -> Gen (Y xs ys)
 LOG gen.auto.derive.infra:0: 
 ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg xs : IVar DerivedGen.X)
-    => (MW ExplicitArg ys : IVar DerivedGen.X)
+    => (MW ExplicitArg outer^<xs> : Implicit True)
+    => (MW ExplicitArg outer^<ys> : Implicit True)
     => ILocal (IApp. IVar <DerivedGen.Y>[0, 1]
                    $ IVar ^outmost-fuel^
-                   $ IVar xs
-                   $ IVar ys)
+                   $ IVar outer^<xs>
+                   $ IVar outer^<ys>)
          IClaim MW
                 Export
                 []
@@ -24,15 +24,15 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IDef <DerivedGen.Y>[0, 1]
               [ PatClause (IApp. IVar <DerivedGen.Y>[0, 1]
                                $ IBindVar ^fuel_arg^
-                               $ IBindVar xs
-                               $ IBindVar ys)
+                               $ IBindVar inter^<xs>
+                               $ IBindVar inter^<ys>)
                           (ILocal (ICase (IVar ^fuel_arg^)
                                          (IVar Data.Fuel.Fuel)
                                          [ PatClause (IVar Data.Fuel.Dry)
                                                      (IApp. IVar <<DerivedGen.A>>
                                                           $ IVar Data.Fuel.Dry
-                                                          $ IVar xs
-                                                          $ IVar ys)
+                                                          $ IVar inter^<xs>
+                                                          $ IVar inter^<ys>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
                                                      (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
@@ -45,16 +45,16 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                $ IPrimVal 1)
                                                                         $ (IApp. IVar <<DerivedGen.A>>
                                                                                $ IVar ^fuel_arg^
-                                                                               $ IVar xs
-                                                                               $ IVar ys))
+                                                                               $ IVar inter^<xs>
+                                                                               $ IVar inter^<ys>))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
                                                                                $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
                                                                                       $ IVar ^sub^fuel_arg^)
                                                                                $ (IApp. IVar <<DerivedGen.B>>
                                                                                       $ IVar ^sub^fuel_arg^
-                                                                                      $ IVar xs
-                                                                                      $ IVar ys))
+                                                                                      $ IVar inter^<xs>
+                                                                                      $ IVar inter^<ys>))
                                                                         $ IVar Nil))) ]))
                             IClaim MW
                                    Export


### PR DESCRIPTION
This is a workaround for idris-lang/Idris2#2983