### PR TITLE
[ cleanup ] Get rid of the SOP library, derive `Show` alternatively

### DIFF
--- a/.github/workflows/ci-deptycheck.yml
+++ b/.github/workflows/ci-deptycheck.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Untar the `pack` dir
         run: tar -xvf "${{ env.pack_dir_file }}" --one-top-level=/ --touch
 
-      - run: pack install elab-util mtl-tuple-impls random-pure sop summary-stat
+      - run: pack install elab-util mtl-tuple-impls random-pure summary-stat
 
       - name: Tar the `pack` dir
         run: tar -uvf "${{ env.pack_dir_file }}" --exclude=".cache" "${{ env.PACK_DIR }}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ thirdparties:build:
   needs:
     - pack:prepare
   script:
-    - pack install elab-util mtl-tuple-impls random-pure sop summary-stat
+    - pack install elab-util mtl-tuple-impls random-pure summary-stat
 
 deptycheck:build:
   stage: deptycheck:build

--- a/pack.toml
+++ b/pack.toml
@@ -41,9 +41,3 @@ type   = "git"
 url    = "https://github.com/buzden/idris2-elab-util"
 commit = "6ff9878208940a9f8074f9030e272f4ca176d64f"
 ipkg   = "elab-util.ipkg"
-
-[custom.all.sop]
-type   = "git"
-url    = "https://github.com/buzden/idris2-sop"
-commit = "a9efb67d23adf3808bfd887781586ef318c56f35"
-ipkg   = "sop.ipkg"

--- a/tests/derivation/_common/RunDerivedGen.idr
+++ b/tests/derivation/_common/RunDerivedGen.idr
@@ -1,8 +1,7 @@
 module RunDerivedGen
 
 import public Deriving.DepTyCheck.Gen
-
-import public Generics.Derive
+import public Deriving.Show
 
 import System.Random.Pure.StdGen
 

--- a/tests/derivation/_common/derive.ipkg
+++ b/tests/derivation/_common/derive.ipkg
@@ -4,4 +4,4 @@ authors = "Denis Buzdalov"
 
 opts = "--no-color --console-width 0"
 
-depends = deptycheck, contrib, elab-util, sop
+depends = deptycheck

--- a/tests/derivation/core/norec nodep noext 002/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep noext 002/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = X0 | X1 Bool | X2 Bool Bool
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 checkedGen : Fuel -> Gen MaybeEmpty X
 checkedGen = deriveGen

--- a/tests/derivation/core/norec nodep noext 003-neg/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep noext 003-neg/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = MkX Void
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 checkedGen : Fuel -> Gen MaybeEmpty X
 checkedGen = deriveGen

--- a/tests/derivation/core/norec nodep noext 003-neg/expected
+++ b/tests/derivation/core/norec nodep noext 003-neg/expected
@@ -2,11 +2,11 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 Error: While processing right hand side of checkedGen. Error during reflection: No constructors found for the type `Builtin.Void`
 
-DerivedGen:14:14--14:23
- 10 | 
- 11 | %runElab derive "X" [Generic, Meta, Show]
- 12 | 
- 13 | checkedGen : Fuel -> Gen MaybeEmpty X
- 14 | checkedGen = deriveGen
+DerivedGen:16:14--16:23
+ 12 | XShow : Show X
+ 13 | XShow = %runElab derive
+ 14 | 
+ 15 | checkedGen : Fuel -> Gen MaybeEmpty X
+ 16 | checkedGen = deriveGen
                    ^^^^^^^^^
 

--- a/tests/derivation/core/norec nodep noext 004-neg/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep noext 004-neg/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = MkX Bool Void
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 checkedGen : Fuel -> Gen MaybeEmpty X
 checkedGen = deriveGen

--- a/tests/derivation/core/norec nodep noext 004-neg/expected
+++ b/tests/derivation/core/norec nodep noext 004-neg/expected
@@ -2,11 +2,11 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 Error: While processing right hand side of checkedGen. Error during reflection: No constructors found for the type `Builtin.Void`
 
-DerivedGen:14:14--14:23
- 10 | 
- 11 | %runElab derive "X" [Generic, Meta, Show]
- 12 | 
- 13 | checkedGen : Fuel -> Gen MaybeEmpty X
- 14 | checkedGen = deriveGen
+DerivedGen:16:14--16:23
+ 12 | XShow : Show X
+ 13 | XShow = %runElab derive
+ 14 | 
+ 15 | checkedGen : Fuel -> Gen MaybeEmpty X
+ 16 | checkedGen = deriveGen
                    ^^^^^^^^^
 

--- a/tests/derivation/core/norec nodep noext 005-neg/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep noext 005-neg/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = X0 | X1 Bool | X2 Void Bool
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 checkedGen : Fuel -> Gen MaybeEmpty X
 checkedGen = deriveGen

--- a/tests/derivation/core/norec nodep noext 005-neg/expected
+++ b/tests/derivation/core/norec nodep noext 005-neg/expected
@@ -2,11 +2,11 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 Error: While processing right hand side of checkedGen. Error during reflection: No constructors found for the type `Builtin.Void`
 
-DerivedGen:14:14--14:23
- 10 | 
- 11 | %runElab derive "X" [Generic, Meta, Show]
- 12 | 
- 13 | checkedGen : Fuel -> Gen MaybeEmpty X
- 14 | checkedGen = deriveGen
+DerivedGen:16:14--16:23
+ 12 | XShow : Show X
+ 13 | XShow = %runElab derive
+ 14 | 
+ 15 | checkedGen : Fuel -> Gen MaybeEmpty X
+ 16 | checkedGen = deriveGen
                    ^^^^^^^^^
 

--- a/tests/derivation/core/norec nodep w_ext 001/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep w_ext 001/DerivedGen.idr
@@ -8,7 +8,9 @@ import public RunDerivedGen
 
 data X = MkX String
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => Gen MaybeEmpty X
 checkedGen = deriveGen

--- a/tests/derivation/core/norec nodep w_ext 002/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep w_ext 002/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = MkX String String
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 export
 checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => Gen MaybeEmpty X

--- a/tests/derivation/core/norec nodep w_ext 003/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep w_ext 003/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = MkX String Nat
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 export
 checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => (Fuel -> Gen MaybeEmpty Nat) => Gen MaybeEmpty X

--- a/tests/derivation/core/norec nodep w_ext 004/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep w_ext 004/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = X1 String Nat | X2 Nat | X3 String
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 export
 checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => (Fuel -> Gen MaybeEmpty Nat) => Gen MaybeEmpty X

--- a/tests/derivation/core/norec nodep w_ext 005/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep w_ext 005/DerivedGen.idr
@@ -8,7 +8,9 @@ import public RunDerivedGen
 
 data X = MkX Void
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 voidsGen : Fuel -> Gen MaybeEmpty Void
 voidsGen _ = empty

--- a/tests/derivation/core/norec nodep w_ext 006/DerivedGen.idr
+++ b/tests/derivation/core/norec nodep w_ext 006/DerivedGen.idr
@@ -8,7 +8,9 @@ import public RunDerivedGen
 
 data X = MkX Bool
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 gensGen : Fuel -> (em : _) -> Gen MaybeEmpty (a ** Gen em a)
 gensGen fuel MaybeEmpty = elements

--- a/tests/derivation/core/norec part noext 003/DerivedGen.idr
+++ b/tests/derivation/core/norec part noext 003/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = MkX (Maybe Bool)
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 checkedGen : Fuel -> Gen MaybeEmpty X
 checkedGen = deriveGen

--- a/tests/derivation/core/norec part noext 003/expected
+++ b/tests/derivation/core/norec part noext 003/expected
@@ -2,11 +2,11 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 Error: While processing right hand side of checkedGen. Error during reflection: Only applications to non-polymorphic type constructors are supported at the moment
 
-DerivedGen:14:14--14:23
- 10 | 
- 11 | %runElab derive "X" [Generic, Meta, Show]
- 12 | 
- 13 | checkedGen : Fuel -> Gen MaybeEmpty X
- 14 | checkedGen = deriveGen
+DerivedGen:16:14--16:23
+ 12 | XShow : Show X
+ 13 | XShow = %runElab derive
+ 14 | 
+ 15 | checkedGen : Fuel -> Gen MaybeEmpty X
+ 16 | checkedGen = deriveGen
                    ^^^^^^^^^
 

--- a/tests/derivation/core/norec part noext 004/DerivedGen.idr
+++ b/tests/derivation/core/norec part noext 004/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = MkX (Bool, Bool)
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 export
 checkedGen : Fuel -> Gen MaybeEmpty X

--- a/tests/derivation/core/norec part noext 004/expected
+++ b/tests/derivation/core/norec part noext 004/expected
@@ -2,11 +2,11 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 Error: While processing right hand side of checkedGen. Error during reflection: Only applications to non-polymorphic type constructors are supported at the moment
 
-DerivedGen:15:14--15:23
- 11 | %runElab derive "X" [Generic, Meta, Show]
- 12 | 
- 13 | export
- 14 | checkedGen : Fuel -> Gen MaybeEmpty X
- 15 | checkedGen = deriveGen
+DerivedGen:17:14--17:23
+ 13 | XShow = %runElab derive
+ 14 | 
+ 15 | export
+ 16 | checkedGen : Fuel -> Gen MaybeEmpty X
+ 17 | checkedGen = deriveGen
                    ^^^^^^^^^
 

--- a/tests/derivation/core/norec part noext 005/DerivedGen.idr
+++ b/tests/derivation/core/norec part noext 005/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = X0 | X1 (Maybe Bool) | X2 Bool (Bool, Bool)
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 export
 checkedGen : Fuel -> Gen MaybeEmpty X

--- a/tests/derivation/core/norec part noext 005/expected
+++ b/tests/derivation/core/norec part noext 005/expected
@@ -2,11 +2,11 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 Error: While processing right hand side of checkedGen. Error during reflection: Only applications to non-polymorphic type constructors are supported at the moment
 
-DerivedGen:15:14--15:23
- 11 | %runElab derive "X" [Generic, Meta, Show]
- 12 | 
- 13 | export
- 14 | checkedGen : Fuel -> Gen MaybeEmpty X
- 15 | checkedGen = deriveGen
+DerivedGen:17:14--17:23
+ 13 | XShow = %runElab derive
+ 14 | 
+ 15 | export
+ 16 | checkedGen : Fuel -> Gen MaybeEmpty X
+ 17 | checkedGen = deriveGen
                    ^^^^^^^^^
 

--- a/tests/derivation/core/norec part w_ext 001/DerivedGen.idr
+++ b/tests/derivation/core/norec part w_ext 001/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = MkX (Maybe String)
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 export
 checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => Gen MaybeEmpty X

--- a/tests/derivation/core/norec part w_ext 001/expected
+++ b/tests/derivation/core/norec part w_ext 001/expected
@@ -2,11 +2,11 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 Error: While processing right hand side of checkedGen. Error during reflection: Only applications to non-polymorphic type constructors are supported at the moment
 
-DerivedGen:15:14--15:23
- 11 | %runElab derive "X" [Generic, Meta, Show]
- 12 | 
- 13 | export
- 14 | checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => Gen MaybeEmpty X
- 15 | checkedGen = deriveGen
+DerivedGen:17:14--17:23
+ 13 | XShow = %runElab derive
+ 14 | 
+ 15 | export
+ 16 | checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => Gen MaybeEmpty X
+ 17 | checkedGen = deriveGen
                    ^^^^^^^^^
 

--- a/tests/derivation/core/norec part w_ext 002/DerivedGen.idr
+++ b/tests/derivation/core/norec part w_ext 002/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = MkX (String, Nat)
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 export
 checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => (Fuel -> Gen MaybeEmpty Nat) => Gen MaybeEmpty X

--- a/tests/derivation/core/norec part w_ext 002/expected
+++ b/tests/derivation/core/norec part w_ext 002/expected
@@ -2,11 +2,11 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 Error: While processing right hand side of checkedGen. Error during reflection: Only applications to non-polymorphic type constructors are supported at the moment
 
-DerivedGen:15:14--15:23
- 11 | %runElab derive "X" [Generic, Meta, Show]
- 12 | 
- 13 | export
- 14 | checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => (Fuel -> Gen MaybeEmpty Nat) => Gen MaybeEmpty X
- 15 | checkedGen = deriveGen
+DerivedGen:17:14--17:23
+ 13 | XShow = %runElab derive
+ 14 | 
+ 15 | export
+ 16 | checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => (Fuel -> Gen MaybeEmpty Nat) => Gen MaybeEmpty X
+ 17 | checkedGen = deriveGen
                    ^^^^^^^^^
 

--- a/tests/derivation/core/norec part w_ext 003/DerivedGen.idr
+++ b/tests/derivation/core/norec part w_ext 003/DerivedGen.idr
@@ -8,7 +8,9 @@ import RunDerivedGen
 
 data X = MkX (String, Nat, String)
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 export
 checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => (Fuel -> Gen MaybeEmpty Nat) => Gen MaybeEmpty X

--- a/tests/derivation/core/norec part w_ext 003/expected
+++ b/tests/derivation/core/norec part w_ext 003/expected
@@ -2,11 +2,11 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 Error: While processing right hand side of checkedGen. Error during reflection: Only applications to non-polymorphic type constructors are supported at the moment
 
-DerivedGen:15:14--15:23
- 11 | %runElab derive "X" [Generic, Meta, Show]
- 12 | 
- 13 | export
- 14 | checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => (Fuel -> Gen MaybeEmpty Nat) => Gen MaybeEmpty X
- 15 | checkedGen = deriveGen
+DerivedGen:17:14--17:23
+ 13 | XShow = %runElab derive
+ 14 | 
+ 15 | export
+ 16 | checkedGen : Fuel -> (Fuel -> Gen MaybeEmpty String) => (Fuel -> Gen MaybeEmpty Nat) => Gen MaybeEmpty X
+ 17 | checkedGen = deriveGen
                    ^^^^^^^^^
 

--- a/tests/derivation/core/typealias con 001/DerivedGen.idr
+++ b/tests/derivation/core/typealias con 001/DerivedGen.idr
@@ -14,7 +14,9 @@ data X : Type where
   X1 : Bool -> X
   X2 : Bool -> SimpleTypeAlias -> X
 
-%runElab derive "X" [Generic, Meta, Show]
+%hint
+XShow : Show X
+XShow = %runElab derive
 
 checkedGen : Fuel -> Gen MaybeEmpty X
 checkedGen = deriveGen

--- a/tests/derivation/core/typealias con 002/DerivedGen.idr
+++ b/tests/derivation/core/typealias con 002/DerivedGen.idr
@@ -15,7 +15,10 @@ data X : Type where
   X1 : Bool -> X
   X2 : ConstantUseTypeAlias True -> ConstantUseTypeAlias False -> X
 
-%runElab derive "X" [Generic, Meta, Show]
+Show X where
+  show X0 = "X0"
+  show (X1 b) = "X1 \{show b}"
+  show (X2 b n) = "X2 \{show b} \{show n}"
 
 checkedGen : Fuel -> Gen MaybeEmpty X
 checkedGen = deriveGen


### PR DESCRIPTION
Use derivation from the standard `base` library