### PR TITLE
[ hack ] An alternative version of the simplification hack

### DIFF
--- a/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
@@ -187,6 +187,8 @@ namespace NonObligatoryExts
         rightmost <- indepPermutations' disjDeps rightmostArgs
         pure $ leftmost ++ leftToRightArgs ++ rightmost
 
+      let allOrders = take 1 allOrders
+
       --------------------------
       -- Producing the result --
       --------------------------

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
@@ -34,7 +34,7 @@ namespace NonObligatoryExts
   ||| It is seemingly most simple to implement, maybe the fastest and
   ||| fits well when external generators are provided for non-dependent types.
   export
-  LeastEffort : ConstructorDerivator
+  LeastEffort : {default False simplificationHack : Bool} -> ConstructorDerivator
   LeastEffort = CD where
     %inline
     [CD] ConstructorDerivator where
@@ -190,7 +190,7 @@ namespace NonObligatoryExts
           rightmost <- indepPermutations' disjDeps rightmostArgs
           pure $ leftmost ++ leftToRightArgs ++ rightmost
 
-        let allOrders = take 1 allOrders
+        let allOrders = if simplificationHack then take 1 allOrders else allOrders
 
         --------------------------
         -- Producing the result --

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
@@ -34,175 +34,178 @@ namespace NonObligatoryExts
   ||| It is seemingly most simple to implement, maybe the fastest and
   ||| fits well when external generators are provided for non-dependent types.
   export
-  [LeastEffort] ConstructorDerivator where
-    consGenExpr sig con givs fuel = do
+  LeastEffort : ConstructorDerivator
+  LeastEffort = CD where
+    %inline
+    [CD] ConstructorDerivator where
+      consGenExpr sig con givs fuel = do
 
-      -------------------------------------------------------------
-      -- Prepare intermediate data and functions using this data --
-      -------------------------------------------------------------
+        -------------------------------------------------------------
+        -- Prepare intermediate data and functions using this data --
+        -------------------------------------------------------------
 
-      -- Get file position of the constructor definition (for better error reporting)
-      let conFC = getFC con.type
+        -- Get file position of the constructor definition (for better error reporting)
+        let conFC = getFC con.type
 
-      -- Build a map from constructor's argument name to its index
-      let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (argName arg, idx)
+        -- Build a map from constructor's argument name to its index
+        let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (argName arg, idx)
 
-      -- Analyse that we can do subgeneration for each constructor argument
-      -- Fails using `Elaboration` if the given expression is not an application to a type constructor
-      let analyseTypeApp : TTImp -> m TypeApp
-          analyseTypeApp expr = do
-            let (lhs, args) = unAppAny expr
-            ty <- case lhs of
-              IVar _ lhsName     => try .| getInfo' lhsName -- TODO to support `lhsName` to be a type parameter of type `Type`
-                                        .| failAt (getFC lhs) "Only applications to non-polymorphic type constructors are supported at the moment"
-              IPrimVal _ (PrT t) => pure $ typeInfoForPrimType t
-              IType _            => pure typeInfoForTypeOfTypes
-              lhs                => failAt (getFC lhs) "Only applications to a name is supported, given \{lhs}"
-            let Yes lengthCorrect = decEq ty.args.length args.length
-              | No _ => failAt (getFC lhs) "INTERNAL ERROR: wrong count of unapp when analysing type application"
-            pure $ MkTypeApp ty $ rewrite lengthCorrect in args.asVect <&> \arg => case getExpr arg of
-              expr@(IVar _ n) => mirror . maybeToEither expr $ lookup n conArgIdxs
-              expr            => Right expr
+        -- Analyse that we can do subgeneration for each constructor argument
+        -- Fails using `Elaboration` if the given expression is not an application to a type constructor
+        let analyseTypeApp : TTImp -> m TypeApp
+            analyseTypeApp expr = do
+              let (lhs, args) = unAppAny expr
+              ty <- case lhs of
+                IVar _ lhsName     => try .| getInfo' lhsName -- TODO to support `lhsName` to be a type parameter of type `Type`
+                                          .| failAt (getFC lhs) "Only applications to non-polymorphic type constructors are supported at the moment"
+                IPrimVal _ (PrT t) => pure $ typeInfoForPrimType t
+                IType _            => pure typeInfoForTypeOfTypes
+                lhs                => failAt (getFC lhs) "Only applications to a name is supported, given \{lhs}"
+              let Yes lengthCorrect = decEq ty.args.length args.length
+                | No _ => failAt (getFC lhs) "INTERNAL ERROR: wrong count of unapp when analysing type application"
+              pure $ MkTypeApp ty $ rewrite lengthCorrect in args.asVect <&> \arg => case getExpr arg of
+                expr@(IVar _ n) => mirror . maybeToEither expr $ lookup n conArgIdxs
+                expr            => Right expr
 
-      -- Compute left-to-right need of generation when there are non-trivial types at the left
-      argsTypeApps <- for con.args.asVect $ analyseTypeApp . type
+        -- Compute left-to-right need of generation when there are non-trivial types at the left
+        argsTypeApps <- for con.args.asVect $ analyseTypeApp . type
 
-      -- Decide how constructor arguments would be named during generation
-      let bindNames : Vect (con.args.length) String
-          bindNames = flip mapWithPos .| fromList con.args .| \idx, arg => case argName arg of
-                        UN (Basic n) => n
-                        n            => (if contains idx givs then id else ("^bnd^" ++)) $ show n
+        -- Decide how constructor arguments would be named during generation
+        let bindNames : Vect (con.args.length) String
+            bindNames = flip mapWithPos .| fromList con.args .| \idx, arg => case argName arg of
+                          UN (Basic n) => n
+                          n            => (if contains idx givs then id else ("^bnd^" ++)) $ show n
 
-      -- Derive constructor calling expression for given order of generation
-      let genForOrder : List (Fin con.args.length) -> m TTImp
-          genForOrder order = foldr apply callCons <$> evalStateT givs (for order genForOneArg) where
+        -- Derive constructor calling expression for given order of generation
+        let genForOrder : List (Fin con.args.length) -> m TTImp
+            genForOrder order = foldr apply callCons <$> evalStateT givs (for order genForOneArg) where
 
-            -- ... state is the set of arguments that are already present (given or generated)
-            genForOneArg : forall m.
-                           CanonicGen m =>
-                           MonadState (SortedSet $ Fin con.args.length) m =>
-                           (gened : Fin con.args.length) -> m $ TTImp -> TTImp
-            genForOneArg genedArg = do
+              -- ... state is the set of arguments that are already present (given or generated)
+              genForOneArg : forall m.
+                             CanonicGen m =>
+                             MonadState (SortedSet $ Fin con.args.length) m =>
+                             (gened : Fin con.args.length) -> m $ TTImp -> TTImp
+              genForOneArg genedArg = do
 
-              -- Get info for the `genedArg`
-              let MkTypeApp typeOfGened argsOfTypeOfGened = index genedArg $ the (Vect _ TypeApp) argsTypeApps
+                -- Get info for the `genedArg`
+                let MkTypeApp typeOfGened argsOfTypeOfGened = index genedArg $ the (Vect _ TypeApp) argsTypeApps
 
-              -- Acquire the set of arguments that are already present
-              presentArguments <- get
+                -- Acquire the set of arguments that are already present
+                presentArguments <- get
 
-              -- TODO to put the following check as up as possible as soon as it typecheks O_O
-              -- Check that those argument that we need to generate is not already present
-              let False = contains genedArg presentArguments
-                | True => pure id
+                -- TODO to put the following check as up as possible as soon as it typecheks O_O
+                -- Check that those argument that we need to generate is not already present
+                let False = contains genedArg presentArguments
+                  | True => pure id
 
-              -- Filter arguments classification according to the set of arguments that are left to be generated;
-              -- Those which are `Right` are given, those which are `Left` are needs to be generated.
-              let depArgs : Vect typeOfGened.args.length (Either (Fin con.args.length) TTImp) := argsOfTypeOfGened <&> \case
-                Right expr => Right expr
-                Left i     => if contains i presentArguments then Right $ var $ argName $ index' con.args i else Left i
+                -- Filter arguments classification according to the set of arguments that are left to be generated;
+                -- Those which are `Right` are given, those which are `Left` are needs to be generated.
+                let depArgs : Vect typeOfGened.args.length (Either (Fin con.args.length) TTImp) := argsOfTypeOfGened <&> \case
+                  Right expr => Right expr
+                  Left i     => if contains i presentArguments then Right $ var $ argName $ index' con.args i else Left i
 
-              -- Determine which arguments will be on the left of dpair in subgen call, in correct order
-              let subgeneratedArgs = mapMaybe getLeft $ toList depArgs
+                -- Determine which arguments will be on the left of dpair in subgen call, in correct order
+                let subgeneratedArgs = mapMaybe getLeft $ toList depArgs
 
-              -- Make sure generated arguments will not be generated again
-              modify $ insert genedArg . union (fromList subgeneratedArgs)
+                -- Make sure generated arguments will not be generated again
+                modify $ insert genedArg . union (fromList subgeneratedArgs)
 
-              -- Form a task for subgen
-              let (subgivensLength ** subgivens) = mapMaybe (\(ie, idx) => (idx,) <$> getRight ie) $ depArgs `zip` Fin.range
-              let subsig : GenSignature := MkGenSignature typeOfGened $ fromList $ fst <$> toList subgivens
-              let Yes Refl = decEq subsig.givenParams.size subgivensLength
-                | No _ => fail "INTERNAL ERROR: error in given params set length computation"
+                -- Form a task for subgen
+                let (subgivensLength ** subgivens) = mapMaybe (\(ie, idx) => (idx,) <$> getRight ie) $ depArgs `zip` Fin.range
+                let subsig : GenSignature := MkGenSignature typeOfGened $ fromList $ fst <$> toList subgivens
+                let Yes Refl = decEq subsig.givenParams.size subgivensLength
+                  | No _ => fail "INTERNAL ERROR: error in given params set length computation"
 
-              -- Check if called subgenerator can call the current one
-              mutRec <- hasNameInsideDeep sig.targetType.name $ var subsig.targetType.name
+                -- Check if called subgenerator can call the current one
+                mutRec <- hasNameInsideDeep sig.targetType.name $ var subsig.targetType.name
 
-              -- Decide whether to use local (decreasing) or outmost fuel, depending on whether we are in mutual recursion with subgen
-              let subfuel = if mutRec then fuel else var outmostFuelArg
+                -- Decide whether to use local (decreasing) or outmost fuel, depending on whether we are in mutual recursion with subgen
+                let subfuel = if mutRec then fuel else var outmostFuelArg
 
-              -- Form an expression to call the subgen
-              subgenCall <- callGen subsig subfuel $ snd <$> subgivens
+                -- Form an expression to call the subgen
+                subgenCall <- callGen subsig subfuel $ snd <$> subgivens
 
-              -- Form an expression of binding the result of subgen
-              let genedArg:::subgeneratedArgs = genedArg:::subgeneratedArgs <&> bindVar . flip Vect.index bindNames
-              let bindSubgenResult = foldr (\l, r => var `{Builtin.DPair.MkDPair} .$ l .$ r) genedArg subgeneratedArgs
+                -- Form an expression of binding the result of subgen
+                let genedArg:::subgeneratedArgs = genedArg:::subgeneratedArgs <&> bindVar . flip Vect.index bindNames
+                let bindSubgenResult = foldr (\l, r => var `{Builtin.DPair.MkDPair} .$ l .$ r) genedArg subgeneratedArgs
 
-              -- Form an expression of the RHS of a bind; simplify lambda if subgeneration result type does not require pattern matching
-              let bindRHS = \cont => case bindSubgenResult of
-                                       IBindVar _ n => lam (MkArg MW ExplicitArg (Just $ UN $ Basic n) implicitFalse) cont
-                                       _            => `(\ ~bindSubgenResult => ~cont)
+                -- Form an expression of the RHS of a bind; simplify lambda if subgeneration result type does not require pattern matching
+                let bindRHS = \cont => case bindSubgenResult of
+                                         IBindVar _ n => lam (MkArg MW ExplicitArg (Just $ UN $ Basic n) implicitFalse) cont
+                                         _            => `(\ ~bindSubgenResult => ~cont)
 
-              -- Chain the subgen call with a given continuation
-              pure $ \cont => `(~subgenCall >>= ~(bindRHS cont))
+                -- Chain the subgen call with a given continuation
+                pure $ \cont => `(~subgenCall >>= ~(bindRHS cont))
 
-            callCons : TTImp
-            callCons = do
-              let constructorCall = callCon con $ bindNames <&> varStr
-              let wrapImpls : Nat -> TTImp
-                  wrapImpls Z     = constructorCall
-                  wrapImpls (S n) = var `{Builtin.DPair.MkDPair} .$ implicitTrue .$ wrapImpls n
-              let consExpr = wrapImpls $ sig.targetType.args.length `minus` sig.givenParams.size
-              `(Prelude.pure {f=Test.DepTyCheck.Gen.Gen _} ~consExpr)
+              callCons : TTImp
+              callCons = do
+                let constructorCall = callCon con $ bindNames <&> varStr
+                let wrapImpls : Nat -> TTImp
+                    wrapImpls Z     = constructorCall
+                    wrapImpls (S n) = var `{Builtin.DPair.MkDPair} .$ implicitTrue .$ wrapImpls n
+                let consExpr = wrapImpls $ sig.targetType.args.length `minus` sig.givenParams.size
+                `(Prelude.pure {f=Test.DepTyCheck.Gen.Gen _} ~consExpr)
 
-      -- Get dependencies of constructor's arguments
-      rawDeps <- argDeps con.args
-      let deps = downmap ((`difference` givs) . mapIn weakenToSuper) rawDeps
+        -- Get dependencies of constructor's arguments
+        rawDeps <- argDeps con.args
+        let deps = downmap ((`difference` givs) . mapIn weakenToSuper) rawDeps
 
-      -------------------------------------------------
-      -- Left-to-right generation phase (2nd phase) ---
-      -------------------------------------------------
+        -------------------------------------------------
+        -- Left-to-right generation phase (2nd phase) ---
+        -------------------------------------------------
 
-      -- Determine which arguments need to be generated in a left-to-right manner
-      let (leftToRightArgsTypeApp, leftToRightArgs) = unzip $ filter (\((MkTypeApp _ as), _) => any isRight as) $ toListI argsTypeApps
+        -- Determine which arguments need to be generated in a left-to-right manner
+        let (leftToRightArgsTypeApp, leftToRightArgs) = unzip $ filter (\((MkTypeApp _ as), _) => any isRight as) $ toListI argsTypeApps
 
-      --------------------------------------------------------------------------------
-      -- Preparation of input for the left-to-right phase (1st right-to-left phase) --
-      --------------------------------------------------------------------------------
+        --------------------------------------------------------------------------------
+        -- Preparation of input for the left-to-right phase (1st right-to-left phase) --
+        --------------------------------------------------------------------------------
 
-      -- Acquire those variables that appear in non-trivial type expressions, i.e. those which needs to be generated before the left-to-right phase
-      let preLTR = leftToRightArgsTypeApp >>= \(MkTypeApp _ as) => rights (toList as) >>= toList . allVarNames
-      let preLTR = SortedSet.fromList $ mapMaybe (flip lookup conArgIdxs) preLTR
+        -- Acquire those variables that appear in non-trivial type expressions, i.e. those which needs to be generated before the left-to-right phase
+        let preLTR = leftToRightArgsTypeApp >>= \(MkTypeApp _ as) => rights (toList as) >>= toList . allVarNames
+        let preLTR = SortedSet.fromList $ mapMaybe (flip lookup conArgIdxs) preLTR
 
-      -- Find rightmost arguments among `preLTR`
-      let depsLTR = SortedSet.fromList $
-                      mapMaybe (\(ds, idx) => whenT .| contains idx preLTR && null ds .| idx) $
-                        toListI $ deps <&> intersection preLTR
+        -- Find rightmost arguments among `preLTR`
+        let depsLTR = SortedSet.fromList $
+                        mapMaybe (\(ds, idx) => whenT .| contains idx preLTR && null ds .| idx) $
+                          toListI $ deps <&> intersection preLTR
 
-      ---------------------------------------------------------------------------------
-      -- Main right-to-left generation phase (3rd phase aka 2nd right-to-left phase) --
-      ---------------------------------------------------------------------------------
+        ---------------------------------------------------------------------------------
+        -- Main right-to-left generation phase (3rd phase aka 2nd right-to-left phase) --
+        ---------------------------------------------------------------------------------
 
-      -- Arguments that no other argument depends on
-      let rightmostArgs = fromFoldable {f=Vect _} range `difference` (givs `union` concat deps)
+        -- Arguments that no other argument depends on
+        let rightmostArgs = fromFoldable {f=Vect _} range `difference` (givs `union` concat deps)
 
-      ---------------------------------------------------------------
-      -- Manage different possible variants of generation ordering --
-      ---------------------------------------------------------------
+        ---------------------------------------------------------------
+        -- Manage different possible variants of generation ordering --
+        ---------------------------------------------------------------
 
-      -- Prepare info about which arguments are independent and thus can be ordered arbitrarily
-      let disjDeps = disjointDepSets rawDeps givs
+        -- Prepare info about which arguments are independent and thus can be ordered arbitrarily
+        let disjDeps = disjointDepSets rawDeps givs
 
-      -- Acquire order(s) in what we will generate arguments
-      let allOrders = do
-        leftmost  <- indepPermutations' disjDeps depsLTR
-        rightmost <- indepPermutations' disjDeps rightmostArgs
-        pure $ leftmost ++ leftToRightArgs ++ rightmost
+        -- Acquire order(s) in what we will generate arguments
+        let allOrders = do
+          leftmost  <- indepPermutations' disjDeps depsLTR
+          rightmost <- indepPermutations' disjDeps rightmostArgs
+          pure $ leftmost ++ leftToRightArgs ++ rightmost
 
-      let allOrders = take 1 allOrders
+        let allOrders = take 1 allOrders
 
-      --------------------------
-      -- Producing the result --
-      --------------------------
+        --------------------------
+        -- Producing the result --
+        --------------------------
 
-      callOneOf "\{show con.name} (orders)" <$> traverse genForOrder allOrders
+        callOneOf "\{show con.name} (orders)" <$> traverse genForOrder allOrders
 
-      where
+        where
 
-        -- TODO make this to be a `record` as soon as #2177 is fixed
-        data TypeApp : Type where
-          MkTypeApp :
-            (type : TypeInfo) ->
-            (argTypes : Vect type.args.length .| Either (Fin con.args.length) TTImp) ->
-            TypeApp
+          -- TODO make this to be a `record` as soon as #2177 is fixed
+          data TypeApp : Type where
+            MkTypeApp :
+              (type : TypeInfo) ->
+              (argTypes : Vect type.args.length .| Either (Fin con.args.length) TTImp) ->
+              TypeApp
 
   ||| Best effort non-obligatory tactic tries to use as much external generators as possible
   ||| but discards some there is a conflict between them.


### PR DESCRIPTION
This is similar to an old simplification hack by the fact that it takes only a single order into account, but it differs by that the only order used is like the original (before the hack) one.

The hack is turned off by default, but can be set to be used by defining a `default` implicit parameter of the `LeastEffort` constructors derivator.