### PR TITLE
[ cleanup ] Remove `frequency'` function variant

### DIFF
--- a/src/Data/Nat/Pos.idr
+++ b/src/Data/Nat/Pos.idr
@@ -29,6 +29,14 @@ Range PosNat where
 --- Simple arithmetics ---
 
 public export %inline
+succ : PosNat -> PosNat
+succ $ Element n _ = Element (S n) %search
+
+public export %inline
+one : PosNat
+one = 1
+
+public export %inline
 (+) : PosNat -> PosNat -> PosNat
 Element (S n) _ + Element (S m) _ = Element (S n + S m) ItIsSucc
 
@@ -60,6 +68,10 @@ public export
 toPosNat : Nat -> Maybe PosNat
 toPosNat Z       = Nothing
 toPosNat k@(S _) = Just $ Element k ItIsSucc
+
+public export %inline
+fromNat : (x : Nat) -> (0 _ : IsSucc x) => PosNat
+fromNat x = Element x %search
 
 --- Greatest common divisor ---
 

--- a/src/Deriving/DepTyCheck/Gen/Core.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core.idr
@@ -92,7 +92,7 @@ ConstructorDerivator => DerivatorCore where
               selectFuel NonRecursive = fuelAr
           let weight : Recursiveness -> TTImp
               weight Recursive    = var `{Deriving.DepTyCheck.Util.Reflection.leftDepth} .$ varStr subFuelArg
-              weight NonRecursive = liftNat 1
+              weight NonRecursive = liftWeight1
           var `{Data.Fuel.More} .$ bindVar subFuelArg .= callFrequency "\{logPosition sig} (spend fuel)"
                                                            (consRecs <&> \(con, rec) => (weight rec, callConsGen (varStr $ selectFuel rec) con))
         ]

--- a/src/Deriving/DepTyCheck/Util/Reflection.idr
+++ b/src/Deriving/DepTyCheck/Util/Reflection.idr
@@ -3,6 +3,7 @@ module Deriving.DepTyCheck.Util.Reflection
 
 import public Data.Fin
 import public Data.Fuel
+import public Data.Nat.Pos
 import public Data.List.Lazy
 import public Data.These
 import public Data.Vect.Dependent
@@ -149,9 +150,8 @@ liftList : Foldable f => f TTImp -> TTImp
 liftList = foldr (\l, r => `(~l :: ~r)) `([])
 
 export
-liftNat : Nat -> TTImp
-liftNat k = `(Prelude.integerToNat ~(primVal $ BI $ cast k))
-  -- we are using `integerToNat` instead of explicit application of `S` and `Z` to make this look nicer in prints.
+liftWeight1 : TTImp
+liftWeight1 = `(Data.Nat.Pos.one)
 
 export
 callOneOf : (desc : String) -> List TTImp -> TTImp
@@ -162,16 +162,16 @@ callOneOf desc variants = `(Test.DepTyCheck.Gen.oneOf {description=Just ~(primVa
 export
 callFrequency : (desc : String) -> List (TTImp, TTImp) -> TTImp
 callFrequency _    [(_, v)] = v
-callFrequency desc variants = `(Test.DepTyCheck.Gen.frequency' {description=Just ~(primVal $ Str desc)}) .$
+callFrequency desc variants = `(Test.DepTyCheck.Gen.frequency {description=Just ~(primVal $ Str desc)}) .$
                                 liftList (variants <&> \(freq, subgen) => var `{Builtin.MkPair} .$ freq .$ subgen)
 
 -- TODO to think of better placement for this function; this anyway is intended to be called from the derived code.
 public export
-leftDepth : Fuel -> Nat
+leftDepth : Fuel -> PosNat
 leftDepth = go 1 where
-  go : Nat -> Fuel -> Nat
+  go : PosNat -> Fuel -> PosNat
   go n Dry      = n
-  go n (More x) = go (S n) x
+  go n (More x) = go (succ n) x
 
 export
 isSimpleBindVar : TTImp -> Bool

--- a/src/Test/DepTyCheck/Gen.idr
+++ b/src/Test/DepTyCheck/Gen.idr
@@ -475,11 +475,6 @@ frequency : {default Nothing description : Maybe String} ->
             LazyLst altsNe (PosNat, Lazy (Gen alem a)) -> Gen em a
 frequency = oneOf {description} . MkGenAlternatives
 
-export %inline
-frequency' : {default Nothing description : Maybe String} ->
-             LazyLst altsNe (Nat, Lazy (Gen alem a)) -> Gen0 a
-frequency' = frequency {description} . mapMaybe (\(freq, gen) => toPosNat freq <&> (, gen))
-
 ||| Choose one of the given values uniformly.
 |||
 ||| This function is equivalent to `oneOf` applied to list of `pure` generators per each value.

--- a/tests/gen-derivation/derivation/infra/empty-cons print 002/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 002/expected
@@ -36,14 +36,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar inter^<elem>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Data.Vect.Vect[0, 1] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Data.Vect.Nil>>
                                                                                $ IVar ^fuel_arg^
                                                                                $ IVar inter^<len>

--- a/tests/gen-derivation/derivation/infra/empty-cons print 006/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 006/expected
@@ -34,14 +34,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar inter^<elem>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Data.Vect.Vect[1] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Data.Vect.Nil>>
                                                                                $ IVar ^fuel_arg^
                                                                                $ IVar inter^<elem>))

--- a/tests/gen-derivation/derivation/infra/empty-cons print 008/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 008/expected
@@ -30,14 +30,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Data.Vect.Vect[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Data.Vect.Nil>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/infra/empty-cons print 010/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 010/expected
@@ -33,20 +33,18 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                         $ IVar Nil)))
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.X[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.X0>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
-                                                                               $ (IApp. IVar Prelude.integerToNat
-                                                                                      $ IPrimVal 1)
+                                                                               $ IVar Data.Nat.Pos.one
                                                                                $ (IApp. IVar <<DerivedGen.X1>>
                                                                                       $ IVar ^fuel_arg^))
                                                                         $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/infra/empty-cons print 011/expected
+++ b/tests/gen-derivation/derivation/infra/empty-cons print 011/expected
@@ -37,20 +37,18 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                         $ IVar Nil)))
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.X[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.X0>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::
                                                                         $ (IApp. IVar Builtin.MkPair
-                                                                               $ (IApp. IVar Prelude.integerToNat
-                                                                                      $ IPrimVal 1)
+                                                                               $ IVar Data.Nat.Pos.one
                                                                                $ (IApp. IVar <<DerivedGen.X1>>
                                                                                       $ IVar ^fuel_arg^))
                                                                         $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/003 noparam/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/003 noparam/expected
@@ -23,14 +23,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/004 noparam/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/004 noparam/expected
@@ -31,14 +31,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::
@@ -94,14 +93,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.X[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.E>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/006 param/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/006 param/expected
@@ -35,14 +35,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/007 right-to-left simple/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/007 right-to-left simple/expected
@@ -43,14 +43,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/008 right-to-left simple/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/008 right-to-left simple/expected
@@ -43,14 +43,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/009 left-to-right/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/009 left-to-right/expected
@@ -41,14 +41,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/010 right-to-left long-dpair/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/010 right-to-left long-dpair/expected
@@ -47,14 +47,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/011 right-to-left long-dpair/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/011 right-to-left long-dpair/expected
@@ -55,14 +55,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/012 right-to-left chained/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/012 right-to-left chained/expected
@@ -55,14 +55,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/adt/013 right-to-left nondet/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/adt/013 right-to-left nondet/expected
@@ -61,14 +61,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/001 gadt/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/001 gadt/expected
@@ -29,14 +29,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar inter^<n>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Data.Fin.Fin[0] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Data.Fin.FZ>>
                                                                                $ IVar ^fuel_arg^
                                                                                $ IVar inter^<n>))

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/002 gadt/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/002 gadt/expected
@@ -35,14 +35,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::
@@ -98,14 +97,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Data.Fin.Fin[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Data.Fin.FZ>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
@@ -75,14 +75,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/004 right-to-left det/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/004 right-to-left det/expected
@@ -91,14 +91,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/005 gadt/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/005 gadt/expected
@@ -101,14 +101,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                         $ IVar Nil)))
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.D[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.JJ>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::
@@ -119,8 +118,7 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                       $ IVar ^sub^fuel_arg^))
                                                                         $ (IApp. IVar ::
                                                                                $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Prelude.integerToNat
-                                                                                             $ IPrimVal 1)
+                                                                                      $ IVar Data.Nat.Pos.one
                                                                                       $ (IApp. IVar <<DerivedGen.TL>>
                                                                                              $ IVar ^fuel_arg^))
                                                                                $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/006 gadt/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/006 gadt/expected
@@ -114,14 +114,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                         $ IVar Nil)))
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.D[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.JJ>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::
@@ -132,8 +131,7 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                       $ IVar ^sub^fuel_arg^))
                                                                         $ (IApp. IVar ::
                                                                                $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Prelude.integerToNat
-                                                                                             $ IPrimVal 1)
+                                                                                      $ IVar Data.Nat.Pos.one
                                                                                       $ (IApp. IVar <<DerivedGen.TL>>
                                                                                              $ IVar ^fuel_arg^))
                                                                                $ (IApp. IVar ::
@@ -310,14 +308,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                         $ IVar Nil)))
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.D[0] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.JJ>>
                                                                                $ IVar ^fuel_arg^
                                                                                $ IVar inter^<{arg:3630}>))
@@ -330,8 +327,7 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                       $ IVar inter^<{arg:3630}>))
                                                                         $ (IApp. IVar ::
                                                                                $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Prelude.integerToNat
-                                                                                             $ IPrimVal 1)
+                                                                                      $ IVar Data.Nat.Pos.one
                                                                                       $ (IApp. IVar <<DerivedGen.TL>>
                                                                                              $ IVar ^fuel_arg^
                                                                                              $ IVar inter^<{arg:3630}>))

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/007 eq-n/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/007 eq-n/expected
@@ -39,14 +39,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal Prelude.Types.Nat[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<Prelude.Types.Z>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/011 eq deepcons/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/011 eq deepcons/expected
@@ -34,14 +34,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar Data.Fuel.Dry)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.LT2[] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.Base>>
                                                                                $ IVar ^fuel_arg^))
                                                                  $ (IApp. IVar ::

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/012 eq deepcons/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/012 eq deepcons/expected
@@ -34,14 +34,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar inter^<{arg:3630}>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.LT2[0] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.Base>>
                                                                                $ IVar ^fuel_arg^
                                                                                $ IVar inter^<{arg:3630}>))

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/013 eq deepcons/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/013 eq deepcons/expected
@@ -34,14 +34,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar inter^<{arg:3633}>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.LT2[1] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.Base>>
                                                                                $ IVar ^fuel_arg^
                                                                                $ IVar inter^<{arg:3633}>))

--- a/tests/gen-derivation/derivation/least-effort/print/gadt/014 eq deepcons/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/gadt/014 eq deepcons/expected
@@ -36,14 +36,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar inter^<{arg:3633}>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.LT2[0, 1] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.Base>>
                                                                                $ IVar ^fuel_arg^
                                                                                $ IVar inter^<{arg:3630}>

--- a/tests/gen-derivation/derivation/least-effort/print/regression/dependent-givens-big/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/dependent-givens-big/expected
@@ -46,14 +46,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar inter^<{arg:4011}>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.VectMaybeAnyType.AtIndex[0, 3] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.VectMaybeAnyType.Here>>
                                                                                $ IVar ^fuel_arg^
                                                                                $ IVar inter^<n>

--- a/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/expected
+++ b/tests/gen-derivation/derivation/least-effort/print/regression/unification-name-mismatch/expected
@@ -36,14 +36,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                           $ IVar inter^<ys>)
                                          , PatClause (IApp. IVar Data.Fuel.More
                                                           $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency')
+                                                     (IApp. INamedApp (IVar Test.DepTyCheck.Gen.frequency)
                                                                       description
                                                                       (IApp. IVar Just
                                                                            $ IPrimVal DerivedGen.Y[0, 1] (spend fuel))
                                                           $ (IApp. IVar ::
                                                                  $ (IApp. IVar Builtin.MkPair
-                                                                        $ (IApp. IVar Prelude.integerToNat
-                                                                               $ IPrimVal 1)
+                                                                        $ IVar Data.Nat.Pos.one
                                                                         $ (IApp. IVar <<DerivedGen.A>>
                                                                                $ IVar ^fuel_arg^
                                                                                $ IVar inter^<xs>


### PR DESCRIPTION
This function seems to be the only one which disturbs us from making the weight to be a distinct non-parameterised type with additional semantics.

Another question is whether or not should we have a function which relates to `frequency` as the function `elements'` relates to `elements`. But in this case 1) it should take any `Foldable` as `elements'` does 2) it will lose additional potential future abilities, if it still takes `Nat`, not a `Weight`.

A pro of such a function should we that it is similar to QuickCheck's `frequency` function. Is there any other?