### PR TITLE
[ performance ] Change the order of derivation, derive one strictly after another

### DIFF
--- a/src/Deriving/DepTyCheck/Gen/Checked.idr
+++ b/src/Deriving/DepTyCheck/Gen/Checked.idr
@@ -4,6 +4,7 @@ module Deriving.DepTyCheck.Gen.Checked
 import public Control.Monad.Either
 import public Control.Monad.Reader
 import public Control.Monad.State
+import public Control.Monad.State.Tuple
 import public Control.Monad.Writer
 import public Control.Monad.RWS
 
@@ -91,8 +92,8 @@ namespace ClojuringCanonicImpl
   ClojuringContext : (Type -> Type) -> Type
   ClojuringContext m =
     ( MonadReader (SortedMap GenSignature (ExternalGenSignature, Name)) m -- external gens
-    , MonadState  (SortedMap GenSignature Name) m -- gens already asked to be derived
-    , MonadWriter (List Decl, List Decl) m -- function declarations and bodies
+    , MonadState  (SortedMap GenSignature Name) m                         -- gens already asked to be derived
+    , MonadWriter (List Decl, List Decl) m                                -- function declarations and bodies
     )
 
   nameForGen : GenSignature -> Name

--- a/tests/derivation/infra/ext print 004/expected
+++ b/tests/derivation/infra/ext print 004/expected
@@ -15,14 +15,6 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IClaim MW
-                Export
-                []
                 (MkTy <AlternativeCore.X'S>[0]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (MW ExplicitArg {arg:5277} : IVar Prelude.Types.Nat)
@@ -30,8 +22,18 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
                                   $ (IApp. IVar AlternativeCore.X'S
                                          $ IVar {arg:5277}))))
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[] $ IBindVar fuel)
+         IClaim MW
+                Export
+                []
+                (MkTy <Prelude.Types.Nat>[]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <AlternativeCore.X'S>[0]
+              [ PatClause (IApp. IVar <AlternativeCore.X'S>[0]
+                               $ IBindVar fuel
+                               $ Implicit True)
                           (IApp. IVar <*>
                                $ (IApp. IVar <$>
                                       $ IVar MkXSN
@@ -39,10 +41,8 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                              $ IVar ^outmost-fuel^))
                                $ (IApp. IVar <Prelude.Types.Nat>[]
                                       $ IVar fuel)) ]
-         IDef <AlternativeCore.X'S>[0]
-              [ PatClause (IApp. IVar <AlternativeCore.X'S>[0]
-                               $ IBindVar fuel
-                               $ Implicit True)
+         IDef <Prelude.Types.Nat>[]
+              [ PatClause (IApp. IVar <Prelude.Types.Nat>[] $ IBindVar fuel)
                           (IApp. IVar <*>
                                $ (IApp. IVar <$>
                                       $ IVar MkXSN

--- a/tests/derivation/least-effort/print/adt/004 noparam/expected
+++ b/tests/derivation/least-effort/print/adt/004 noparam/expected
@@ -8,91 +8,19 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IClaim MW
-                Export
-                []
                 (MkTy <DerivedGen.X>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
                                   $ IVar DerivedGen.X)))
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:789} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:789}))))) ] ]
+         IClaim MW
+                Export
+                []
+                (MkTy <Prelude.Types.Nat>[]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ IVar Prelude.Types.Nat)))
          IDef <DerivedGen.X>[]
               [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
                           (ILocal (ICase (IVar ^fuel_arg^)
@@ -169,3 +97,75 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                        $ (IApp. IVar DerivedGen.R
                                                                                               $ IVar ^bnd^{arg:3633}
                                                                                               $ IVar ^bnd^{arg:3636}))))))) ] ]
+         IDef <Prelude.Types.Nat>[]
+              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (ICase (IVar ^fuel_arg^)
+                                         (IVar Data.Fuel.Fuel)
+                                         [ PatClause (IVar Data.Fuel.Dry)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
+                                                          $ (IApp. IVar <<Prelude.Types.Z>>
+                                                                 $ IVar Data.Fuel.Dry))
+                                         , PatClause (IApp. IVar Data.Fuel.More
+                                                          $ IBindVar ^sub^fuel_arg^)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
+                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
+                                                                 $ (IApp. IVar ::
+                                                                        $ (IApp. IVar Builtin.MkPair
+                                                                               $ IVar Data.Nat.Pos.one
+                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
+                                                                                      $ IVar ^fuel_arg^))
+                                                                        $ (IApp. IVar ::
+                                                                               $ (IApp. IVar Builtin.MkPair
+                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
+                                                                                             $ IVar ^sub^fuel_arg^)
+                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
+                                                                                             $ IVar ^sub^fuel_arg^))
+                                                                               $ IVar Nil)))) ]))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Types.Z>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Types.Nat)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Types.S>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Types.Nat)))
+                            IDef <<Prelude.Types.Z>>
+                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Types.Z (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ IVar Prelude.Types.Z)) ]
+                            IDef <<Prelude.Types.S>>
+                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Types.S (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^cons_fuel^)
+                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:789} : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Prelude.Types.S
+                                                                               $ IVar ^bnd^{arg:789}))))) ] ]

--- a/tests/derivation/least-effort/print/adt/006 param/expected
+++ b/tests/derivation/least-effort/print/adt/006 param/expected
@@ -8,14 +8,6 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IClaim MW
-                Export
-                []
                 (MkTy <DerivedGen.X>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
@@ -25,6 +17,52 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                          $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
                                                 => (IApp. IVar DerivedGen.X
                                                         $ IVar {arg:3630}))))))
+         IClaim MW
+                Export
+                []
+                (MkTy <Prelude.Types.Nat>[]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <DerivedGen.X>[]
+              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X
+                                                                           $ IVar {arg:3630}))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ INamedApp (IVar DerivedGen.MkX)
+                                                                                           n
+                                                                                           (IVar n)))))) ] ]
          IDef <Prelude.Types.Nat>[]
               [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
                                $ IBindVar ^fuel_arg^)
@@ -97,41 +135,3 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                          $ Implicit True)
                                                                         $ (IApp. IVar Prelude.Types.S
                                                                                $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:3630}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkX)
-                                                                                           n
-                                                                                           (IVar n)))))) ] ]

--- a/tests/derivation/least-effort/print/adt/007 right-to-left simple/expected
+++ b/tests/derivation/least-effort/print/adt/007 right-to-left simple/expected
@@ -8,11 +8,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
+                                  $ IVar DerivedGen.Y)))
          IClaim MW
                 Export
                 []
@@ -28,11 +28,87 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <Prelude.Types.Nat>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <DerivedGen.Y>[]
+              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkY>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkY>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar DerivedGen.Y)))
+                            IDef <<DerivedGen.MkY>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkY (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <DerivedGen.X>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                => ICase (IVar {lamc:0})
+                                                                         (Implicit False)
+                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                          $ IBindVar n
+                                                                                          $ IBindVar ^bnd^{arg:3642})
+                                                                                     (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                      f
+                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                           $ Implicit True)
+                                                                                          $ (IApp. INamedApp (IVar DerivedGen.MkY)
+                                                                                                             n
+                                                                                                             (IVar n)
+                                                                                                 $ IVar ^bnd^{arg:3642})) ]))) ] ]
+         IDef <DerivedGen.X>[]
+              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X
+                                                                           $ IVar {arg:3630}))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ INamedApp (IVar DerivedGen.MkX)
+                                                                                           n
+                                                                                           (IVar n)))))) ] ]
          IDef <Prelude.Types.Nat>[]
               [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
                                $ IBindVar ^fuel_arg^)
@@ -105,79 +181,3 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                          $ Implicit True)
                                                                         $ (IApp. IVar Prelude.Types.S
                                                                                $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:3630}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkX)
-                                                                                           n
-                                                                                           (IVar n)))))) ] ]
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ IBindVar ^bnd^{arg:3642})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (IVar DerivedGen.MkY)
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:3642})) ]))) ] ]

--- a/tests/derivation/least-effort/print/adt/008 right-to-left simple/expected
+++ b/tests/derivation/least-effort/print/adt/008 right-to-left simple/expected
@@ -8,11 +8,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
+                                  $ IVar DerivedGen.Y)))
          IClaim MW
                 Export
                 []
@@ -28,11 +28,87 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <Prelude.Types.Nat>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <DerivedGen.Y>[]
+              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkY>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkY>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar DerivedGen.Y)))
+                            IDef <<DerivedGen.MkY>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkY (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <DerivedGen.X>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                => ICase (IVar {lamc:0})
+                                                                         (Implicit False)
+                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                          $ IBindVar n
+                                                                                          $ IBindVar ^bnd^{arg:3643})
+                                                                                     (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                      f
+                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                           $ Implicit True)
+                                                                                          $ (IApp. INamedApp (IVar DerivedGen.MkY)
+                                                                                                             n
+                                                                                                             (IVar n)
+                                                                                                 $ IVar ^bnd^{arg:3643})) ]))) ] ]
+         IDef <DerivedGen.X>[]
+              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X
+                                                                           $ IVar {arg:3630}))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ INamedApp (IVar DerivedGen.MkX)
+                                                                                           n
+                                                                                           (IVar n)))))) ] ]
          IDef <Prelude.Types.Nat>[]
               [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
                                $ IBindVar ^fuel_arg^)
@@ -105,79 +181,3 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                          $ Implicit True)
                                                                         $ (IApp. IVar Prelude.Types.S
                                                                                $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:3630}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkX)
-                                                                                           n
-                                                                                           (IVar n)))))) ] ]
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ IBindVar ^bnd^{arg:3643})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (IVar DerivedGen.MkY)
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:3643})) ]))) ] ]

--- a/tests/derivation/least-effort/print/adt/009 left-to-right/expected
+++ b/tests/derivation/least-effort/print/adt/009 left-to-right/expected
@@ -8,11 +8,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
+                                  $ IVar DerivedGen.Y)))
          IClaim MW
                 Export
                 []
@@ -26,11 +26,87 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <Prelude.Types.Nat>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <DerivedGen.Y>[]
+              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkY>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkY>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar DerivedGen.Y)))
+                            IDef <<DerivedGen.MkY>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkY (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. IVar >>=
+                                                                        $ (IApp. IVar <DerivedGen.X>[0]
+                                                                               $ IVar ^outmost-fuel^
+                                                                               $ (IApp. IVar Prelude.Types.mult
+                                                                                      $ IVar n
+                                                                                      $ (IApp. IVar Prelude.Types.S
+                                                                                             $ (IApp. IVar Prelude.Types.S
+                                                                                                    $ IVar Prelude.Types.Z))))
+                                                                        $ (ILam.  (MW ExplicitArg ^bnd^{arg:3646} : Implicit False)
+                                                                               => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                   f
+                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                        $ Implicit True)
+                                                                                       $ (IApp. INamedApp (IVar DerivedGen.MkY)
+                                                                                                          n
+                                                                                                          (IVar n)
+                                                                                              $ IVar ^bnd^{arg:3646}))))))) ] ]
+         IDef <DerivedGen.X>[0]
+              [ PatClause (IApp. IVar <DerivedGen.X>[0]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar inter^<{arg:3630}>)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^
+                                              $ IVar inter^<{arg:3630}>)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar DerivedGen.X
+                                                            $ IVar {arg:3630}))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ IBindVar n)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ INamedApp (IVar DerivedGen.MkX)
+                                                                     n
+                                                                     (IVar n))) ] ]
          IDef <Prelude.Types.Nat>[]
               [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
                                $ IBindVar ^fuel_arg^)
@@ -103,79 +179,3 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                          $ Implicit True)
                                                                         $ (IApp. IVar Prelude.Types.S
                                                                                $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3630}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:3630}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:3630}))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ INamedApp (IVar DerivedGen.MkX)
-                                                                     n
-                                                                     (IVar n))) ] ]
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <DerivedGen.X>[0]
-                                                                               $ IVar ^outmost-fuel^
-                                                                               $ (IApp. IVar Prelude.Types.mult
-                                                                                      $ IVar n
-                                                                                      $ (IApp. IVar Prelude.Types.S
-                                                                                             $ (IApp. IVar Prelude.Types.S
-                                                                                                    $ IVar Prelude.Types.Z))))
-                                                                        $ (ILam.  (MW ExplicitArg ^bnd^{arg:3646} : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. INamedApp (IVar DerivedGen.MkY)
-                                                                                                          n
-                                                                                                          (IVar n)
-                                                                                              $ IVar ^bnd^{arg:3646}))))))) ] ]

--- a/tests/derivation/least-effort/print/adt/010 right-to-left long-dpair/expected
+++ b/tests/derivation/least-effort/print/adt/010 right-to-left long-dpair/expected
@@ -8,11 +8,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
+                                  $ IVar DerivedGen.Y)))
          IClaim MW
                 Export
                 []
@@ -32,11 +32,103 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <Prelude.Types.Nat>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <DerivedGen.Y>[]
+              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkY>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkY>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar DerivedGen.Y)))
+                            IDef <<DerivedGen.MkY>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkY (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <DerivedGen.X>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                => ICase (IVar {lamc:0})
+                                                                         (Implicit False)
+                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                          $ IBindVar n
+                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                 $ IBindVar m
+                                                                                                 $ IBindVar ^bnd^{arg:3651}))
+                                                                                     (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                      f
+                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                           $ Implicit True)
+                                                                                          $ (IApp. INamedApp (INamedApp (IVar DerivedGen.MkY)
+                                                                                                                        m
+                                                                                                                        (IVar m))
+                                                                                                             n
+                                                                                                             (IVar n)
+                                                                                                 $ IVar ^bnd^{arg:3651})) ]))) ] ]
+         IDef <DerivedGen.X>[]
+              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Prelude.Types.Nat
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                                  => (IApp. IVar DerivedGen.X
+                                                                                          $ IVar {arg:3630}
+                                                                                          $ IVar {arg:3633}))))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. IVar >>=
+                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                               $ IVar ^outmost-fuel^)
+                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                               => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                   f
+                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                        $ Implicit True)
+                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                              $ Implicit True
+                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                     $ Implicit True
+                                                                                                     $ INamedApp (INamedApp (IVar DerivedGen.MkX)
+                                                                                                                            n
+                                                                                                                            (IVar n))
+                                                                                                                 m
+                                                                                                                 (IVar m))))))))) ] ]
          IDef <Prelude.Types.Nat>[]
               [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
                                $ IBindVar ^fuel_arg^)
@@ -109,95 +201,3 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                          $ Implicit True)
                                                                         $ (IApp. IVar Prelude.Types.S
                                                                                $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:3630}
-                                                                                          $ IVar {arg:3633}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ INamedApp (INamedApp (IVar DerivedGen.MkX)
-                                                                                                                            n
-                                                                                                                            (IVar n))
-                                                                                                                 m
-                                                                                                                 (IVar m))))))))) ] ]
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar m
-                                                                                                 $ IBindVar ^bnd^{arg:3651}))
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                        m
-                                                                                                                        (IVar m))
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:3651})) ]))) ] ]

--- a/tests/derivation/least-effort/print/adt/011 right-to-left long-dpair/expected
+++ b/tests/derivation/least-effort/print/adt/011 right-to-left long-dpair/expected
@@ -8,19 +8,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IClaim MW
-                Export
-                []
-                (MkTy <Builtin.Unit>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Builtin.Unit)))
+                                  $ IVar DerivedGen.Y)))
          IClaim MW
                 Export
                 []
@@ -40,11 +32,137 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <Builtin.Unit>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
+                                  $ IVar Builtin.Unit)))
+         IClaim MW
+                Export
+                []
+                (MkTy <Prelude.Types.Nat>[]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <DerivedGen.Y>[]
+              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkY>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkY>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar DerivedGen.Y)))
+                            IDef <<DerivedGen.MkY>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkY (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <DerivedGen.X>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                => ICase (IVar {lamc:0})
+                                                                         (Implicit False)
+                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                          $ IBindVar n
+                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                 $ IBindVar m
+                                                                                                 $ IBindVar ^bnd^{arg:3651}))
+                                                                                     (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                      f
+                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                           $ Implicit True)
+                                                                                          $ (IApp. INamedApp (INamedApp (IVar DerivedGen.MkY)
+                                                                                                                        m
+                                                                                                                        (IVar m))
+                                                                                                             n
+                                                                                                             (IVar n)
+                                                                                                 $ IVar ^bnd^{arg:3651})) ]))) ] ]
+         IDef <DerivedGen.X>[]
+              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Builtin.Unit
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Builtin.Unit)
+                                                                                  => (IApp. IVar DerivedGen.X
+                                                                                          $ IVar {arg:3630}
+                                                                                          $ IVar {arg:3633}))))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. IVar >>=
+                                                                        $ (IApp. IVar <Builtin.Unit>[]
+                                                                               $ IVar ^outmost-fuel^)
+                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                               => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                   f
+                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                        $ Implicit True)
+                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                              $ Implicit True
+                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                     $ Implicit True
+                                                                                                     $ INamedApp (INamedApp (IVar DerivedGen.MkX)
+                                                                                                                            n
+                                                                                                                            (IVar n))
+                                                                                                                 m
+                                                                                                                 (IVar m))))))))) ] ]
+         IDef <Builtin.Unit>[]
+              [ PatClause (IApp. IVar <Builtin.Unit>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal Builtin.Unit[] (non-recursive))
+                                       $ (IApp. IVar <<Builtin.MkUnit>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Builtin.MkUnit>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Builtin.Unit)))
+                            IDef <<Builtin.MkUnit>>
+                                 [ PatClause (IApp. IVar <<Builtin.MkUnit>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Builtin.MkUnit (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ IVar Builtin.MkUnit)) ] ]
          IDef <Prelude.Types.Nat>[]
               [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
                                $ IBindVar ^fuel_arg^)
@@ -117,121 +235,3 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                          $ Implicit True)
                                                                         $ (IApp. IVar Prelude.Types.S
                                                                                $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <Builtin.Unit>[]
-              [ PatClause (IApp. IVar <Builtin.Unit>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Builtin.Unit[] (non-recursive))
-                                       $ (IApp. IVar <<Builtin.MkUnit>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Builtin.MkUnit>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Builtin.Unit)))
-                            IDef <<Builtin.MkUnit>>
-                                 [ PatClause (IApp. IVar <<Builtin.MkUnit>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Builtin.MkUnit (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Builtin.MkUnit)) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Builtin.Unit
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Builtin.Unit)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:3630}
-                                                                                          $ IVar {arg:3633}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Builtin.Unit>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ INamedApp (INamedApp (IVar DerivedGen.MkX)
-                                                                                                                            n
-                                                                                                                            (IVar n))
-                                                                                                                 m
-                                                                                                                 (IVar m))))))))) ] ]
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar m
-                                                                                                 $ IBindVar ^bnd^{arg:3651}))
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                        m
-                                                                                                                        (IVar m))
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:3651})) ]))) ] ]

--- a/tests/derivation/least-effort/print/adt/012 right-to-left chained/expected
+++ b/tests/derivation/least-effort/print/adt/012 right-to-left chained/expected
@@ -8,23 +8,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X1>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X1
-                                                        $ IVar {arg:3630}))))))
+                                  $ IVar DerivedGen.Y)))
          IClaim MW
                 Export
                 []
@@ -40,11 +28,141 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <DerivedGen.X1>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
+                                  $ (IApp. IVar Builtin.DPair.DPair
+                                         $ IVar Prelude.Types.Nat
+                                         $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                => (IApp. IVar DerivedGen.X1
+                                                        $ IVar {arg:3630}))))))
+         IClaim MW
+                Export
+                []
+                (MkTy <Prelude.Types.Nat>[]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <DerivedGen.Y>[]
+              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkY>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkY>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar DerivedGen.Y)))
+                            IDef <<DerivedGen.MkY>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkY (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <DerivedGen.X2>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                => ICase (IVar {lamc:0})
+                                                                         (Implicit False)
+                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                          $ IBindVar n
+                                                                                          $ IBindVar ^bnd^{arg:3658})
+                                                                                     (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                      f
+                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                           $ Implicit True)
+                                                                                          $ (IApp. INamedApp (IVar DerivedGen.MkY)
+                                                                                                             n
+                                                                                                             (IVar n)
+                                                                                                 $ IVar ^bnd^{arg:3658})) ]))) ] ]
+         IDef <DerivedGen.X2>[]
+              [ PatClause (IApp. IVar <DerivedGen.X2>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X2[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX2>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX2>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3641} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X2
+                                                                           $ IVar {arg:3641}))))))
+                            IDef <<DerivedGen.MkX2>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX2>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX2 (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <DerivedGen.X1>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                => ICase (IVar {lamc:0})
+                                                                         (Implicit False)
+                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                          $ IBindVar n
+                                                                                          $ IBindVar ^bnd^{arg:3650})
+                                                                                     (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                      f
+                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                           $ Implicit True)
+                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                 $ Implicit True
+                                                                                                 $ (IApp. IVar DerivedGen.MkX2
+                                                                                                        $ IVar n
+                                                                                                        $ IVar ^bnd^{arg:3650}))) ]))) ] ]
+         IDef <DerivedGen.X1>[]
+              [ PatClause (IApp. IVar <DerivedGen.X1>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X1[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX1>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX1>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X1
+                                                                           $ IVar {arg:3630}))))))
+                            IDef <<DerivedGen.MkX1>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX1>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX1 (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ (IApp. IVar DerivedGen.MkX1
+                                                                                      $ IVar n)))))) ] ]
          IDef <Prelude.Types.Nat>[]
               [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
                                $ IBindVar ^fuel_arg^)
@@ -117,121 +235,3 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                          $ Implicit True)
                                                                         $ (IApp. IVar Prelude.Types.S
                                                                                $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.X1>[]
-              [ PatClause (IApp. IVar <DerivedGen.X1>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X1[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX1>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX1>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X1
-                                                                           $ IVar {arg:3630}))))))
-                            IDef <<DerivedGen.MkX1>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX1>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX1 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar DerivedGen.MkX1
-                                                                                      $ IVar n)))))) ] ]
-         IDef <DerivedGen.X2>[]
-              [ PatClause (IApp. IVar <DerivedGen.X2>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X2[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX2>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX2>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3641} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X2
-                                                                           $ IVar {arg:3641}))))))
-                            IDef <<DerivedGen.MkX2>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX2>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX2 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X1>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ IBindVar ^bnd^{arg:3650})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ Implicit True
-                                                                                                 $ (IApp. IVar DerivedGen.MkX2
-                                                                                                        $ IVar n
-                                                                                                        $ IVar ^bnd^{arg:3650}))) ]))) ] ]
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X2>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ IBindVar ^bnd^{arg:3658})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (IVar DerivedGen.MkY)
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:3658})) ]))) ] ]

--- a/tests/derivation/least-effort/print/adt/013 right-to-left nondet/expected
+++ b/tests/derivation/least-effort/print/adt/013 right-to-left nondet/expected
@@ -8,11 +8,25 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
+                                  $ IVar DerivedGen.Y)))
+         IClaim MW
+                Export
+                []
+                (MkTy <DerivedGen.X>[0]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ (IApp. IVar Builtin.DPair.DPair
+                                         $ IVar Prelude.Types.Nat
+                                         $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                => (IApp. IVar DerivedGen.X
+                                                        $ IVar {arg:3630}
+                                                        $ IVar {arg:3633}))))))
          IClaim MW
                 Export
                 []
@@ -32,25 +46,162 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.X>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:3630}
-                                                        $ IVar {arg:3633}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <Prelude.Types.Nat>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <DerivedGen.Y>[]
+              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkY>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkY>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar DerivedGen.Y)))
+                            IDef <<DerivedGen.MkY>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkY (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <DerivedGen.X>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                => ICase (IVar {lamc:0})
+                                                                         (Implicit False)
+                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                          $ IBindVar n
+                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                 $ IBindVar k
+                                                                                                 $ IBindVar ^bnd^{arg:3654}))
+                                                                                     (IApp. IVar >>=
+                                                                                          $ (IApp. IVar <DerivedGen.X>[0]
+                                                                                                 $ IVar ^outmost-fuel^
+                                                                                                 $ IVar n)
+                                                                                          $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                                                 => ICase (IVar {lamc:0})
+                                                                                                          (Implicit False)
+                                                                                                          [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                                           $ IBindVar m
+                                                                                                                           $ IBindVar ^bnd^{arg:3651})
+                                                                                                                      (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                                                       f
+                                                                                                                                       (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                                                            $ Implicit True)
+                                                                                                                           $ (IApp. INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
+                                                                                                                                                                    k
+                                                                                                                                                                    (IVar k))
+                                                                                                                                                         m
+                                                                                                                                                         (IVar m))
+                                                                                                                                              n
+                                                                                                                                              (IVar n)
+                                                                                                                                  $ IVar ^bnd^{arg:3651}
+                                                                                                                                  $ IVar ^bnd^{arg:3654})) ])) ]))) ] ]
+         IDef <DerivedGen.X>[0]
+              [ PatClause (IApp. IVar <DerivedGen.X>[0]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar inter^<{arg:3630}>)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^
+                                              $ IVar inter^<{arg:3630}>)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X
+                                                                           $ IVar {arg:3630}
+                                                                           $ IVar {arg:3633}))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ IBindVar n)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ INamedApp (INamedApp (IVar DerivedGen.MkX)
+                                                                                                      n
+                                                                                                      (IVar n))
+                                                                                           m
+                                                                                           (IVar m)))))) ] ]
+         IDef <DerivedGen.X>[]
+              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Prelude.Types.Nat
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                                  => (IApp. IVar DerivedGen.X
+                                                                                          $ IVar {arg:3630}
+                                                                                          $ IVar {arg:3633}))))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. IVar >>=
+                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                               $ IVar ^outmost-fuel^)
+                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                               => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                   f
+                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                        $ Implicit True)
+                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                              $ Implicit True
+                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                     $ Implicit True
+                                                                                                     $ INamedApp (INamedApp (IVar DerivedGen.MkX)
+                                                                                                                            n
+                                                                                                                            (IVar n))
+                                                                                                                 m
+                                                                                                                 (IVar m))))))))) ] ]
          IDef <Prelude.Types.Nat>[]
               [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
                                $ IBindVar ^fuel_arg^)
@@ -123,154 +274,3 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                          $ Implicit True)
                                                                         $ (IApp. IVar Prelude.Types.S
                                                                                $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:3630}
-                                                                                          $ IVar {arg:3633}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ INamedApp (INamedApp (IVar DerivedGen.MkX)
-                                                                                                                            n
-                                                                                                                            (IVar n))
-                                                                                                                 m
-                                                                                                                 (IVar m))))))))) ] ]
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3630}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:3630}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:3630}
-                                                                           $ IVar {arg:3633}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (INamedApp (IVar DerivedGen.MkX)
-                                                                                                      n
-                                                                                                      (IVar n))
-                                                                                           m
-                                                                                           (IVar m)))))) ] ]
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar k
-                                                                                                 $ IBindVar ^bnd^{arg:3654}))
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar <DerivedGen.X>[0]
-                                                                                                 $ IVar ^outmost-fuel^
-                                                                                                 $ IVar n)
-                                                                                          $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                                                 => ICase (IVar {lamc:0})
-                                                                                                          (Implicit False)
-                                                                                                          [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                           $ IBindVar m
-                                                                                                                           $ IBindVar ^bnd^{arg:3651})
-                                                                                                                      (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                                       f
-                                                                                                                                       (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                                            $ Implicit True)
-                                                                                                                           $ (IApp. INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                                                                    k
-                                                                                                                                                                    (IVar k))
-                                                                                                                                                         m
-                                                                                                                                                         (IVar m))
-                                                                                                                                              n
-                                                                                                                                              (IVar n)
-                                                                                                                                  $ IVar ^bnd^{arg:3651}
-                                                                                                                                  $ IVar ^bnd^{arg:3654})) ])) ]))) ] ]

--- a/tests/derivation/least-effort/print/adt/014 right-to-left nondet ext/expected
+++ b/tests/derivation/least-effort/print/adt/014 right-to-left nondet ext/expected
@@ -16,19 +16,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.X>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IPrimVal String
-                                         $ (ILam.  (MW ExplicitArg {arg:3630} : IPrimVal String)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.X
-                                                                       $ IVar {arg:3630}
-                                                                       $ IVar {arg:3633}))))))))
+                                  $ IVar DerivedGen.Y)))
          IClaim MW
                 Export
                 []
@@ -46,103 +38,19 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <DerivedGen.X>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IPrimVal String
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IPrimVal String)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:3630}
-                                                                                          $ IVar {arg:3633}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<^prim^.String>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ (IApp. IVar DerivedGen.MkX
-                                                                                                            $ IVar n
-                                                                                                            $ IVar m))))))))) ] ]
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3630}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:3630}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3630} : IPrimVal String)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:3630}
-                                                                           $ IVar {arg:3633}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar DerivedGen.MkX
-                                                                                      $ IVar n
-                                                                                      $ IVar m)))))) ] ]
+                                  $ (IApp. IVar Builtin.DPair.DPair
+                                         $ IPrimVal String
+                                         $ (ILam.  (MW ExplicitArg {arg:3630} : IPrimVal String)
+                                                => (IApp. IVar Builtin.DPair.DPair
+                                                        $ IVar Prelude.Types.Nat
+                                                        $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                               => (IApp. IVar DerivedGen.X
+                                                                       $ IVar {arg:3630}
+                                                                       $ IVar {arg:3633}))))))))
          IDef <DerivedGen.Y>[]
               [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
                           (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
@@ -198,3 +106,95 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                                                                               (IVar n)
                                                                                                                                   $ IVar ^bnd^{arg:3651}
                                                                                                                                   $ IVar ^bnd^{arg:3654})) ])) ]))) ] ]
+         IDef <DerivedGen.X>[0]
+              [ PatClause (IApp. IVar <DerivedGen.X>[0]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar inter^<{arg:3630}>)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^
+                                              $ IVar inter^<{arg:3630}>)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3630} : IPrimVal String)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X
+                                                                           $ IVar {arg:3630}
+                                                                           $ IVar {arg:3633}))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ IBindVar n)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar external^<Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ (IApp. IVar DerivedGen.MkX
+                                                                                      $ IVar n
+                                                                                      $ IVar m)))))) ] ]
+         IDef <DerivedGen.X>[]
+              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IPrimVal String
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IPrimVal String)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Prelude.Types.Nat
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                                  => (IApp. IVar DerivedGen.X
+                                                                                          $ IVar {arg:3630}
+                                                                                          $ IVar {arg:3633}))))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar external^<^prim^.String>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. IVar >>=
+                                                                        $ (IApp. IVar external^<Prelude.Types.Nat>[]
+                                                                               $ IVar ^outmost-fuel^)
+                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                               => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                   f
+                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                        $ Implicit True)
+                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                              $ Implicit True
+                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                     $ Implicit True
+                                                                                                     $ (IApp. IVar DerivedGen.MkX
+                                                                                                            $ IVar n
+                                                                                                            $ IVar m))))))))) ] ]

--- a/tests/derivation/least-effort/print/gadt/002 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/002 gadt/expected
@@ -8,14 +8,6 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IClaim MW
-                Export
-                []
                 (MkTy <Data.Fin.Fin>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
@@ -25,78 +17,14 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                          $ (ILam.  (MW ExplicitArg n : IVar Prelude.Types.Nat)
                                                 => (IApp. IVar Data.Fin.Fin
                                                         $ IVar n))))))
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:789} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:789}))))) ] ]
+         IClaim MW
+                Export
+                []
+                (MkTy <Prelude.Types.Nat>[]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ IVar Prelude.Types.Nat)))
          IDef <Data.Fin.Fin>[]
               [ PatClause (IApp. IVar <Data.Fin.Fin>[] $ IBindVar ^fuel_arg^)
                           (ILocal (ICase (IVar ^fuel_arg^)
@@ -193,3 +121,75 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                                                     k
                                                                                                                     (IVar k)
                                                                                                         $ IVar ^bnd^{arg:3095}))) ]))) ] ]
+         IDef <Prelude.Types.Nat>[]
+              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (ICase (IVar ^fuel_arg^)
+                                         (IVar Data.Fuel.Fuel)
+                                         [ PatClause (IVar Data.Fuel.Dry)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
+                                                          $ (IApp. IVar <<Prelude.Types.Z>>
+                                                                 $ IVar Data.Fuel.Dry))
+                                         , PatClause (IApp. IVar Data.Fuel.More
+                                                          $ IBindVar ^sub^fuel_arg^)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
+                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
+                                                                 $ (IApp. IVar ::
+                                                                        $ (IApp. IVar Builtin.MkPair
+                                                                               $ IVar Data.Nat.Pos.one
+                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
+                                                                                      $ IVar ^fuel_arg^))
+                                                                        $ (IApp. IVar ::
+                                                                               $ (IApp. IVar Builtin.MkPair
+                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
+                                                                                             $ IVar ^sub^fuel_arg^)
+                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
+                                                                                             $ IVar ^sub^fuel_arg^))
+                                                                               $ IVar Nil)))) ]))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Types.Z>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Types.Nat)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Types.S>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Types.Nat)))
+                            IDef <<Prelude.Types.Z>>
+                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Types.Z (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ IVar Prelude.Types.Z)) ]
+                            IDef <<Prelude.Types.S>>
+                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Types.S (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^cons_fuel^)
+                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:789} : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Prelude.Types.S
+                                                                               $ IVar ^bnd^{arg:789}))))) ] ]

--- a/tests/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
+++ b/tests/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
@@ -8,11 +8,39 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
+                                  $ IVar DerivedGen.Y)))
+         IClaim MW
+                Export
+                []
+                (MkTy <DerivedGen.X_GADT>[1]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ (IApp. IVar Builtin.DPair.DPair
+                                         $ IVar Prelude.Types.Nat
+                                         $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                => (IApp. IVar DerivedGen.X_GADT
+                                                        $ IVar {arg:3630}
+                                                        $ IVar {arg:3633}))))))
+         IClaim MW
+                Export
+                []
+                (MkTy <DerivedGen.X_GADT>[0]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ (IApp. IVar Builtin.DPair.DPair
+                                         $ IVar Prelude.Types.Nat
+                                         $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                => (IApp. IVar DerivedGen.X_GADT
+                                                        $ IVar {arg:3630}
+                                                        $ IVar {arg:3633}))))))
          IClaim MW
                 Export
                 []
@@ -32,379 +60,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.X_GADT>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X_GADT
-                                                        $ IVar {arg:3630}
-                                                        $ IVar {arg:3633}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X_GADT>[1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X_GADT
-                                                        $ IVar {arg:3630}
-                                                        $ IVar {arg:3633}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <Prelude.Types.Nat>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:789} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.X_GADT>[]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_GADT
-                                                                                          $ IVar {arg:3630}
-                                                                                          $ IVar {arg:3633}))))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_GADT
-                                                                                          $ IVar {arg:3630}
-                                                                                          $ IVar {arg:3633}))))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                       $ Implicit True
-                                                                       $ IVar DerivedGen.MkXG_4)))) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                      $ Implicit True
-                                                                                      $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                                                  m
-                                                                                                  (IVar m))))))) ] ]
-         IDef <DerivedGen.X_GADT>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3630}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[0] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^
-                                                            $ IVar inter^<{arg:3630}>)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^
-                                                                   $ IVar inter^<{arg:3630}>)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:3630}
-                                                                           $ IVar {arg:3633}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:3630}
-                                                                           $ IVar {arg:3633}))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ IVar Prelude.Types.Z)))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ IVar DerivedGen.MkXG_4)))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ (IApp. IVar Prelude.Types.S
-                                                                                     $ IVar Prelude.Types.Z))))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                                           m
-                                                                                           (IVar m))))))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
-         IDef <DerivedGen.X_GADT>[1]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3633}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[1] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^
-                                                            $ IVar inter^<{arg:3633}>)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^
-                                                                   $ IVar inter^<{arg:3633}>)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:3630}
-                                                                           $ IVar {arg:3633}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:3630}
-                                                                           $ IVar {arg:3633}))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ (IApp. IVar Prelude.Types.S
-                                                                                     $ IVar Prelude.Types.Z))))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ IVar DerivedGen.MkXG_4)))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar m)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                            m
-                                                                            (IVar m)))) ] ]
+                                  $ IVar Prelude.Types.Nat)))
          IDef <DerivedGen.Y>[]
               [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
                           (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
@@ -516,3 +176,343 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                                                                               (IVar n)
                                                                                                                                   $ IVar ^bnd^{arg:3666}
                                                                                                                                   $ IVar ^bnd^{arg:3669})) ])) ]))) ] ]
+         IDef <DerivedGen.X_GADT>[1]
+              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[1]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar inter^<{arg:3633}>)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X_GADT[1] (non-recursive))
+                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
+                                                          em
+                                                          (IVar MaybeEmpty)
+                                              $ (IApp. IVar ::
+                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                            $ IVar ^fuel_arg^
+                                                            $ IVar inter^<{arg:3633}>)
+                                                     $ (IApp. IVar ::
+                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                                   $ IVar ^fuel_arg^
+                                                                   $ IVar inter^<{arg:3633}>)
+                                                            $ IVar Nil)))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_4>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X_GADT
+                                                                           $ IVar {arg:3630}
+                                                                           $ IVar {arg:3633}))))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_5>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X_GADT
+                                                                           $ IVar {arg:3630}
+                                                                           $ IVar {arg:3633}))))))
+                            IDef <<DerivedGen.MkXG_4>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ (IApp. IVar Prelude.Types.S
+                                                         $ (IApp. IVar Prelude.Types.S
+                                                                $ (IApp. IVar Prelude.Types.S
+                                                                       $ (IApp. IVar Prelude.Types.S
+                                                                              $ (IApp. IVar Prelude.Types.S
+                                                                                     $ IVar Prelude.Types.Z))))))
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                $ Implicit True
+                                                                $ IVar DerivedGen.MkXG_4)))
+                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                  $ Implicit True
+                                                  $ Implicit True)
+                                             (IVar empty) ]
+                            IDef <<DerivedGen.MkXG_5>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ IBindVar m)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                $ Implicit True
+                                                                $ INamedApp (IVar DerivedGen.MkXG_5)
+                                                                            m
+                                                                            (IVar m)))) ] ]
+         IDef <DerivedGen.X_GADT>[0]
+              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[0]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar inter^<{arg:3630}>)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X_GADT[0] (non-recursive))
+                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
+                                                          em
+                                                          (IVar MaybeEmpty)
+                                              $ (IApp. IVar ::
+                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                            $ IVar ^fuel_arg^
+                                                            $ IVar inter^<{arg:3630}>)
+                                                     $ (IApp. IVar ::
+                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                                   $ IVar ^fuel_arg^
+                                                                   $ IVar inter^<{arg:3630}>)
+                                                            $ IVar Nil)))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_4>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X_GADT
+                                                                           $ IVar {arg:3630}
+                                                                           $ IVar {arg:3633}))))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_5>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X_GADT
+                                                                           $ IVar {arg:3630}
+                                                                           $ IVar {arg:3633}))))))
+                            IDef <<DerivedGen.MkXG_4>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ (IApp. IVar Prelude.Types.S
+                                                         $ (IApp. IVar Prelude.Types.S
+                                                                $ (IApp. IVar Prelude.Types.S
+                                                                       $ (IApp. IVar Prelude.Types.S
+                                                                              $ IVar Prelude.Types.Z)))))
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                $ Implicit True
+                                                                $ IVar DerivedGen.MkXG_4)))
+                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                  $ Implicit True
+                                                  $ Implicit True)
+                                             (IVar empty) ]
+                            IDef <<DerivedGen.MkXG_5>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ (IApp. IVar Prelude.Types.S
+                                                         $ (IApp. IVar Prelude.Types.S
+                                                                $ (IApp. IVar Prelude.Types.S
+                                                                       $ (IApp. IVar Prelude.Types.S
+                                                                              $ (IApp. IVar Prelude.Types.S
+                                                                                     $ IVar Prelude.Types.Z))))))
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ INamedApp (IVar DerivedGen.MkXG_5)
+                                                                                           m
+                                                                                           (IVar m))))))
+                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                  $ Implicit True
+                                                  $ Implicit True)
+                                             (IVar empty) ] ]
+         IDef <DerivedGen.X_GADT>[]
+              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X_GADT[] (non-recursive))
+                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
+                                                          em
+                                                          (IVar MaybeEmpty)
+                                              $ (IApp. IVar ::
+                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                            $ IVar ^fuel_arg^)
+                                                     $ (IApp. IVar ::
+                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                                   $ IVar ^fuel_arg^)
+                                                            $ IVar Nil)))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_4>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Prelude.Types.Nat
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                                  => (IApp. IVar DerivedGen.X_GADT
+                                                                                          $ IVar {arg:3630}
+                                                                                          $ IVar {arg:3633}))))))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_5>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Prelude.Types.Nat
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                                  => (IApp. IVar DerivedGen.X_GADT
+                                                                                          $ IVar {arg:3630}
+                                                                                          $ IVar {arg:3633}))))))))
+                            IDef <<DerivedGen.MkXG_4>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                $ Implicit True
+                                                                $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                       $ Implicit True
+                                                                       $ IVar DerivedGen.MkXG_4)))) ]
+                            IDef <<DerivedGen.MkXG_5>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                      $ Implicit True
+                                                                                      $ INamedApp (IVar DerivedGen.MkXG_5)
+                                                                                                  m
+                                                                                                  (IVar m))))))) ] ]
+         IDef <Prelude.Types.Nat>[]
+              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (ICase (IVar ^fuel_arg^)
+                                         (IVar Data.Fuel.Fuel)
+                                         [ PatClause (IVar Data.Fuel.Dry)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
+                                                          $ (IApp. IVar <<Prelude.Types.Z>>
+                                                                 $ IVar Data.Fuel.Dry))
+                                         , PatClause (IApp. IVar Data.Fuel.More
+                                                          $ IBindVar ^sub^fuel_arg^)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
+                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
+                                                                 $ (IApp. IVar ::
+                                                                        $ (IApp. IVar Builtin.MkPair
+                                                                               $ IVar Data.Nat.Pos.one
+                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
+                                                                                      $ IVar ^fuel_arg^))
+                                                                        $ (IApp. IVar ::
+                                                                               $ (IApp. IVar Builtin.MkPair
+                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
+                                                                                             $ IVar ^sub^fuel_arg^)
+                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
+                                                                                             $ IVar ^sub^fuel_arg^))
+                                                                               $ IVar Nil)))) ]))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Types.Z>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Types.Nat)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Types.S>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Types.Nat)))
+                            IDef <<Prelude.Types.Z>>
+                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Types.Z (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ IVar Prelude.Types.Z)) ]
+                            IDef <<Prelude.Types.S>>
+                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Types.S (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^cons_fuel^)
+                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:789} : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Prelude.Types.S
+                                                                               $ IVar ^bnd^{arg:789}))))) ] ]

--- a/tests/derivation/least-effort/print/gadt/004 right-to-left det/expected
+++ b/tests/derivation/least-effort/print/gadt/004 right-to-left det/expected
@@ -8,41 +8,25 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
+                (MkTy <DerivedGen.Y>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
+                                  $ IVar DerivedGen.Y)))
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.X_ADT>[]
+                (MkTy <DerivedGen.X_ADT>[0]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (MW ExplicitArg {arg:3651} : IVar Prelude.Types.Nat)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
                                   $ (IApp. IVar Builtin.DPair.DPair
                                          $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:3651} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:3654} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.X_ADT
-                                                                       $ IVar {arg:3651}
-                                                                       $ IVar {arg:3654}))))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X_GADT>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X_GADT
-                                                        $ IVar {arg:3630}
-                                                        $ IVar {arg:3633}))))))
+                                         $ (ILam.  (MW ExplicitArg {arg:3654} : IVar Prelude.Types.Nat)
+                                                => (IApp. IVar DerivedGen.X_ADT
+                                                        $ IVar {arg:3651}
+                                                        $ IVar {arg:3654}))))))
          IClaim MW
                 Export
                 []
@@ -62,372 +46,41 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.X_ADT>[0]
+                (MkTy <DerivedGen.X_GADT>[0]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:3651} : IVar Prelude.Types.Nat)
+                          -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
                                   $ (IApp. IVar Builtin.DPair.DPair
                                          $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:3654} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X_ADT
-                                                        $ IVar {arg:3651}
-                                                        $ IVar {arg:3654}))))))
+                                         $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                => (IApp. IVar DerivedGen.X_GADT
+                                                        $ IVar {arg:3630}
+                                                        $ IVar {arg:3633}))))))
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.Y>[]
+                (MkTy <DerivedGen.X_ADT>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:789} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.X_ADT>[]
-              [ PatClause (IApp. IVar <DerivedGen.X_ADT>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_ADT[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3651} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3654} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_ADT
-                                                                                          $ IVar {arg:3651}
-                                                                                          $ IVar {arg:3654}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ (IApp. IVar DerivedGen.MkX
-                                                                                                            $ IVar n
-                                                                                                            $ IVar m))))))))) ] ]
-         IDef <DerivedGen.X_GADT>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3630}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[0] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^
-                                                            $ IVar inter^<{arg:3630}>)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^
-                                                                   $ IVar inter^<{arg:3630}>)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:3630}
-                                                                           $ IVar {arg:3633}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:3630}
-                                                                           $ IVar {arg:3633}))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ IVar Prelude.Types.Z)))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ IVar DerivedGen.MkXG_4)))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ (IApp. IVar Prelude.Types.S
-                                                                                     $ IVar Prelude.Types.Z))))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                                           m
-                                                                                           (IVar m))))))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
-         IDef <DerivedGen.X_GADT>[]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_GADT
-                                                                                          $ IVar {arg:3630}
-                                                                                          $ IVar {arg:3633}))))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_GADT
-                                                                                          $ IVar {arg:3630}
-                                                                                          $ IVar {arg:3633}))))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                       $ Implicit True
-                                                                       $ IVar DerivedGen.MkXG_4)))) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                      $ Implicit True
-                                                                                      $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                                                  m
-                                                                                                  (IVar m))))))) ] ]
-         IDef <DerivedGen.X_ADT>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X_ADT>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3651}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_ADT[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:3651}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3651} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3654} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_ADT
-                                                                           $ IVar {arg:3651}
-                                                                           $ IVar {arg:3654}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar DerivedGen.MkX
-                                                                                      $ IVar n
-                                                                                      $ IVar m)))))) ] ]
+                                  $ (IApp. IVar Builtin.DPair.DPair
+                                         $ IVar Prelude.Types.Nat
+                                         $ (ILam.  (MW ExplicitArg {arg:3651} : IVar Prelude.Types.Nat)
+                                                => (IApp. IVar Builtin.DPair.DPair
+                                                        $ IVar Prelude.Types.Nat
+                                                        $ (ILam.  (MW ExplicitArg {arg:3654} : IVar Prelude.Types.Nat)
+                                                               => (IApp. IVar DerivedGen.X_ADT
+                                                                       $ IVar {arg:3651}
+                                                                       $ IVar {arg:3654}))))))))
+         IClaim MW
+                Export
+                []
+                (MkTy <Prelude.Types.Nat>[]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ IVar Prelude.Types.Nat)))
          IDef <DerivedGen.Y>[]
               [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
                           (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
@@ -539,3 +192,350 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                                                                               (IVar n)
                                                                                                                                   $ IVar ^bnd^{arg:3681}
                                                                                                                                   $ IVar ^bnd^{arg:3684})) ])) ]))) ] ]
+         IDef <DerivedGen.X_ADT>[0]
+              [ PatClause (IApp. IVar <DerivedGen.X_ADT>[0]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar inter^<{arg:3651}>)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X_ADT[0] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^
+                                              $ IVar inter^<{arg:3651}>)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3651} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3654} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X_ADT
+                                                                           $ IVar {arg:3651}
+                                                                           $ IVar {arg:3654}))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ IBindVar n)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ (IApp. IVar DerivedGen.MkX
+                                                                                      $ IVar n
+                                                                                      $ IVar m)))))) ] ]
+         IDef <DerivedGen.X_GADT>[]
+              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X_GADT[] (non-recursive))
+                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
+                                                          em
+                                                          (IVar MaybeEmpty)
+                                              $ (IApp. IVar ::
+                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                            $ IVar ^fuel_arg^)
+                                                     $ (IApp. IVar ::
+                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                                   $ IVar ^fuel_arg^)
+                                                            $ IVar Nil)))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_4>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Prelude.Types.Nat
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                                  => (IApp. IVar DerivedGen.X_GADT
+                                                                                          $ IVar {arg:3630}
+                                                                                          $ IVar {arg:3633}))))))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_5>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Prelude.Types.Nat
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                                  => (IApp. IVar DerivedGen.X_GADT
+                                                                                          $ IVar {arg:3630}
+                                                                                          $ IVar {arg:3633}))))))))
+                            IDef <<DerivedGen.MkXG_4>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                $ Implicit True
+                                                                $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                       $ Implicit True
+                                                                       $ IVar DerivedGen.MkXG_4)))) ]
+                            IDef <<DerivedGen.MkXG_5>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                      $ Implicit True
+                                                                                      $ INamedApp (IVar DerivedGen.MkXG_5)
+                                                                                                  m
+                                                                                                  (IVar m))))))) ] ]
+         IDef <DerivedGen.X_GADT>[0]
+              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[0]
+                               $ IBindVar ^fuel_arg^
+                               $ IBindVar inter^<{arg:3630}>)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X_GADT[0] (non-recursive))
+                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
+                                                          em
+                                                          (IVar MaybeEmpty)
+                                              $ (IApp. IVar ::
+                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                            $ IVar ^fuel_arg^
+                                                            $ IVar inter^<{arg:3630}>)
+                                                     $ (IApp. IVar ::
+                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                                   $ IVar ^fuel_arg^
+                                                                   $ IVar inter^<{arg:3630}>)
+                                                            $ IVar Nil)))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_4>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X_GADT
+                                                                           $ IVar {arg:3630}
+                                                                           $ IVar {arg:3633}))))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkXG_5>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar DerivedGen.X_GADT
+                                                                           $ IVar {arg:3630}
+                                                                           $ IVar {arg:3633}))))))
+                            IDef <<DerivedGen.MkXG_4>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ (IApp. IVar Prelude.Types.S
+                                                         $ (IApp. IVar Prelude.Types.S
+                                                                $ (IApp. IVar Prelude.Types.S
+                                                                       $ (IApp. IVar Prelude.Types.S
+                                                                              $ IVar Prelude.Types.Z)))))
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                $ Implicit True
+                                                                $ IVar DerivedGen.MkXG_4)))
+                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
+                                                  $ Implicit True
+                                                  $ Implicit True)
+                                             (IVar empty) ]
+                            IDef <<DerivedGen.MkXG_5>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                  $ IBindVar ^cons_fuel^
+                                                  $ (IApp. IVar Prelude.Types.S
+                                                         $ (IApp. IVar Prelude.Types.S
+                                                                $ (IApp. IVar Prelude.Types.S
+                                                                       $ (IApp. IVar Prelude.Types.S
+                                                                              $ (IApp. IVar Prelude.Types.S
+                                                                                     $ IVar Prelude.Types.Z))))))
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ INamedApp (IVar DerivedGen.MkXG_5)
+                                                                                           m
+                                                                                           (IVar m))))))
+                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
+                                                  $ Implicit True
+                                                  $ Implicit True)
+                                             (IVar empty) ] ]
+         IDef <DerivedGen.X_ADT>[]
+              [ PatClause (IApp. IVar <DerivedGen.X_ADT>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.X_ADT[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.MkX>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.MkX>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3651} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Prelude.Types.Nat
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3654} : IVar Prelude.Types.Nat)
+                                                                                  => (IApp. IVar DerivedGen.X_ADT
+                                                                                          $ IVar {arg:3651}
+                                                                                          $ IVar {arg:3654}))))))))
+                            IDef <<DerivedGen.MkX>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.MkX (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
+                                                                => (IApp. IVar >>=
+                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                               $ IVar ^outmost-fuel^)
+                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
+                                                                               => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                   f
+                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                        $ Implicit True)
+                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                              $ Implicit True
+                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                     $ Implicit True
+                                                                                                     $ (IApp. IVar DerivedGen.MkX
+                                                                                                            $ IVar n
+                                                                                                            $ IVar m))))))))) ] ]
+         IDef <Prelude.Types.Nat>[]
+              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (ICase (IVar ^fuel_arg^)
+                                         (IVar Data.Fuel.Fuel)
+                                         [ PatClause (IVar Data.Fuel.Dry)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
+                                                          $ (IApp. IVar <<Prelude.Types.Z>>
+                                                                 $ IVar Data.Fuel.Dry))
+                                         , PatClause (IApp. IVar Data.Fuel.More
+                                                          $ IBindVar ^sub^fuel_arg^)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
+                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
+                                                                 $ (IApp. IVar ::
+                                                                        $ (IApp. IVar Builtin.MkPair
+                                                                               $ IVar Data.Nat.Pos.one
+                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
+                                                                                      $ IVar ^fuel_arg^))
+                                                                        $ (IApp. IVar ::
+                                                                               $ (IApp. IVar Builtin.MkPair
+                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
+                                                                                             $ IVar ^sub^fuel_arg^)
+                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
+                                                                                             $ IVar ^sub^fuel_arg^))
+                                                                               $ IVar Nil)))) ]))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Types.Z>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Types.Nat)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Types.S>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Types.Nat)))
+                            IDef <<Prelude.Types.Z>>
+                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Types.Z (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ IVar Prelude.Types.Z)) ]
+                            IDef <<Prelude.Types.S>>
+                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Types.S (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^cons_fuel^)
+                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:789} : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Prelude.Types.S
+                                                                               $ IVar ^bnd^{arg:789}))))) ] ]

--- a/tests/derivation/least-effort/print/gadt/005 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/005 gadt/expected
@@ -16,14 +16,6 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Basics.Bool>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Basics.Bool)))
-         IClaim MW
-                Export
-                []
                 (MkTy <DerivedGen.D>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
@@ -33,60 +25,14 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                          $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
                                                 => (IApp. IVar DerivedGen.D
                                                         $ IVar {arg:3630}))))))
-         IDef <Prelude.Basics.Bool>[]
-              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Prelude.Basics.Bool[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<Prelude.Basics.False>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<Prelude.Basics.True>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.False>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.True>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IDef <<Prelude.Basics.False>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.False>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.False (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.False)) ]
-                            IDef <<Prelude.Basics.True>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.True>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.True (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.True)) ] ]
+         IClaim MW
+                Export
+                []
+                (MkTy <Prelude.Basics.Bool>[]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ IVar Prelude.Basics.Bool)))
          IDef <DerivedGen.D>[]
               [ PatClause (IApp. IVar <DerivedGen.D>[] $ IBindVar ^fuel_arg^)
                           (ILocal (ICase (IVar ^fuel_arg^)
@@ -289,3 +235,57 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                                                                    (IVar b)
                                                                                                                        $ IVar ^bnd^{arg:3659}
                                                                                                                        $ IVar ^bnd^{arg:3662}))))) ]))) ] ]
+         IDef <Prelude.Basics.Bool>[]
+              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal Prelude.Basics.Bool[] (non-recursive))
+                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
+                                                          em
+                                                          (IVar MaybeEmpty)
+                                              $ (IApp. IVar ::
+                                                     $ (IApp. IVar <<Prelude.Basics.False>>
+                                                            $ IVar ^fuel_arg^)
+                                                     $ (IApp. IVar ::
+                                                            $ (IApp. IVar <<Prelude.Basics.True>>
+                                                                   $ IVar ^fuel_arg^)
+                                                            $ IVar Nil)))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Basics.False>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Basics.Bool)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Basics.True>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Basics.Bool)))
+                            IDef <<Prelude.Basics.False>>
+                                 [ PatClause (IApp. IVar <<Prelude.Basics.False>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Basics.False (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ IVar Prelude.Basics.False)) ]
+                            IDef <<Prelude.Basics.True>>
+                                 [ PatClause (IApp. IVar <<Prelude.Basics.True>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Basics.True (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ IVar Prelude.Basics.True)) ] ]

--- a/tests/derivation/least-effort/print/gadt/006 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/006 gadt/expected
@@ -19,11 +19,13 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Basics.Bool>[]
+                (MkTy <DerivedGen.D>[0]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Basics.Bool)))
+                                  $ (IApp. IVar DerivedGen.D
+                                         $ IVar {arg:3630}))))
          IClaim MW
                 Export
                 []
@@ -39,269 +41,11 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <DerivedGen.D>[0]
+                (MkTy <Prelude.Basics.Bool>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
                                   $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.D
-                                         $ IVar {arg:3630}))))
-         IDef <Prelude.Basics.Bool>[]
-              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Prelude.Basics.Bool[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<Prelude.Basics.False>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<Prelude.Basics.True>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.False>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.True>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IDef <<Prelude.Basics.False>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.False>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.False (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.False)) ]
-                            IDef <<Prelude.Basics.True>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.True>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.True (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.True)) ] ]
-         IDef <DerivedGen.D>[]
-              [ PatClause (IApp. IVar <DerivedGen.D>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.D[] (dry fuel))
-                                                          $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                                             em
-                                                                             (IVar MaybeEmpty)
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar <<DerivedGen.JJ>>
-                                                                               $ IVar Data.Fuel.Dry)
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar <<DerivedGen.TL>>
-                                                                                      $ IVar Data.Fuel.Dry)
-                                                                               $ IVar Nil))))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.D[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.JJ>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.FN>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ (IApp. IVar ::
-                                                                                      $ (IApp. IVar Builtin.MkPair
-                                                                                             $ IVar Data.Nat.Pos.one
-                                                                                             $ (IApp. IVar <<DerivedGen.TL>>
-                                                                                                    $ IVar ^fuel_arg^))
-                                                                                      $ (IApp. IVar ::
-                                                                                             $ (IApp. IVar Builtin.MkPair
-                                                                                                    $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                                           $ IVar ^sub^fuel_arg^)
-                                                                                                    $ (IApp. IVar <<DerivedGen.TR>>
-                                                                                                           $ IVar ^sub^fuel_arg^))
-                                                                                             $ IVar Nil)))))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.JJ>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3630}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.FN>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3630}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.TL>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3630}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.TR>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3630}))))))
-                            IDef <<DerivedGen.JJ>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.JJ>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.JJ (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Basics.Bool>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg b : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg ^bnd^{arg:3636} : Implicit False)
-                                                                               => (IApp. IVar >>=
-                                                                                       $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                                              $ IVar ^outmost-fuel^)
-                                                                                       $ (ILam.  (MW ExplicitArg ^bnd^{arg:3639} : Implicit False)
-                                                                                              => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                  f
-                                                                                                                  (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                       $ Implicit True)
-                                                                                                      $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                             $ Implicit True
-                                                                                                             $ (IApp. INamedApp (IVar DerivedGen.JJ)
-                                                                                                                                b
-                                                                                                                                (IVar b)
-                                                                                                                    $ IVar ^bnd^{arg:3636}
-                                                                                                                    $ IVar ^bnd^{arg:3639})))))))))) ]
-                            IDef <<DerivedGen.FN>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.FN>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.FN (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.D>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar b
-                                                                                          $ IBindVar ^bnd^{arg:3648})
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                                                 $ IVar ^outmost-fuel^)
-                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:3645} : Implicit False)
-                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                     f
-                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                          $ Implicit True)
-                                                                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                $ Implicit True
-                                                                                                                $ (IApp. INamedApp (IVar DerivedGen.FN)
-                                                                                                                                   b
-                                                                                                                                   (IVar b)
-                                                                                                                       $ IVar ^bnd^{arg:3645}
-                                                                                                                       $ IVar ^bnd^{arg:3648}))))) ]))) ]
-                            IDef <<DerivedGen.TL>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.TL>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.TL (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<^prim^.String>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:3654} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar DerivedGen.TL
-                                                                                      $ IVar ^bnd^{arg:3654})))))) ]
-                            IDef <<DerivedGen.TR>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.TR>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.TR (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.D>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar b
-                                                                                          $ IBindVar ^bnd^{arg:3662})
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar external^<^prim^.String>[]
-                                                                                                 $ IVar ^outmost-fuel^)
-                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:3659} : Implicit False)
-                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                     f
-                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                          $ Implicit True)
-                                                                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                $ Implicit True
-                                                                                                                $ (IApp. INamedApp (IVar DerivedGen.TR)
-                                                                                                                                   b
-                                                                                                                                   (IVar b)
-                                                                                                                       $ IVar ^bnd^{arg:3659}
-                                                                                                                       $ IVar ^bnd^{arg:3662}))))) ]))) ] ]
+                                  $ IVar Prelude.Basics.Bool)))
          IDef <DerivedGen.D>[0]
               [ PatClause (IApp. IVar <DerivedGen.D>[0]
                                $ IBindVar ^fuel_arg^
@@ -508,3 +252,259 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                   $ Implicit True
                                                   $ Implicit True)
                                              (IVar empty) ] ]
+         IDef <DerivedGen.D>[]
+              [ PatClause (IApp. IVar <DerivedGen.D>[] $ IBindVar ^fuel_arg^)
+                          (ILocal (ICase (IVar ^fuel_arg^)
+                                         (IVar Data.Fuel.Fuel)
+                                         [ PatClause (IVar Data.Fuel.Dry)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal DerivedGen.D[] (dry fuel))
+                                                          $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
+                                                                             em
+                                                                             (IVar MaybeEmpty)
+                                                                 $ (IApp. IVar ::
+                                                                        $ (IApp. IVar <<DerivedGen.JJ>>
+                                                                               $ IVar Data.Fuel.Dry)
+                                                                        $ (IApp. IVar ::
+                                                                               $ (IApp. IVar <<DerivedGen.TL>>
+                                                                                      $ IVar Data.Fuel.Dry)
+                                                                               $ IVar Nil))))
+                                         , PatClause (IApp. IVar Data.Fuel.More
+                                                          $ IBindVar ^sub^fuel_arg^)
+                                                     (IApp. IVar Test.DepTyCheck.Gen.label
+                                                          $ (IApp. IVar fromString
+                                                                 $ IPrimVal DerivedGen.D[] (spend fuel))
+                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
+                                                                 $ (IApp. IVar ::
+                                                                        $ (IApp. IVar Builtin.MkPair
+                                                                               $ IVar Data.Nat.Pos.one
+                                                                               $ (IApp. IVar <<DerivedGen.JJ>>
+                                                                                      $ IVar ^fuel_arg^))
+                                                                        $ (IApp. IVar ::
+                                                                               $ (IApp. IVar Builtin.MkPair
+                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
+                                                                                             $ IVar ^sub^fuel_arg^)
+                                                                                      $ (IApp. IVar <<DerivedGen.FN>>
+                                                                                             $ IVar ^sub^fuel_arg^))
+                                                                               $ (IApp. IVar ::
+                                                                                      $ (IApp. IVar Builtin.MkPair
+                                                                                             $ IVar Data.Nat.Pos.one
+                                                                                             $ (IApp. IVar <<DerivedGen.TL>>
+                                                                                                    $ IVar ^fuel_arg^))
+                                                                                      $ (IApp. IVar ::
+                                                                                             $ (IApp. IVar Builtin.MkPair
+                                                                                                    $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
+                                                                                                           $ IVar ^sub^fuel_arg^)
+                                                                                                    $ (IApp. IVar <<DerivedGen.TR>>
+                                                                                                           $ IVar ^sub^fuel_arg^))
+                                                                                             $ IVar Nil)))))) ]))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.JJ>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Basics.Bool
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
+                                                                   => (IApp. IVar DerivedGen.D
+                                                                           $ IVar {arg:3630}))))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.FN>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Basics.Bool
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
+                                                                   => (IApp. IVar DerivedGen.D
+                                                                           $ IVar {arg:3630}))))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.TL>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Basics.Bool
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
+                                                                   => (IApp. IVar DerivedGen.D
+                                                                           $ IVar {arg:3630}))))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.TR>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Basics.Bool
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Basics.Bool)
+                                                                   => (IApp. IVar DerivedGen.D
+                                                                           $ IVar {arg:3630}))))))
+                            IDef <<DerivedGen.JJ>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.JJ>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.JJ (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Basics.Bool>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg b : Implicit False)
+                                                                => (IApp. IVar >>=
+                                                                        $ (IApp. IVar external^<Prelude.Types.Nat>[]
+                                                                               $ IVar ^outmost-fuel^)
+                                                                        $ (ILam.  (MW ExplicitArg ^bnd^{arg:3636} : Implicit False)
+                                                                               => (IApp. IVar >>=
+                                                                                       $ (IApp. IVar external^<Prelude.Types.Nat>[]
+                                                                                              $ IVar ^outmost-fuel^)
+                                                                                       $ (ILam.  (MW ExplicitArg ^bnd^{arg:3639} : Implicit False)
+                                                                                              => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                                  f
+                                                                                                                  (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                                       $ Implicit True)
+                                                                                                      $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                             $ Implicit True
+                                                                                                             $ (IApp. INamedApp (IVar DerivedGen.JJ)
+                                                                                                                                b
+                                                                                                                                (IVar b)
+                                                                                                                    $ IVar ^bnd^{arg:3636}
+                                                                                                                    $ IVar ^bnd^{arg:3639})))))))))) ]
+                            IDef <<DerivedGen.FN>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.FN>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.FN (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <DerivedGen.D>[]
+                                                                $ IVar ^cons_fuel^)
+                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                => ICase (IVar {lamc:0})
+                                                                         (Implicit False)
+                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                          $ IBindVar b
+                                                                                          $ IBindVar ^bnd^{arg:3648})
+                                                                                     (IApp. IVar >>=
+                                                                                          $ (IApp. IVar external^<Prelude.Types.Nat>[]
+                                                                                                 $ IVar ^outmost-fuel^)
+                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:3645} : Implicit False)
+                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                                     f
+                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                                          $ Implicit True)
+                                                                                                         $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                                $ Implicit True
+                                                                                                                $ (IApp. INamedApp (IVar DerivedGen.FN)
+                                                                                                                                   b
+                                                                                                                                   (IVar b)
+                                                                                                                       $ IVar ^bnd^{arg:3645}
+                                                                                                                       $ IVar ^bnd^{arg:3648}))))) ]))) ]
+                            IDef <<DerivedGen.TL>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.TL>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.TL (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar external^<^prim^.String>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:3654} : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ (IApp. IVar DerivedGen.TL
+                                                                                      $ IVar ^bnd^{arg:3654})))))) ]
+                            IDef <<DerivedGen.TR>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.TR>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.TR (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <DerivedGen.D>[]
+                                                                $ IVar ^cons_fuel^)
+                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
+                                                                => ICase (IVar {lamc:0})
+                                                                         (Implicit False)
+                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
+                                                                                          $ IBindVar b
+                                                                                          $ IBindVar ^bnd^{arg:3662})
+                                                                                     (IApp. IVar >>=
+                                                                                          $ (IApp. IVar external^<^prim^.String>[]
+                                                                                                 $ IVar ^outmost-fuel^)
+                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:3659} : Implicit False)
+                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                                                     f
+                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                                                          $ Implicit True)
+                                                                                                         $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                                                $ Implicit True
+                                                                                                                $ (IApp. INamedApp (IVar DerivedGen.TR)
+                                                                                                                                   b
+                                                                                                                                   (IVar b)
+                                                                                                                       $ IVar ^bnd^{arg:3659}
+                                                                                                                       $ IVar ^bnd^{arg:3662}))))) ]))) ] ]
+         IDef <Prelude.Basics.Bool>[]
+              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal Prelude.Basics.Bool[] (non-recursive))
+                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
+                                                          em
+                                                          (IVar MaybeEmpty)
+                                              $ (IApp. IVar ::
+                                                     $ (IApp. IVar <<Prelude.Basics.False>>
+                                                            $ IVar ^fuel_arg^)
+                                                     $ (IApp. IVar ::
+                                                            $ (IApp. IVar <<Prelude.Basics.True>>
+                                                                   $ IVar ^fuel_arg^)
+                                                            $ IVar Nil)))))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Basics.False>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Basics.Bool)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<Prelude.Basics.True>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ IVar Prelude.Basics.Bool)))
+                            IDef <<Prelude.Basics.False>>
+                                 [ PatClause (IApp. IVar <<Prelude.Basics.False>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Basics.False (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ IVar Prelude.Basics.False)) ]
+                            IDef <<Prelude.Basics.True>>
+                                 [ PatClause (IApp. IVar <<Prelude.Basics.True>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal Prelude.Basics.True (orders))
+                                                  $ (IApp. INamedApp (IVar Prelude.pure)
+                                                                     f
+                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                          $ Implicit True)
+                                                         $ IVar Prelude.Basics.True)) ] ]

--- a/tests/derivation/least-effort/print/gadt/007 eq-n/expected
+++ b/tests/derivation/least-effort/print/gadt/007 eq-n/expected
@@ -8,14 +8,6 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
          IClaim MW
                 Export
                 []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IClaim MW
-                Export
-                []
                 (MkTy <DerivedGen.EqualN>[]
                       (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
                           -> (IApp. IVar Test.DepTyCheck.Gen.Gen
@@ -29,6 +21,59 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                => (IApp. IVar DerivedGen.EqualN
                                                                        $ IVar {arg:3630}
                                                                        $ IVar {arg:3633}))))))))
+         IClaim MW
+                Export
+                []
+                (MkTy <Prelude.Types.Nat>[]
+                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                  $ IVar Prelude.Types.Nat)))
+         IDef <DerivedGen.EqualN>[]
+              [ PatClause (IApp. IVar <DerivedGen.EqualN>[]
+                               $ IBindVar ^fuel_arg^)
+                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
+                                       $ (IApp. IVar fromString
+                                              $ IPrimVal DerivedGen.EqualN[] (non-recursive))
+                                       $ (IApp. IVar <<DerivedGen.ReflN>>
+                                              $ IVar ^fuel_arg^)))
+                            IClaim MW
+                                   Export
+                                   []
+                                   (MkTy <<DerivedGen.ReflN>>
+                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
+                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
+                                                     $ (IApp. IVar Builtin.DPair.DPair
+                                                            $ IVar Prelude.Types.Nat
+                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
+                                                                   => (IApp. IVar Builtin.DPair.DPair
+                                                                           $ IVar Prelude.Types.Nat
+                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
+                                                                                  => (IApp. IVar DerivedGen.EqualN
+                                                                                          $ IVar {arg:3630}
+                                                                                          $ IVar {arg:3633}))))))))
+                            IDef <<DerivedGen.ReflN>>
+                                 [ PatClause (IApp. IVar <<DerivedGen.ReflN>>
+                                                  $ IBindVar ^cons_fuel^)
+                                             (IApp. IVar Test.DepTyCheck.Gen.label
+                                                  $ (IApp. IVar fromString
+                                                         $ IPrimVal DerivedGen.ReflN (orders))
+                                                  $ (IApp. IVar >>=
+                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
+                                                                $ IVar ^outmost-fuel^)
+                                                         $ (ILam.  (MW ExplicitArg x : Implicit False)
+                                                                => (IApp. INamedApp (IVar Prelude.pure)
+                                                                                    f
+                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
+                                                                                         $ Implicit True)
+                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                               $ Implicit True
+                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
+                                                                                      $ Implicit True
+                                                                                      $ INamedApp (IVar DerivedGen.ReflN)
+                                                                                                  x
+                                                                                                  (IVar x))))))) ] ]
          IDef <Prelude.Types.Nat>[]
               [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
                                $ IBindVar ^fuel_arg^)
@@ -101,48 +146,3 @@ ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
                                                                                          $ Implicit True)
                                                                         $ (IApp. IVar Prelude.Types.S
                                                                                $ IVar ^bnd^{arg:789}))))) ] ]
-         IDef <DerivedGen.EqualN>[]
-              [ PatClause (IApp. IVar <DerivedGen.EqualN>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.EqualN[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.ReflN>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.ReflN>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3630} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3633} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.EqualN
-                                                                                          $ IVar {arg:3630}
-                                                                                          $ IVar {arg:3633}))))))))
-                            IDef <<DerivedGen.ReflN>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.ReflN>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.ReflN (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg x : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                      $ Implicit True
-                                                                                      $ INamedApp (IVar DerivedGen.ReflN)
-                                                                                                  x
-                                                                                                  (IVar x))))))) ] ]


### PR DESCRIPTION
Since this should reduce the monadic depth during derivation, this should increase the performance of the derivation