### PR TITLE
[ upstream ] Switch to newer `elab-util` with a special compat layer

### DIFF
--- a/.github/workflows/ci-deptycheck.yml
+++ b/.github/workflows/ci-deptycheck.yml
@@ -47,7 +47,7 @@ jobs:
 
       - run: pack update-db
       - name: Switch to appropriate `pack` collection
-        run: pack switch "$( if [[ '${{ github.event_name }}' == 'schedule' ]]; then echo latest; else cat .pack-collection; fi )"
+        run: pack switch "$( if [[ '${{ github.event_name }}' == 'schedule' ]]; then echo latest; else ./.pack-collection; fi )"
       - run: ./.patch-chez-gc-handler idris2
 
       - name: Tar the `pack` dir

--- a/.gitlab/deptycheck.yml
+++ b/.gitlab/deptycheck.yml
@@ -20,7 +20,7 @@ pack:prepare:
   stage: .pre
   script:
     - pack update-db
-    - pack switch "$( if [[ "$CI_PIPELINE_SOURCE" == 'schedule' ]]; then echo latest; else cat .pack-collection; fi )"
+    - pack switch "$( if [[ "$CI_PIPELINE_SOURCE" == 'schedule' ]]; then echo latest; else ./.pack-collection; fi )"
     - ./.patch-chez-gc-handler idris2
 
 stages:

--- a/.pack-collection
+++ b/.pack-collection
@@ -1,1 +1,3 @@
-nightly-240404
+#!/bin/sh
+
+(grep 'version *= *\([0-9]\+.\)\+[0-9]\{6\}$' deptycheck.ipkg || echo 'latest') | sed 's/.*\./nightly-/'

--- a/README.md
+++ b/README.md
@@ -359,13 +359,4 @@ For building and testing we use [`pack`](https://github.com/stefan-hoeck/idris2-
 
 The main `pack`'s collection we test the library against is the one mentioned in the last section of the library version.
 Also, we test against the latest pack collection nightly.
-
 We try to use as fresh version of the Idris 2 compiler and thirdparty libraries as possible.
-However, this is not absolute.
-For example, we didn't manage to migrate [one big overhaul](https://github.com/stefan-hoeck/idris2-elab-util/pull/56) of the `elab-util` package,
-thus we maintain a pre-overhaul fork with necessary compatibility updates.
-Used versions are set in the local `pack.toml` configuration file.
-
-Due to the stuff above, DepTyCheck is not yet committed to the pack collection.
-If you plan to use it, you need to copy particular versions of the compiler and dependencies
-from the library's `pack.toml` to a local `pack.toml`.

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ For building and testing we use [`pack`](https://github.com/stefan-hoeck/idris2-
 > Despite that, to make [LSP](https://github.com/idris-community/idris2-lsp) working well,
 > only a single code-related `ipkg` file is left in the top-level folder of the project.
 
-The main `pack`'s collection we test against is in the file called [`.pack-collection`](/.pack-collection) in the root of this repository.
+The main `pack`'s collection we test the library against is the one mentioned in the last section of the library version.
 Also, we test against the latest pack collection nightly.
 
 We try to use as fresh version of the Idris 2 compiler and thirdparty libraries as possible.

--- a/deptycheck.ipkg
+++ b/deptycheck.ipkg
@@ -30,12 +30,15 @@ modules = Data.Nat.Pos
         , Deriving.DepTyCheck.Util.Logging
         , Deriving.DepTyCheck.Util.Reflection
         , Deriving.DepTyCheck.Util.Syntax
+        , Language.Reflection.Compat
         , Test.DepTyCheck.Gen
         , Test.DepTyCheck.Gen.Coverage
         , Test.DepTyCheck.Gen.Emptiness
         , Test.DepTyCheck.Gen.Labels
 
-depends = elab-util
+depends = contrib
+        , elab-pretty
+        , elab-util
         , if-unsolved-implicit
         , mtl-tuple-impls
         , random-pure

--- a/deptycheck.ipkg
+++ b/deptycheck.ipkg
@@ -9,7 +9,7 @@ license = "MPL-2.0"
 sourcedir = "src"
 builddir = ".build"
 
-version = 0.0.220712
+version = 0.0.240407
 
 modules = Data.Nat.Pos
         , Data.Vect.Dependent

--- a/examples/sorted-list/tests/gens/print/expected
+++ b/examples/sorted-list/tests/gens/print/expected
@@ -2,589 +2,594 @@
 2/2: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Data.List.Sorted.SortedList>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.List.Sorted.SortedList>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Data.List.Sorted.SortedList)))
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.List.Sorted.FirstGT>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Data.List.Sorted.SortedList
-                                                        $ (ILam.  (MW ExplicitArg {arg:2} : IVar Data.List.Sorted.SortedList)
-                                                               => (IApp. IVar Data.List.Sorted.FirstGT
-                                                                       $ IVar {arg:1}
-                                                                       $ IVar {arg:2}))))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.List.Sorted.FirstGT>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Data.List.Sorted.SortedList
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Data.List.Sorted.SortedList)
-                                                => (IApp. IVar Data.List.Sorted.FirstGT
-                                                        $ IVar {arg:1}
-                                                        $ IVar {arg:2}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Nat.LTE>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg m : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Data.Nat.LTE
-                                                        $ IVar n
-                                                        $ IVar m))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <Data.List.Sorted.SortedList>[]
-              [ PatClause (IApp. IVar <Data.List.Sorted.SortedList>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.List.Sorted.SortedList[] (dry fuel))
-                                                          $ (IApp. IVar <<Data.List.Sorted.Nil>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.List.Sorted.SortedList[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Data.List.Sorted.Nil>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Data.List.Sorted.(::)>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.List.Sorted.Nil>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Data.List.Sorted.SortedList)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.List.Sorted.(::)>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Data.List.Sorted.SortedList)))
-                            IDef <<Data.List.Sorted.Nil>>
-                                 [ PatClause (IApp. IVar <<Data.List.Sorted.Nil>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.List.Sorted.Nil (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Data.List.Sorted.Nil)) ]
-                            IDef <<Data.List.Sorted.(::)>>
-                                 [ PatClause (IApp. IVar <<Data.List.Sorted.(::)>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.List.Sorted.(::) (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Data.List.Sorted.FirstGT>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar x
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar xs
-                                                                                                 $ IBindVar ^bnd^{conArg:1}))
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ IAutoApp (IApp. IVar Data.List.Sorted.(::)
-                                                                                                          $ IVar x
-                                                                                                          $ IVar xs)
-                                                                                                     (IVar ^bnd^{conArg:1})) ]))) ] ]
-         IDef <Data.List.Sorted.FirstGT>[]
-              [ PatClause (IApp. IVar <Data.List.Sorted.FirstGT>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.List.Sorted.FirstGT[] (dry fuel))
-                                                          $ (IApp. IVar <<Data.List.Sorted.E>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.List.Sorted.FirstGT[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Data.List.Sorted.E>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Data.List.Sorted.NE>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.List.Sorted.E>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Data.List.Sorted.SortedList
-                                                                           $ (ILam.  (MW ExplicitArg {arg:2} : IVar Data.List.Sorted.SortedList)
-                                                                                  => (IApp. IVar Data.List.Sorted.FirstGT
-                                                                                          $ IVar {arg:1}
-                                                                                          $ IVar {arg:2}))))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.List.Sorted.NE>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Data.List.Sorted.SortedList
-                                                                           $ (ILam.  (MW ExplicitArg {arg:2} : IVar Data.List.Sorted.SortedList)
-                                                                                  => (IApp. IVar Data.List.Sorted.FirstGT
-                                                                                          $ IVar {arg:1}
-                                                                                          $ IVar {arg:2}))))))))
-                            IDef <<Data.List.Sorted.E>>
-                                 [ PatClause (IApp. IVar <<Data.List.Sorted.E>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.List.Sorted.E (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                      $ Implicit True
-                                                                                      $ INamedApp (IVar Data.List.Sorted.E)
-                                                                                                  n
-                                                                                                  (IVar n))))))) ]
-                            IDef <<Data.List.Sorted.NE>>
-                                 [ PatClause (IApp. IVar <<Data.List.Sorted.NE>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.List.Sorted.NE (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Data.Nat.LTE>[0]
-                                                                               $ IVar ^outmost-fuel^
-                                                                               $ (IApp. IVar Prelude.Types.S
-                                                                                      $ IVar n))
-                                                                        $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                               => ICase (IVar {lamc:0})
-                                                                                        (Implicit False)
-                                                                                        [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                         $ IBindVar x
-                                                                                                         $ IBindVar ^bnd^{arg:3})
-                                                                                                    (IApp. IVar >>=
-                                                                                                         $ (IApp. IVar <Data.List.Sorted.FirstGT>[0]
-                                                                                                                $ IVar ^cons_fuel^
-                                                                                                                $ IVar x)
-                                                                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                                                                => ICase (IVar {lamc:0})
-                                                                                                                         (Implicit False)
-                                                                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                                          $ IBindVar xs
-                                                                                                                                          $ IBindVar prf)
-                                                                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                                                      f
-                                                                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                                                           $ Implicit True)
-                                                                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                                                 $ Implicit True
-                                                                                                                                                 $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                                                        $ Implicit True
-                                                                                                                                                        $ (IApp. INamedApp (INamedApp (INamedApp (INamedApp (IVar Data.List.Sorted.NE)
-                                                                                                                                                                                                            xs
-                                                                                                                                                                                                            (IVar xs))
-                                                                                                                                                                                                 x
-                                                                                                                                                                                                 (IVar x))
-                                                                                                                                                                                      prf
-                                                                                                                                                                                      (IVar prf))
-                                                                                                                                                                           n
-                                                                                                                                                                           (IVar n)
-                                                                                                                                                               $ IVar ^bnd^{arg:3})))) ])) ]))))) ] ]
-         IDef <Data.List.Sorted.FirstGT>[0]
-              [ PatClause (IApp. IVar <Data.List.Sorted.FirstGT>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.List.Sorted.FirstGT[0] (dry fuel))
-                                                          $ (IApp. IVar <<Data.List.Sorted.E>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<{arg:1}>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.List.Sorted.FirstGT[0] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Data.List.Sorted.E>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<{arg:1}>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Data.List.Sorted.NE>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<{arg:1}>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.List.Sorted.E>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Data.List.Sorted.SortedList
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Data.List.Sorted.SortedList)
-                                                                   => (IApp. IVar Data.List.Sorted.FirstGT
-                                                                           $ IVar {arg:1}
-                                                                           $ IVar {arg:2}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.List.Sorted.NE>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Data.List.Sorted.SortedList
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Data.List.Sorted.SortedList)
-                                                                   => (IApp. IVar Data.List.Sorted.FirstGT
-                                                                           $ IVar {arg:1}
-                                                                           $ IVar {arg:2}))))))
-                            IDef <<Data.List.Sorted.E>>
-                                 [ PatClause (IApp. IVar <<Data.List.Sorted.E>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.List.Sorted.E (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ INamedApp (IVar Data.List.Sorted.E)
-                                                                            n
-                                                                            (IVar n)))) ]
-                            IDef <<Data.List.Sorted.NE>>
-                                 [ PatClause (IApp. IVar <<Data.List.Sorted.NE>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.List.Sorted.NE (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Data.Nat.LTE>[0]
-                                                                $ IVar ^outmost-fuel^
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ IVar n))
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar x
-                                                                                          $ IBindVar ^bnd^{arg:3})
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar <Data.List.Sorted.FirstGT>[0]
-                                                                                                 $ IVar ^cons_fuel^
-                                                                                                 $ IVar x)
-                                                                                          $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                                                 => ICase (IVar {lamc:0})
-                                                                                                          (Implicit False)
-                                                                                                          [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                           $ IBindVar xs
-                                                                                                                           $ IBindVar prf)
-                                                                                                                      (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                                       f
-                                                                                                                                       (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                                            $ Implicit True)
-                                                                                                                           $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                                  $ Implicit True
-                                                                                                                                  $ (IApp. INamedApp (INamedApp (INamedApp (INamedApp (IVar Data.List.Sorted.NE)
-                                                                                                                                                                                      xs
-                                                                                                                                                                                      (IVar xs))
-                                                                                                                                                                           x
-                                                                                                                                                                           (IVar x))
-                                                                                                                                                                prf
-                                                                                                                                                                (IVar prf))
-                                                                                                                                                     n
-                                                                                                                                                     (IVar n)
-                                                                                                                                         $ IVar ^bnd^{arg:3}))) ])) ]))) ] ]
-         IDef <Data.Nat.LTE>[0]
-              [ PatClause (IApp. IVar <Data.Nat.LTE>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<n>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Nat.LTE[0] (dry fuel))
-                                                          $ (IApp. IVar <<Data.Nat.LTEZero>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<n>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Nat.LTE[0] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Data.Nat.LTEZero>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<n>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Data.Nat.LTESucc>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<n>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Nat.LTEZero>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg m : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Data.Nat.LTE
-                                                                           $ IVar n
-                                                                           $ IVar m))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Nat.LTESucc>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg m : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Data.Nat.LTE
-                                                                           $ IVar n
-                                                                           $ IVar m))))))
-                            IDef <<Data.Nat.LTEZero>>
-                                 [ PatClause (IApp. IVar <<Data.Nat.LTEZero>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IVar Prelude.Types.Z)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.Nat.LTEZero (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg right : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar Data.Nat.LTEZero)
-                                                                                           right
-                                                                                           (IVar right))))))
-                                 , PatClause (IApp. IVar <<Data.Nat.LTEZero>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<Data.Nat.LTESucc>>
-                                 [ PatClause (IApp. IVar <<Data.Nat.LTESucc>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar left))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.Nat.LTESucc (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Data.Nat.LTE>[0]
-                                                                $ IVar ^cons_fuel^
-                                                                $ IVar left)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar right
-                                                                                          $ IBindVar ^bnd^{arg:4})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ Implicit True
-                                                                                                 $ (IApp. INamedApp (INamedApp (IVar Data.Nat.LTESucc)
-                                                                                                                               right
-                                                                                                                               (IVar right))
-                                                                                                                    left
-                                                                                                                    (IVar left)
-                                                                                                        $ IVar ^bnd^{arg:4}))) ])))
-                                 , PatClause (IApp. IVar <<Data.Nat.LTESucc>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:5} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:5}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.List.Sorted.SortedList>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Data.List.Sorted.SortedList"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.List.Sorted.FirstGT>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Data.List.Sorted.SortedList"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.List.Sorted.SortedList")
+                                         .=> var "Data.List.Sorted.FirstGT" .$ var "{arg:1}" .$ var "{arg:2}")))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.List.Sorted.FirstGT>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Data.List.Sorted.SortedList"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.List.Sorted.SortedList")
+                                 .=> var "Data.List.Sorted.FirstGT" .$ var "{arg:1}" .$ var "{arg:2}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Nat.LTE>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "m") (var "Prelude.Types.Nat") .=> var "Data.Nat.LTE" .$ var "n" .$ var "m"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<Data.List.Sorted.SortedList>[]"
+              [    var "<Data.List.Sorted.SortedList>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.List.Sorted.Nil>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ var "Data.List.Sorted.SortedList"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.List.Sorted.(::)>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ var "Data.List.Sorted.SortedList"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Data.List.Sorted.Nil>>"
+                             [    var "<<Data.List.Sorted.Nil>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.Nil (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Data.List.Sorted.Nil")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Data.List.Sorted.(::)>>"
+                             [    var "<<Data.List.Sorted.(::)>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.(::) (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Data.List.Sorted.FirstGT>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "x"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "xs" .$ bindVar "^bnd^{conArg:1}")
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (var "Data.List.Sorted.(::)" .$ var "x" .$ var "xs" .@ var "^bnd^{conArg:1}")
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.SortedList[] (dry fuel)"))
+                                    .$ (var "<<Data.List.Sorted.Nil>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.SortedList[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<Data.List.Sorted.Nil>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Data.List.Sorted.(::)>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Data.List.Sorted.FirstGT>[]"
+              [    var "<Data.List.Sorted.FirstGT>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.List.Sorted.E>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Data.List.Sorted.SortedList"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.List.Sorted.SortedList")
+                                                        .=> var "Data.List.Sorted.FirstGT" .$ var "{arg:1}" .$ var "{arg:2}")))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.List.Sorted.NE>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Data.List.Sorted.SortedList"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.List.Sorted.SortedList")
+                                                        .=> var "Data.List.Sorted.FirstGT" .$ var "{arg:1}" .$ var "{arg:2}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Data.List.Sorted.E>>"
+                             [    var "<<Data.List.Sorted.E>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.E (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (   var "Builtin.DPair.MkDPair"
+                                                  .$ implicitTrue
+                                                  .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "Data.List.Sorted.E" .! ("n", var "n"))))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Data.List.Sorted.NE>>"
+                             [    var "<<Data.List.Sorted.NE>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.NE (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "<Data.Nat.LTE>[0]" .$ var "^outmost-fuel^" .$ (var "Prelude.Types.S" .$ var "n"))
+                                              .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                                  .=> iCase
+                                                        { sc = var "{lamc:0}"
+                                                        , ty = implicitFalse
+                                                        , clauses =
+                                                            [    var "Builtin.DPair.MkDPair" .$ bindVar "x" .$ bindVar "^bnd^{arg:3}"
+                                                              .=    var ">>="
+                                                                 .$ (var "<Data.List.Sorted.FirstGT>[0]" .$ var "^cons_fuel^" .$ var "x")
+                                                                 .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                                                     .=> iCase
+                                                                           { sc = var "{lamc:0}"
+                                                                           , ty = implicitFalse
+                                                                           , clauses =
+                                                                               [    var "Builtin.DPair.MkDPair" .$ bindVar "xs" .$ bindVar "prf"
+                                                                                 .=    var "Prelude.pure"
+                                                                                    .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                                    .$ (   var "Builtin.DPair.MkDPair"
+                                                                                        .$ implicitTrue
+                                                                                        .$ (   var "Builtin.DPair.MkDPair"
+                                                                                            .$ implicitTrue
+                                                                                            .$ (   var "Data.List.Sorted.NE"
+                                                                                                .! ("xs", var "xs")
+                                                                                                .! ("x", var "x")
+                                                                                                .! ("prf", var "prf")
+                                                                                                .! ("n", var "n")
+                                                                                                .$ var "^bnd^{arg:3}")))
+                                                                               ]
+                                                                           })
+                                                            ]
+                                                        })))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.FirstGT[] (dry fuel)"))
+                                    .$ (var "<<Data.List.Sorted.E>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.FirstGT[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Data.List.Sorted.E>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Data.List.Sorted.NE>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Data.List.Sorted.FirstGT>[0]"
+              [    var "<Data.List.Sorted.FirstGT>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.List.Sorted.E>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Data.List.Sorted.SortedList"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.List.Sorted.SortedList")
+                                                .=> var "Data.List.Sorted.FirstGT" .$ var "{arg:1}" .$ var "{arg:2}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.List.Sorted.NE>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Data.List.Sorted.SortedList"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.List.Sorted.SortedList")
+                                                .=> var "Data.List.Sorted.FirstGT" .$ var "{arg:1}" .$ var "{arg:2}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Data.List.Sorted.E>>"
+                             [    var "<<Data.List.Sorted.E>>" .$ bindVar "^cons_fuel^" .$ bindVar "n"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.E (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "Data.List.Sorted.E" .! ("n", var "n"))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Data.List.Sorted.NE>>"
+                             [    var "<<Data.List.Sorted.NE>>" .$ bindVar "^cons_fuel^" .$ bindVar "n"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.NE (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Data.Nat.LTE>[0]" .$ var "^outmost-fuel^" .$ (var "Prelude.Types.S" .$ var "n"))
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "x" .$ bindVar "^bnd^{arg:3}"
+                                                      .=    var ">>="
+                                                         .$ (var "<Data.List.Sorted.FirstGT>[0]" .$ var "^cons_fuel^" .$ var "x")
+                                                         .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                                             .=> iCase
+                                                                   { sc = var "{lamc:0}"
+                                                                   , ty = implicitFalse
+                                                                   , clauses =
+                                                                       [    var "Builtin.DPair.MkDPair" .$ bindVar "xs" .$ bindVar "prf"
+                                                                         .=    var "Prelude.pure"
+                                                                            .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                            .$ (   var "Builtin.DPair.MkDPair"
+                                                                                .$ implicitTrue
+                                                                                .$ (   var "Data.List.Sorted.NE"
+                                                                                    .! ("xs", var "xs")
+                                                                                    .! ("x", var "x")
+                                                                                    .! ("prf", var "prf")
+                                                                                    .! ("n", var "n")
+                                                                                    .$ var "^bnd^{arg:3}"))
+                                                                       ]
+                                                                   })
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.FirstGT[0] (dry fuel)"))
+                                    .$ (var "<<Data.List.Sorted.E>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.FirstGT[0] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<Data.List.Sorted.E>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Data.List.Sorted.NE>>" .$ var "^sub^fuel_arg^" .$ var "inter^<{arg:1}>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Data.Nat.LTE>[0]"
+              [    var "<Data.Nat.LTE>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<n>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Nat.LTEZero>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "m") (var "Prelude.Types.Nat")
+                                                .=> var "Data.Nat.LTE" .$ var "n" .$ var "m"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Nat.LTESucc>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "m") (var "Prelude.Types.Nat")
+                                                .=> var "Data.Nat.LTE" .$ var "n" .$ var "m"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Data.Nat.LTEZero>>"
+                             [    var "<<Data.Nat.LTEZero>>" .$ bindVar "^cons_fuel^" .$ var "Prelude.Types.Z"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.Nat.LTEZero (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "right") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "Data.Nat.LTEZero" .! ("right", var "right")))))
+                             , var "<<Data.Nat.LTEZero>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Data.Nat.LTESucc>>"
+                             [    var "<<Data.Nat.LTESucc>>" .$ bindVar "^cons_fuel^" .$ (var "Prelude.Types.S" .$ bindVar "left")
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.Nat.LTESucc (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Data.Nat.LTE>[0]" .$ var "^cons_fuel^" .$ var "left")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "right" .$ bindVar "^bnd^{arg:4}"
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (   var "Builtin.DPair.MkDPair"
+                                                             .$ implicitTrue
+                                                             .$ (   var "Data.Nat.LTESucc"
+                                                                 .! ("right", var "right")
+                                                                 .! ("left", var "left")
+                                                                 .$ var "^bnd^{arg:4}"))
+                                                    ]
+                                                }))
+                             , var "<<Data.Nat.LTESucc>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Nat.LTE[0] (dry fuel)"))
+                                    .$ (var "<<Data.Nat.LTEZero>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Nat.LTE[0] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<Data.Nat.LTEZero>>" .$ var "^fuel_arg^" .$ var "inter^<n>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Data.Nat.LTESucc>>" .$ var "^sub^fuel_arg^" .$ var "inter^<n>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:5}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:5}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<Data.List.Sorted.SortedList>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/pack.toml
+++ b/pack.toml
@@ -41,13 +41,3 @@ type = "local"
 path = "examples/sorted-list"
 ipkg = "sorted-list.ipkg"
 test = "tests/tests.ipkg"
-
-####################
-### Thirdparties ###
-####################
-
-[custom.all.elab-util]
-type   = "git"
-url    = "https://github.com/buzden/idris2-elab-util"
-commit = "f1fd467ea368e7a28ae280405e3bc1d41af6eec5"
-ipkg   = "elab-util.ipkg"

--- a/src/Deriving/DepTyCheck/Gen/Checked.idr
+++ b/src/Deriving/DepTyCheck/Gen/Checked.idr
@@ -18,8 +18,6 @@ import public Decidable.Equality
 import public Deriving.DepTyCheck.Gen.Derive
 import public Deriving.DepTyCheck.Util
 
-import public Language.Reflection.Types
-
 import public Syntax.WithProof
 
 %default total

--- a/src/Deriving/DepTyCheck/Gen/Core.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core.idr
@@ -4,9 +4,6 @@ module Deriving.DepTyCheck.Gen.Core
 import public Deriving.DepTyCheck.Gen.Core.ConsEntry
 import public Deriving.DepTyCheck.Util.Reflection
 
-import public Language.Reflection.Syntax
-import public Language.Reflection.Types
-
 %default total
 
 -----------------------------------------

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsEntry.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsEntry.idr
@@ -126,6 +126,6 @@ canonicConsBody sig name con = do
   pure $
     -- Happy case, given arguments conform out constructor's GADT indices
     [ deceqise (callCanonic sig name $ bindVar fuelArg) !(consGenExpr sig con .| fromList givenConArgs .| varStr fuelArg) ]
-    ++ if all isSimpleBindVar $ bindExprs empty then [] {- do not produce dead code if the happy case handles everything already -} else
+    ++ if all isSimpleBindVar $ bindExprs SortedSet.empty then [] {- do not produce dead code if the happy case handles everything already -} else
       -- The rest case, if given arguments do not conform to the current constructor then return empty generator
       [ callCanonic sig name implicitTrue (replicate _ implicitTrue) .= `(empty) ]

--- a/src/Deriving/DepTyCheck/Gen/Core/Util.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/Util.idr
@@ -9,6 +9,8 @@ import public Deriving.DepTyCheck.Gen.Derive
 
 %default total
 
+%hide Language.Reflection.Syntax.Arg.piInfo
+
 --- Utilities ---
 
 public export
@@ -117,7 +119,7 @@ analyseDeepConsApp ccdi freeNames = catch . isD where
       typeDeterminedArgs : forall m. Elaboration m => (con : Con) -> m $ Vect con.args.length ConsDetermInfo
       typeDeterminedArgs con = do
         let conArgNames = fromList $ mapI' con.args $ \idx, arg => (argName arg, idx)
-        determined <- fromMaybe [] <$> map fst <$> analyseDeepConsApp False (SortedSet.keySet conArgNames) con.type
+        determined <- fromMaybe [] . map fst <$> analyseDeepConsApp False (SortedSet.keySet conArgNames) con.type
         let determined = mapMaybe (flip lookup conArgNames) determined
         pure $ map cast $ presenceVect $ fromList determined
 

--- a/src/Deriving/DepTyCheck/Gen/Entry.idr
+++ b/src/Deriving/DepTyCheck/Gen/Entry.idr
@@ -142,7 +142,7 @@ checkTypeIsGen checkSide sig = do
     | _ :: _ => failAt targetTypeFC "All arguments of the target type must be different"
 
   -- check the given type info corresponds to the given type application, and convert a `List` to an appropriate `Vect`
-  let Yes targetTypeArgsLengthCorrect = targetType.args.length `decEq` targetTypeArgs.length
+  let Yes targetTypeArgsLengthCorrect = targetType.tyArgs.length `decEq` targetTypeArgs.length
     | No _ => fail "INTERNAL ERROR: unequal argument lists lengths: \{show targetTypeArgs.length} and \{show targetType.args.length}"
 
   ------------------------------------------------------------

--- a/src/Deriving/DepTyCheck/Util/Reflection.idr
+++ b/src/Deriving/DepTyCheck/Util/Reflection.idr
@@ -21,23 +21,32 @@ import public Deriving.DepTyCheck.Util.Fin
 import public Deriving.DepTyCheck.Util.Logging
 import public Deriving.DepTyCheck.Util.Syntax
 
+import public Language.Reflection.Compat
 import public Language.Reflection.TTImp
-import public Language.Reflection.Types
 import public Language.Reflection.Pretty
 
+import public Text.PrettyPrint.Bernardy
+
 %default total
+
+%hide Language.Reflection.Syntax.pi
+%hide Language.Reflection.Syntax.piAll
+%hide Language.Reflection.Syntax.unPi
 
 -----------------------
 --- Pretty-printing ---
 -----------------------
 
+LayoutOpts : LayoutOpts
+LayoutOpts = Opts 152 -- acceptable line length
+
 export
 Interpolation TTImp where
-  interpolate expr = show $ assert_total $ pretty {ann=Unit} expr
+  interpolate = render LayoutOpts . pretty
 
 export
 Interpolation Decl where
-  interpolate decl = show $ assert_total $ pretty {ann=Unit} decl
+  interpolate = render LayoutOpts . pretty
 
 export
 SingleLogPosition Con where
@@ -591,7 +600,7 @@ allInvolvedTypes minimalRig ti = toList <$> go [ti] empty where
       | [] => pure curr
     let next = insert c.name c curr
     args <- atRig M0 $ join <$> for c.args typesOfArg
-    cons <- join <$> for c.cons typesOfCon
+    cons <- join <$> for c.tyCons typesOfCon
     assert_total $ go (args ++ cons ++ left) next
     where
       atRig : Count -> m (List a) -> m (List a)

--- a/src/Deriving/DepTyCheck/Util/Syntax.idr
+++ b/src/Deriving/DepTyCheck/Util/Syntax.idr
@@ -5,8 +5,6 @@ import public Data.SortedMap.Dependent
 import public Data.SortedSet
 import public Data.Vect
 
-import public Language.Reflection.Types
-
 %default total
 
 ----------------------------
@@ -117,19 +115,3 @@ namespace Monad
   public export
   any : Monad n => (a -> n Bool) -> List a -> n Bool
   any = foldl (||) (pure False) .: map
-
--------------------------------------
---- Working around type inference ---
--------------------------------------
-
-public export
-argName : NamedArg -> Name
-argName = (.name)
-
-public export %inline
-(.tyArgs) : TypeInfo -> List NamedArg
-(.tyArgs) = args
-
-public export %inline
-(.conArgs) : Con -> List NamedArg
-(.conArgs) = args

--- a/src/Language/Reflection/Compat.idr
+++ b/src/Language/Reflection/Compat.idr
@@ -1,0 +1,150 @@
+||| This module contains copies of the pre-overhaul definitions of the `elab-util` library and/or code derived from these copies
+||| (the overhaul is this one: https://github.com/stefan-hoeck/idris2-elab-util/pull/56).
+||| This is done due to be able to migrate to the newer `elab-util` slowly, using both old and new definitions.
+|||
+||| This copying is done with the permission of Stefan Höck, the author and copyright holder of the `elab-util` library.
+module Language.Reflection.Compat
+
+import public Data.List1
+import public Data.String
+import public Data.Vect
+
+import public Language.Reflection
+import public Language.Reflection.Syntax
+import public Language.Reflection.Syntax.Ops
+
+%default total
+
+%hide Syntax.unPi
+
+--------------------------------------------------------------------------------
+--          Function Arguments
+--------------------------------------------------------------------------------
+
+public export
+record Arg (nameMandatory : Bool) where
+  constructor MkArg
+  count  : Count
+  piInfo : PiInfo TTImp
+  name   : if nameMandatory then Name else Maybe Name
+  type   : TTImp
+
+public export
+NamedArg : Type
+NamedArg = Arg True
+
+export
+namedArg : Elaboration m => Arg False -> m NamedArg
+namedArg (MkArg c p m t) =
+  maybe (genSym "x") pure m <&> \n => MkArg c p n t
+
+export
+arg : TTImp -> Arg False
+arg = MkArg MW ExplicitArg Nothing
+
+export
+erasedArg : TTImp -> Arg False
+erasedArg = MkArg M0 ExplicitArg Nothing
+
+export
+lambdaArg : Name -> Arg False
+lambdaArg n = MkArg MW ExplicitArg (Just n) implicitFalse
+
+||| Extracts the arguments from a function type.
+export
+unPi : TTImp -> (List $ Arg False, TTImp)
+unPi (IPi _ c p n at rt) = mapFst (MkArg c p n at ::) $ unPi rt
+unPi tpe                 = ([],tpe)
+
+||| Extracts properly named arguments from a function type.
+export
+unPiNamed : Elaboration m => TTImp -> m (List NamedArg, TTImp)
+unPiNamed v = let (args,rt') = unPi v
+               in (, rt') <$> traverse namedArg args
+
+--------------------------------------------------------------------------------
+--          Function Types
+--------------------------------------------------------------------------------
+
+||| Defines a function type.
+|||
+||| This passes the fields of `Arg` to `IPi EmptyFC`
+export
+pi : Arg False -> (retTy : TTImp) -> TTImp
+pi (MkArg c p n t) = IPi EmptyFC c p n t
+
+||| Defines a function type taking the given arguments.
+export
+piAll : TTImp -> List (Arg False) -> TTImp
+piAll res = foldr pi res
+
+--------------------------------------------------------------------------------
+--          General Types
+--------------------------------------------------------------------------------
+
+||| Constructor of a data type
+public export
+record Con where
+  constructor MkCon
+  name : Name
+  args : List NamedArg
+  type : TTImp
+
+||| Tries to lookup a constructor by name.
+export
+getCon : Elaboration m => Name -> m Con
+getCon n = do (n',tt)    <- lookupName n
+              (args,tpe) <- unPiNamed tt
+              pure $ MkCon n' args tpe
+
+||| Information about a data type
+|||
+||| @name : Name of the data type
+|||         Note: There is no guarantee that the name will be fully
+|||         qualified
+||| @args : Type arguments of the data type
+||| @cons : List of data constructors
+public export
+record TypeInfo where
+  constructor MkTypeInfo
+  name : Name
+  args : List NamedArg
+  cons : List Con
+
+||| Tries to get information about the data type specified
+||| by name. The name need not be fully qualified, but
+||| needs to be unambiguous.
+export
+getInfo' : Elaboration m => Name -> m TypeInfo
+getInfo' n = do
+  (n',tt)        <- lookupName n
+  (args,IType _) <- unPiNamed tt
+    | (_,_) => fail "Type declaration does not end in IType"
+  conNames       <- getCons n'
+  cons           <- traverse getCon conNames
+  pure (MkTypeInfo n' args cons)
+
+||| macro version of `getInfo'`
+export %macro
+getInfo : Name -> Elab TypeInfo
+getInfo = getInfo'
+
+-------------------------------------
+--- Working around type inference ---
+-------------------------------------
+
+public export
+argName : NamedArg -> Name
+argName = (.name)
+
+public export %inline
+(.tyArgs) : TypeInfo -> List NamedArg
+(.tyArgs) = args
+
+public export %inline
+(.tyCons) : TypeInfo -> List Con
+(.tyCons) = cons
+
+public export %inline
+(.conArgs) : Con -> List NamedArg
+(.conArgs) = args

--- a/src/Test/DepTyCheck/Gen/Coverage.idr
+++ b/src/Test/DepTyCheck/Gen/Coverage.idr
@@ -18,8 +18,6 @@ import public Deriving.DepTyCheck.Util.Logging
 import public Deriving.DepTyCheck.Util.Reflection
 
 import public Language.Reflection
-import public Language.Reflection.Types
-import public Language.Reflection.Syntax
 
 import Test.DepTyCheck.Gen
 

--- a/tests/derivation/infra/empty-body print 001/expected
+++ b/tests/derivation/infra/empty-body print 001/expected
@@ -3,16 +3,22 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty ()
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Builtin.Unit>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Builtin.Unit>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Builtin.Unit)))
-         IDef <Builtin.Unit>[]
-              [ PatClause (IApp. IVar <Builtin.Unit>[] $ Implicit True)
-                          (IVar empty) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Builtin.Unit>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                 })
+          , IDef emptyFC "<Builtin.Unit>[]" [var "<Builtin.Unit>[]" .$ implicitTrue .= var "empty"]
+          ]
+      , scope = var "<Builtin.Unit>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-body print 002/expected
+++ b/tests/derivation/infra/empty-body print 002/expected
@@ -3,28 +3,28 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (a : Type) -> Gen MaybeEmpty (Vect n a)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>
-                   $ IVar outer^<a>)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Vect.Vect>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg elem : IType)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Data.Vect.Vect
-                                         $ IVar len
-                                         $ IVar elem))))
-         IDef <Data.Vect.Vect>[0, 1]
-              [ PatClause (IApp. IVar <Data.Vect.Vect>[0, 1]
-                               $ Implicit True
-                               $ Implicit True
-                               $ Implicit True)
-                          (IVar empty) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Vect.Vect>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "elem") type
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "Data.Vect.Vect" .$ var "len" .$ var "elem")
+                 })
+          , IDef emptyFC "<Data.Vect.Vect>[0, 1]" [var "<Data.Vect.Vect>[0, 1]" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"]
+          ]
+      , scope = var "<Data.Vect.Vect>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<n>" .$ var "outer^<a>"
+      }
+

--- a/tests/derivation/infra/empty-body print 003/expected
+++ b/tests/derivation/infra/empty-body print 003/expected
@@ -3,20 +3,28 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty Nat)} -> Gen MaybeEmpty Bool
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<Prelude.Types.Nat>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                            -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                    $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                    $ IVar Prelude.Types.Nat))
-    => ILocal (IApp. IVar <Prelude.Basics.Bool>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Basics.Bool>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Basics.Bool)))
-         IDef <Prelude.Basics.Bool>[]
-              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[] $ Implicit True)
-                          (IVar empty) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<Prelude.Types.Nat>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Basics.Bool>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                 })
+          , IDef emptyFC "<Prelude.Basics.Bool>[]" [var "<Prelude.Basics.Bool>[]" .$ implicitTrue .= var "empty"]
+          ]
+      , scope = var "<Prelude.Basics.Bool>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-body print 004/expected
+++ b/tests/derivation/infra/empty-body print 004/expected
@@ -3,23 +3,24 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen MaybeEmpty (X n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:1}))))
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ Implicit True
-                               $ Implicit True)
-                          (IVar empty) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ (var "DerivedGen.X" .$ var "{arg:1}")
+                 })
+          , IDef emptyFC "<DerivedGen.X>[0]" [var "<DerivedGen.X>[0]" .$ implicitTrue .$ implicitTrue .= var "empty"]
+          ]
+      , scope = var "<DerivedGen.X>[0]" .$ var "^outmost-fuel^" .$ var "outer^<n>"
+      }
+

--- a/tests/derivation/infra/empty-body print 005/expected
+++ b/tests/derivation/infra/empty-body print 005/expected
@@ -3,20 +3,26 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** X n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:1}))))))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ Implicit True)
-                          (IVar empty) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat") .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                 })
+          , IDef emptyFC "<DerivedGen.X>[]" [var "<DerivedGen.X>[]" .$ implicitTrue .= var "empty"]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-body print 006/expected
+++ b/tests/derivation/infra/empty-body print 006/expected
@@ -3,27 +3,28 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Type) -> Gen MaybeEmpty (n : Nat ** Vect n a)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Vect.Vect>[1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg elem : IType)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Data.Vect.Vect
-                                                        $ IVar len
-                                                        $ IVar elem))))))
-         IDef <Data.Vect.Vect>[1]
-              [ PatClause (IApp. IVar <Data.Vect.Vect>[1]
-                               $ Implicit True
-                               $ Implicit True)
-                          (IVar empty) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Vect.Vect>[1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "elem") type
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat") .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem"))
+                 })
+          , IDef emptyFC "<Data.Vect.Vect>[1]" [var "<Data.Vect.Vect>[1]" .$ implicitTrue .$ implicitTrue .= var "empty"]
+          ]
+      , scope = var "<Data.Vect.Vect>[1]" .$ var "^outmost-fuel^" .$ var "outer^<a>"
+      }
+

--- a/tests/derivation/infra/empty-body print 007/expected
+++ b/tests/derivation/infra/empty-body print 007/expected
@@ -3,24 +3,30 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** (b : Bool ** X n b))
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Basics.Bool
-                                                        $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Basics.Bool)
-                                                               => (IApp. IVar DerivedGen.X
-                                                                       $ IVar {arg:1}
-                                                                       $ IVar {arg:2}))))))))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ Implicit True)
-                          (IVar empty) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Basics.Bool"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Basics.Bool")
+                                         .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                 })
+          , IDef emptyFC "<DerivedGen.X>[]" [var "<DerivedGen.X>[]" .$ implicitTrue .= var "empty"]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-body print 008/expected
+++ b/tests/derivation/infra/empty-body print 008/expected
@@ -3,24 +3,29 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** (a : Type ** Vect n a))
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Vect.Vect>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IType
-                                                        $ (ILam.  (MW ExplicitArg elem : IType)
-                                                               => (IApp. IVar Data.Vect.Vect
-                                                                       $ IVar len
-                                                                       $ IVar elem))))))))
-         IDef <Data.Vect.Vect>[]
-              [ PatClause (IApp. IVar <Data.Vect.Vect>[] $ Implicit True)
-                          (IVar empty) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Vect.Vect>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ type
+                                     .$ (MkArg MW ExplicitArg (Just "elem") type .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem")))
+                 })
+          , IDef emptyFC "<Data.Vect.Vect>[]" [var "<Data.Vect.Vect>[]" .$ implicitTrue .= var "empty"]
+          ]
+      , scope = var "<Data.Vect.Vect>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-cons print 001/expected
+++ b/tests/derivation/infra/empty-cons print 001/expected
@@ -3,32 +3,46 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty ()
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Builtin.Unit>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Builtin.Unit>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Builtin.Unit)))
-         IDef <Builtin.Unit>[]
-              [ PatClause (IApp. IVar <Builtin.Unit>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Builtin.Unit[] (non-recursive))
-                                       $ (IApp. IVar <<Builtin.MkUnit>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Builtin.MkUnit>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Builtin.Unit)))
-                            IDef <<Builtin.MkUnit>>
-                                 [ PatClause (IApp. IVar <<Builtin.MkUnit>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Builtin.Unit>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                 })
+          , IDef
+              emptyFC
+              "<Builtin.Unit>[]"
+              [    var "<Builtin.Unit>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Builtin.MkUnit>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                                })
+                         , IDef emptyFC "<<Builtin.MkUnit>>" [var "<<Builtin.MkUnit>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "Builtin.Unit[] (non-recursive)"))
+                         .$ (var "<<Builtin.MkUnit>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          ]
+      , scope = var "<Builtin.Unit>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-cons print 002/expected
+++ b/tests/derivation/infra/empty-cons print 002/expected
@@ -3,106 +3,103 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (a : Type) -> Gen MaybeEmpty (Vect n a)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>
-                   $ IVar outer^<a>)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Vect.Vect>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg elem : IType)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Data.Vect.Vect
-                                         $ IVar len
-                                         $ IVar elem))))
-         IDef <Data.Vect.Vect>[0, 1]
-              [ PatClause (IApp. IVar <Data.Vect.Vect>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<len>
-                               $ IBindVar inter^<elem>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Vect.Vect[0, 1] (dry fuel))
-                                                          $ (IApp. IVar <<Data.Vect.Nil>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<len>
-                                                                 $ IVar inter^<elem>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Vect.Vect[0, 1] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Data.Vect.Nil>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<len>
-                                                                                      $ IVar inter^<elem>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Data.Vect.(::)>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<len>
-                                                                                             $ IVar inter^<elem>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Vect.Nil>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg elem : IType)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Data.Vect.Vect
-                                                            $ IVar len
-                                                            $ IVar elem))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Vect.(::)>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg elem : IType)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Data.Vect.Vect
-                                                            $ IVar len
-                                                            $ IVar elem))))
-                            IDef <<Data.Vect.Nil>>
-                                 [ PatClause (IApp. IVar <<Data.Vect.Nil>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IVar Prelude.Types.Z
-                                                  $ IBindVar elem)
-                                             (IVar empty)
-                                 , PatClause (IApp. IVar <<Data.Vect.Nil>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<Data.Vect.(::)>>
-                                 [ PatClause (IApp. IVar <<Data.Vect.(::)>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar len)
-                                                  $ IBindVar elem)
-                                             (IVar empty)
-                                 , PatClause (IApp. IVar <<Data.Vect.(::)>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Vect.Vect>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "elem") type
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "Data.Vect.Vect" .$ var "len" .$ var "elem")
+                 })
+          , IDef
+              emptyFC
+              "<Data.Vect.Vect>[0, 1]"
+              [    var "<Data.Vect.Vect>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<len>" .$ bindVar "inter^<elem>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Vect.Nil>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "elem") type
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "Data.Vect.Vect" .$ var "len" .$ var "elem")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Vect.(::)>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "elem") type
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "Data.Vect.Vect" .$ var "len" .$ var "elem")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Data.Vect.Nil>>"
+                             [ var "<<Data.Vect.Nil>>" .$ bindVar "^cons_fuel^" .$ var "Prelude.Types.Z" .$ bindVar "elem" .= var "empty"
+                             , var "<<Data.Vect.Nil>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Data.Vect.(::)>>"
+                             [    var "<<Data.Vect.(::)>>" .$ bindVar "^cons_fuel^" .$ (var "Prelude.Types.S" .$ bindVar "len") .$ bindVar "elem"
+                               .= var "empty"
+                             , var "<<Data.Vect.(::)>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[0, 1] (dry fuel)"))
+                                    .$ (var "<<Data.Vect.Nil>>" .$ var "Data.Fuel.Dry" .$ var "inter^<len>" .$ var "inter^<elem>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[0, 1] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<Data.Vect.Nil>>" .$ var "^fuel_arg^" .$ var "inter^<len>" .$ var "inter^<elem>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Data.Vect.(::)>>" .$ var "^sub^fuel_arg^" .$ var "inter^<len>" .$ var "inter^<elem>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<Data.Vect.Vect>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<n>" .$ var "outer^<a>"
+      }
+

--- a/tests/derivation/infra/empty-cons print 003/expected
+++ b/tests/derivation/infra/empty-cons print 003/expected
@@ -3,57 +3,68 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty Nat)} -> Gen MaybeEmpty Bool
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<Prelude.Types.Nat>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                            -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                    $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                    $ IVar Prelude.Types.Nat))
-    => ILocal (IApp. IVar <Prelude.Basics.Bool>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Basics.Bool>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Basics.Bool)))
-         IDef <Prelude.Basics.Bool>[]
-              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Prelude.Basics.Bool[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<Prelude.Basics.False>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<Prelude.Basics.True>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.False>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.True>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IDef <<Prelude.Basics.False>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.False>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ]
-                            IDef <<Prelude.Basics.True>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.True>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<Prelude.Types.Nat>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Basics.Bool>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                 })
+          , IDef
+              emptyFC
+              "<Prelude.Basics.Bool>[]"
+              [    var "<Prelude.Basics.Bool>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Basics.False>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Basics.True>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                                })
+                         , IDef emptyFC "<<Prelude.Basics.False>>" [var "<<Prelude.Basics.False>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         , IDef emptyFC "<<Prelude.Basics.True>>" [var "<<Prelude.Basics.True>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "Prelude.Basics.Bool[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<Prelude.Basics.False>>" .$ var "^fuel_arg^")
+                                 .$ (var "::" .$ (var "<<Prelude.Basics.True>>" .$ var "^fuel_arg^") .$ var "Nil")))
+                     }
+              ]
+          ]
+      , scope = var "<Prelude.Basics.Bool>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-cons print 004/expected
+++ b/tests/derivation/infra/empty-cons print 004/expected
@@ -3,43 +3,51 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen MaybeEmpty (X n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:1}))))
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:1}))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ (var "DerivedGen.X" .$ var "{arg:1}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0]"
+              [    var "<DerivedGen.X>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:1}")
+                                })
+                         , IDef emptyFC "<<DerivedGen.MkX>>" [var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^" .$ bindVar "n" .= var "empty"]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0]" .$ var "^outmost-fuel^" .$ var "outer^<n>"
+      }
+

--- a/tests/derivation/infra/empty-cons print 005/expected
+++ b/tests/derivation/infra/empty-cons print 005/expected
@@ -3,40 +3,55 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** X n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:1}))))))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat") .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                                })
+                         , IDef emptyFC "<<DerivedGen.MkX>>" [var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-cons print 006/expected
+++ b/tests/derivation/infra/empty-cons print 006/expected
@@ -3,93 +3,96 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Type) -> Gen MaybeEmpty (n : Nat ** Vect n a)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Vect.Vect>[1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg elem : IType)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Data.Vect.Vect
-                                                        $ IVar len
-                                                        $ IVar elem))))))
-         IDef <Data.Vect.Vect>[1]
-              [ PatClause (IApp. IVar <Data.Vect.Vect>[1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<elem>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Vect.Vect[1] (dry fuel))
-                                                          $ (IApp. IVar <<Data.Vect.Nil>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<elem>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Vect.Vect[1] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Data.Vect.Nil>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<elem>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Data.Vect.(::)>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<elem>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Vect.Nil>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg elem : IType)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Data.Vect.Vect
-                                                                           $ IVar len
-                                                                           $ IVar elem))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Vect.(::)>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg elem : IType)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Data.Vect.Vect
-                                                                           $ IVar len
-                                                                           $ IVar elem))))))
-                            IDef <<Data.Vect.Nil>>
-                                 [ PatClause (IApp. IVar <<Data.Vect.Nil>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar elem)
-                                             (IVar empty) ]
-                            IDef <<Data.Vect.(::)>>
-                                 [ PatClause (IApp. IVar <<Data.Vect.(::)>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar elem)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Vect.Vect>[1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "elem") type
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat") .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem"))
+                 })
+          , IDef
+              emptyFC
+              "<Data.Vect.Vect>[1]"
+              [    var "<Data.Vect.Vect>[1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<elem>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Vect.Nil>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "elem") type
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                                                .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Vect.(::)>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "elem") type
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                                                .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem"))
+                                })
+                         , IDef emptyFC "<<Data.Vect.Nil>>" [var "<<Data.Vect.Nil>>" .$ bindVar "^cons_fuel^" .$ bindVar "elem" .= var "empty"]
+                         , IDef emptyFC "<<Data.Vect.(::)>>" [var "<<Data.Vect.(::)>>" .$ bindVar "^cons_fuel^" .$ bindVar "elem" .= var "empty"]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[1] (dry fuel)"))
+                                    .$ (var "<<Data.Vect.Nil>>" .$ var "Data.Fuel.Dry" .$ var "inter^<elem>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[1] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<Data.Vect.Nil>>" .$ var "^fuel_arg^" .$ var "inter^<elem>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Data.Vect.(::)>>" .$ var "^sub^fuel_arg^" .$ var "inter^<elem>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<Data.Vect.Vect>[1]" .$ var "^outmost-fuel^" .$ var "outer^<a>"
+      }
+

--- a/tests/derivation/infra/empty-cons print 007/expected
+++ b/tests/derivation/infra/empty-cons print 007/expected
@@ -3,76 +3,86 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** (b : Bool ** X n b))
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Basics.Bool
-                                                        $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Basics.Bool)
-                                                               => (IApp. IVar DerivedGen.X
-                                                                       $ IVar {arg:1}
-                                                                       $ IVar {arg:2}))))))))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.X0>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.X1>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X0>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Basics.Bool
-                                                                           $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Basics.Bool)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:1}
-                                                                                          $ IVar {arg:2}))))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X1>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Basics.Bool
-                                                                           $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Basics.Bool)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:1}
-                                                                                          $ IVar {arg:2}))))))))
-                            IDef <<DerivedGen.X0>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X0>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.X1>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X1>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Basics.Bool"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Basics.Bool")
+                                         .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X0>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Basics.Bool"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Basics.Bool")
+                                                        .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X1>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Basics.Bool"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Basics.Bool")
+                                                        .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                                })
+                         , IDef emptyFC "<<DerivedGen.X0>>" [var "<<DerivedGen.X0>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         , IDef emptyFC "<<DerivedGen.X1>>" [var "<<DerivedGen.X1>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.X0>>" .$ var "^fuel_arg^")
+                                 .$ (var "::" .$ (var "<<DerivedGen.X1>>" .$ var "^fuel_arg^") .$ var "Nil")))
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-cons print 008/expected
+++ b/tests/derivation/infra/empty-cons print 008/expected
@@ -3,89 +3,97 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** (a : Type ** Vect n a))
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Vect.Vect>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IType
-                                                        $ (ILam.  (MW ExplicitArg elem : IType)
-                                                               => (IApp. IVar Data.Vect.Vect
-                                                                       $ IVar len
-                                                                       $ IVar elem))))))))
-         IDef <Data.Vect.Vect>[]
-              [ PatClause (IApp. IVar <Data.Vect.Vect>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Vect.Vect[] (dry fuel))
-                                                          $ (IApp. IVar <<Data.Vect.Nil>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Vect.Vect[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Data.Vect.Nil>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Data.Vect.(::)>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Vect.Nil>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IType
-                                                                           $ (ILam.  (MW ExplicitArg elem : IType)
-                                                                                  => (IApp. IVar Data.Vect.Vect
-                                                                                          $ IVar len
-                                                                                          $ IVar elem))))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Vect.(::)>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IType
-                                                                           $ (ILam.  (MW ExplicitArg elem : IType)
-                                                                                  => (IApp. IVar Data.Vect.Vect
-                                                                                          $ IVar len
-                                                                                          $ IVar elem))))))))
-                            IDef <<Data.Vect.Nil>>
-                                 [ PatClause (IApp. IVar <<Data.Vect.Nil>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ]
-                            IDef <<Data.Vect.(::)>>
-                                 [ PatClause (IApp. IVar <<Data.Vect.(::)>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Vect.Vect>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ type
+                                     .$ (MkArg MW ExplicitArg (Just "elem") type .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem")))
+                 })
+          , IDef
+              emptyFC
+              "<Data.Vect.Vect>[]"
+              [    var "<Data.Vect.Vect>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Vect.Nil>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ type
+                                                    .$ (MkArg MW ExplicitArg (Just "elem") type .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem")))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Vect.(::)>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ type
+                                                    .$ (MkArg MW ExplicitArg (Just "elem") type .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem")))
+                                })
+                         , IDef emptyFC "<<Data.Vect.Nil>>" [var "<<Data.Vect.Nil>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         , IDef emptyFC "<<Data.Vect.(::)>>" [var "<<Data.Vect.(::)>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[] (dry fuel)"))
+                                    .$ (var "<<Data.Vect.Nil>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Data.Vect.Nil>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Data.Vect.(::)>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<Data.Vect.Vect>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-cons print 009/expected
+++ b/tests/derivation/infra/empty-cons print 009/expected
@@ -3,67 +3,76 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty X
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.X)))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.X0>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.X1>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ (IApp. IVar ::
-                                                                   $ (IApp. IVar <<DerivedGen.X2>>
-                                                                          $ IVar ^fuel_arg^)
-                                                                   $ IVar Nil))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X0>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.X)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X1>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.X)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X2>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.X)))
-                            IDef <<DerivedGen.X0>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X0>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.X1>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X1>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.X2>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X2>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X0>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X1>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X2>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                })
+                         , IDef emptyFC "<<DerivedGen.X0>>" [var "<<DerivedGen.X0>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         , IDef emptyFC "<<DerivedGen.X1>>" [var "<<DerivedGen.X1>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         , IDef emptyFC "<<DerivedGen.X2>>" [var "<<DerivedGen.X2>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.X0>>" .$ var "^fuel_arg^")
+                                 .$ (   var "::"
+                                     .$ (var "<<DerivedGen.X1>>" .$ var "^fuel_arg^")
+                                     .$ (var "::" .$ (var "<<DerivedGen.X2>>" .$ var "^fuel_arg^") .$ var "Nil"))))
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-cons print 010/expected
+++ b/tests/derivation/infra/empty-cons print 010/expected
@@ -3,90 +3,94 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty X
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.X)))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.X[] (dry fuel))
-                                                          $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                                             em
-                                                                             (IVar MaybeEmpty)
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar <<DerivedGen.X0>>
-                                                                               $ IVar Data.Fuel.Dry)
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar <<DerivedGen.X1>>
-                                                                                      $ IVar Data.Fuel.Dry)
-                                                                               $ IVar Nil))))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.X[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.X0>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ IVar Data.Nat.Pos.one
-                                                                                      $ (IApp. IVar <<DerivedGen.X1>>
-                                                                                             $ IVar ^fuel_arg^))
-                                                                               $ (IApp. IVar ::
-                                                                                      $ (IApp. IVar Builtin.MkPair
-                                                                                             $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                                    $ IVar ^sub^fuel_arg^)
-                                                                                             $ (IApp. IVar <<DerivedGen.X2>>
-                                                                                                    $ IVar ^sub^fuel_arg^))
-                                                                                      $ IVar Nil))))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X0>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.X)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X1>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.X)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X2>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.X)))
-                            IDef <<DerivedGen.X0>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X0>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.X1>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X1>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.X2>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X2>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X0>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X1>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X2>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                })
+                         , IDef emptyFC "<<DerivedGen.X0>>" [var "<<DerivedGen.X0>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         , IDef emptyFC "<<DerivedGen.X1>>" [var "<<DerivedGen.X1>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         , IDef emptyFC "<<DerivedGen.X2>>" [var "<<DerivedGen.X2>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (dry fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                                        .! ("em", var "MaybeEmpty")
+                                        .$ (   var "::"
+                                            .$ (var "<<DerivedGen.X0>>" .$ var "Data.Fuel.Dry")
+                                            .$ (var "::" .$ (var "<<DerivedGen.X1>>" .$ var "Data.Fuel.Dry") .$ var "Nil")))
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<DerivedGen.X0>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<DerivedGen.X1>>" .$ var "^fuel_arg^"))
+                                                .$ (   var "::"
+                                                    .$ (   var "Builtin.MkPair"
+                                                        .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                        .$ (var "<<DerivedGen.X2>>" .$ var "^sub^fuel_arg^"))
+                                                    .$ var "Nil"))))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-cons print 011/expected
+++ b/tests/derivation/infra/empty-cons print 011/expected
@@ -3,106 +3,110 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (a : Type ** X a)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IType
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IType)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:1}))))))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.X[] (dry fuel))
-                                                          $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                                             em
-                                                                             (IVar MaybeEmpty)
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar <<DerivedGen.X0>>
-                                                                               $ IVar Data.Fuel.Dry)
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar <<DerivedGen.X1>>
-                                                                                      $ IVar Data.Fuel.Dry)
-                                                                               $ IVar Nil))))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.X[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.X0>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ IVar Data.Nat.Pos.one
-                                                                                      $ (IApp. IVar <<DerivedGen.X1>>
-                                                                                             $ IVar ^fuel_arg^))
-                                                                               $ (IApp. IVar ::
-                                                                                      $ (IApp. IVar Builtin.MkPair
-                                                                                             $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                                    $ IVar ^sub^fuel_arg^)
-                                                                                             $ (IApp. IVar <<DerivedGen.X2>>
-                                                                                                    $ IVar ^sub^fuel_arg^))
-                                                                                      $ IVar Nil))))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X0>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IType
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IType)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:1}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X1>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IType
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IType)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:1}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.X2>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IType
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IType)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.X0>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X0>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.X1>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X1>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.X2>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.X2>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ type
+                             .$ (MkArg MW ExplicitArg (Just "{arg:1}") type .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X0>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ type
+                                            .$ (MkArg MW ExplicitArg (Just "{arg:1}") type .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X1>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ type
+                                            .$ (MkArg MW ExplicitArg (Just "{arg:1}") type .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.X2>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ type
+                                            .$ (MkArg MW ExplicitArg (Just "{arg:1}") type .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                                })
+                         , IDef emptyFC "<<DerivedGen.X0>>" [var "<<DerivedGen.X0>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         , IDef emptyFC "<<DerivedGen.X1>>" [var "<<DerivedGen.X1>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         , IDef emptyFC "<<DerivedGen.X2>>" [var "<<DerivedGen.X2>>" .$ bindVar "^cons_fuel^" .= var "empty"]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (dry fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                                        .! ("em", var "MaybeEmpty")
+                                        .$ (   var "::"
+                                            .$ (var "<<DerivedGen.X0>>" .$ var "Data.Fuel.Dry")
+                                            .$ (var "::" .$ (var "<<DerivedGen.X1>>" .$ var "Data.Fuel.Dry") .$ var "Nil")))
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<DerivedGen.X0>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<DerivedGen.X1>>" .$ var "^fuel_arg^"))
+                                                .$ (   var "::"
+                                                    .$ (   var "Builtin.MkPair"
+                                                        .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                        .$ (var "<<DerivedGen.X2>>" .$ var "^sub^fuel_arg^"))
+                                                    .$ var "Nil"))))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/empty-cons print 012/expected
+++ b/tests/derivation/infra/empty-cons print 012/expected
@@ -3,126 +3,131 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (m : Nat) -> Gen MaybeEmpty (X n m)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => (MW ExplicitArg outer^<m> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>
-                   $ IVar outer^<m>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}))))
-         IDef <DerivedGen.X>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0, 1] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.XE>>
-                                                            $ IVar ^fuel_arg^
-                                                            $ IVar inter^<{arg:1}>
-                                                            $ IVar inter^<{arg:2}>)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.XS>>
-                                                                   $ IVar ^fuel_arg^
-                                                                   $ IVar inter^<{arg:1}>
-                                                                   $ IVar inter^<{arg:2}>)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.XE>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.XS>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}))))
-                            IDef <<DerivedGen.XE>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.XE>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar n
-                                                   $ IBindVar to_be_deceqed^^n0)
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^n0
-                                                   $ IVar n)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<m>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0, 1]"
+              [    var "<DerivedGen.X>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>" .$ bindVar "inter^<{arg:2}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.XE>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.XS>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.XE>>"
+                             [ withClause
+                                 { lhs = var "<<DerivedGen.XE>>" .$ bindVar "^cons_fuel^" .$ bindVar "n" .$ bindVar "to_be_deceqed^^n0"
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [       var "<<DerivedGen.XE>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ bindVar "n"
+                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                       .= var "empty"
+                                     ,       var "<<DerivedGen.XE>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ bindVar "to_be_deceqed^^n0"
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.XS>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.XS>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ bindVar "n"
+                                     .$ (var "Prelude.Types.S" .$ bindVar "to_be_deceqed^^n0")
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [       var "<<DerivedGen.XS>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                       .= var "empty"
+                                     ,       var "<<DerivedGen.XS>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ (var "Prelude.Types.S" .$ bindVar "to_be_deceqed^^n0")
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             , var "<<DerivedGen.XS>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0, 1] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.XE>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
+                                 .$ (   var "::"
+                                     .$ (var "<<DerivedGen.XS>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
+                                     .$ var "Nil")))
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<n>" .$ var "outer^<m>"
+      }
 
-                                              []
-                                              [ PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ IBindVar n
-                                                               $ (IApp. IVar Prelude.Yes
-                                                                      $ IVar Builtin.Refl))
-                                                          (IVar empty)
-                                              , PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ IBindVar to_be_deceqed^^n0
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ] ]
-                            IDef <<DerivedGen.XS>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.XS>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar n
-                                                   $ (IApp. IVar Prelude.Types.S
-                                                          $ IBindVar to_be_deceqed^^n0))
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^n0
-                                                   $ IVar n)
-
-                                              []
-                                              [ PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ (IApp. IVar Prelude.Types.S
-                                                                      $ IBindVar n)
-                                                               $ (IApp. IVar Prelude.Yes
-                                                                      $ IVar Builtin.Refl))
-                                                          (IVar empty)
-                                              , PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ (IApp. IVar Prelude.Types.S
-                                                                      $ IBindVar to_be_deceqed^^n0)
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ]
-                                 , PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]

--- a/tests/derivation/infra/empty-cons print 013/expected
+++ b/tests/derivation/infra/empty-cons print 013/expected
@@ -3,218 +3,222 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (m : Nat) -> (p : Nat) -> (k : Nat) -> Gen MaybeEmpty (X n m p k)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => (MW ExplicitArg outer^<m> : Implicit True)
-    => (MW ExplicitArg outer^<p> : Implicit True)
-    => (MW ExplicitArg outer^<k> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>
-                   $ IVar outer^<m>
-                   $ IVar outer^<p>
-                   $ IVar outer^<k>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0, 1, 2, 3]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}
-                                         $ IVar {arg:3}
-                                         $ IVar {arg:4}))))
-         IDef <DerivedGen.X>[0, 1, 2, 3]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>
-                               $ IBindVar inter^<{arg:3}>
-                               $ IBindVar inter^<{arg:4}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0, 1, 2, 3] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.XE>>
-                                                            $ IVar ^fuel_arg^
-                                                            $ IVar inter^<{arg:1}>
-                                                            $ IVar inter^<{arg:2}>
-                                                            $ IVar inter^<{arg:3}>
-                                                            $ IVar inter^<{arg:4}>)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.XS>>
-                                                                   $ IVar ^fuel_arg^
-                                                                   $ IVar inter^<{arg:1}>
-                                                                   $ IVar inter^<{arg:2}>
-                                                                   $ IVar inter^<{arg:3}>
-                                                                   $ IVar inter^<{arg:4}>)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.XE>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}
-                                                            $ IVar {arg:3}
-                                                            $ IVar {arg:4}))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.XS>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}
-                                                            $ IVar {arg:3}
-                                                            $ IVar {arg:4}))))
-                            IDef <<DerivedGen.XE>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.XE>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar n
-                                                   $ (IApp. IVar Prelude.Types.S
-                                                          $ IBindVar to_be_deceqed^^n0)
-                                                   $ IBindVar m
-                                                   $ IBindVar to_be_deceqed^^n1)
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^n0
-                                                   $ IVar n)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<m>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<p>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<k>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0, 1, 2, 3]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}" .$ var "{arg:3}" .$ var "{arg:4}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0, 1, 2, 3]"
+              [       var "<DerivedGen.X>[0, 1, 2, 3]"
+                   .$ bindVar "^fuel_arg^"
+                   .$ bindVar "inter^<{arg:1}>"
+                   .$ bindVar "inter^<{arg:2}>"
+                   .$ bindVar "inter^<{arg:3}>"
+                   .$ bindVar "inter^<{arg:4}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.XE>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}" .$ var "{arg:3}" .$ var "{arg:4}")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.XS>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}" .$ var "{arg:3}" .$ var "{arg:4}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.XE>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.XE>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ bindVar "n"
+                                     .$ (var "Prelude.Types.S" .$ bindVar "to_be_deceqed^^n0")
+                                     .$ bindVar "m"
+                                     .$ bindVar "to_be_deceqed^^n1"
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.XE>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ bindVar "n"
+                                             .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                             .$ bindVar "m"
+                                             .$ bindVar "to_be_deceqed^^n1"
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n1" .$ var "n"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [       var "<<DerivedGen.XE>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                                  .$ bindVar "m"
+                                                  .$ bindVar "n"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                               .= var "empty"
+                                             ,       var "<<DerivedGen.XE>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                                  .$ bindVar "m"
+                                                  .$ bindVar "to_be_deceqed^^n1"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.XE>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ (var "Prelude.Types.S" .$ bindVar "to_be_deceqed^^n0")
+                                          .$ bindVar "m"
+                                          .$ bindVar "to_be_deceqed^^n1"
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             , var "<<DerivedGen.XE>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.XS>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.XS>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ bindVar "n"
+                                     .$ bindVar "to_be_deceqed^^n0"
+                                     .$ bindVar "m"
+                                     .$ bindVar "to_be_deceqed^^m1"
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^m1" .$ var "m"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.XS>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ bindVar "n"
+                                             .$ bindVar "to_be_deceqed^^n0"
+                                             .$ bindVar "m"
+                                             .$ bindVar "m"
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [       var "<<DerivedGen.XS>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "m"
+                                                  .$ bindVar "m"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                               .= var "empty"
+                                             ,       var "<<DerivedGen.XS>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "to_be_deceqed^^n0"
+                                                  .$ bindVar "m"
+                                                  .$ bindVar "m"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.XS>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ bindVar "to_be_deceqed^^n0"
+                                          .$ bindVar "m"
+                                          .$ bindVar "to_be_deceqed^^m1"
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0, 1, 2, 3] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (   var "<<DerivedGen.XE>>"
+                                     .$ var "^fuel_arg^"
+                                     .$ var "inter^<{arg:1}>"
+                                     .$ var "inter^<{arg:2}>"
+                                     .$ var "inter^<{arg:3}>"
+                                     .$ var "inter^<{arg:4}>")
+                                 .$ (   var "::"
+                                     .$ (   var "<<DerivedGen.XS>>"
+                                         .$ var "^fuel_arg^"
+                                         .$ var "inter^<{arg:1}>"
+                                         .$ var "inter^<{arg:2}>"
+                                         .$ var "inter^<{arg:3}>"
+                                         .$ var "inter^<{arg:4}>")
+                                     .$ var "Nil")))
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0, 1, 2, 3]" .$ var "^outmost-fuel^" .$ var "outer^<n>" .$ var "outer^<m>" .$ var "outer^<p>" .$ var "outer^<k>"
+      }
 
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.XE>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ IBindVar n
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ IBindVar n)
-                                                                $ IBindVar m
-                                                                $ IBindVar to_be_deceqed^^n1
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^n1
-                                                                $ IVar n)
-
-                                                           []
-                                                           [ PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ (IApp. IVar Prelude.Types.S
-                                                                                   $ IBindVar n)
-                                                                            $ IBindVar m
-                                                                            $ IBindVar n
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl))
-                                                                       (IVar empty)
-                                                           , PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ (IApp. IVar Prelude.Types.S
-                                                                                   $ IBindVar n)
-                                                                            $ IBindVar m
-                                                                            $ IBindVar to_be_deceqed^^n1
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ (IApp. IVar Prelude.Types.S
-                                                                      $ IBindVar to_be_deceqed^^n0)
-                                                               $ IBindVar m
-                                                               $ IBindVar to_be_deceqed^^n1
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ]
-                                 , PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.XS>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.XS>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar n
-                                                   $ IBindVar to_be_deceqed^^n0
-                                                   $ IBindVar m
-                                                   $ IBindVar to_be_deceqed^^m1)
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^m1
-                                                   $ IVar m)
-
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.XS>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ IBindVar n
-                                                                $ IBindVar to_be_deceqed^^n0
-                                                                $ IBindVar m
-                                                                $ IBindVar m
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^n0
-                                                                $ IVar n)
-
-                                                           []
-                                                           [ PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ IBindVar n
-                                                                            $ IBindVar m
-                                                                            $ IBindVar m
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl))
-                                                                       (IVar empty)
-                                                           , PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ IBindVar to_be_deceqed^^n0
-                                                                            $ IBindVar m
-                                                                            $ IBindVar m
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ IBindVar to_be_deceqed^^n0
-                                                               $ IBindVar m
-                                                               $ IBindVar to_be_deceqed^^m1
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ] ] ]

--- a/tests/derivation/infra/empty-cons print 014/expected
+++ b/tests/derivation/infra/empty-cons print 014/expected
@@ -3,222 +3,228 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (m : Nat) -> (p : Nat) -> (k : Nat) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty String)} -> Gen MaybeEmpty (X n m p k)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => (MW ExplicitArg outer^<m> : Implicit True)
-    => (MW ExplicitArg outer^<p> : Implicit True)
-    => (MW ExplicitArg outer^<k> : Implicit True)
-    => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                        -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                $ IPrimVal String))
-    => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>
-                   $ IVar outer^<m>
-                   $ IVar outer^<p>
-                   $ IVar outer^<k>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0, 1, 2, 3]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:5} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:2}
-                                         $ IVar {arg:3}
-                                         $ IVar {arg:4}
-                                         $ IVar {arg:5}))))
-         IDef <DerivedGen.X>[0, 1, 2, 3]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:2}>
-                               $ IBindVar inter^<{arg:3}>
-                               $ IBindVar inter^<{arg:4}>
-                               $ IBindVar inter^<{arg:5}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0, 1, 2, 3] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.XE>>
-                                                            $ IVar ^fuel_arg^
-                                                            $ IVar inter^<{arg:2}>
-                                                            $ IVar inter^<{arg:3}>
-                                                            $ IVar inter^<{arg:4}>
-                                                            $ IVar inter^<{arg:5}>)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.XS>>
-                                                                   $ IVar ^fuel_arg^
-                                                                   $ IVar inter^<{arg:2}>
-                                                                   $ IVar inter^<{arg:3}>
-                                                                   $ IVar inter^<{arg:4}>
-                                                                   $ IVar inter^<{arg:5}>)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.XE>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:5} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:2}
-                                                            $ IVar {arg:3}
-                                                            $ IVar {arg:4}
-                                                            $ IVar {arg:5}))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.XS>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:5} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:2}
-                                                            $ IVar {arg:3}
-                                                            $ IVar {arg:4}
-                                                            $ IVar {arg:5}))))
-                            IDef <<DerivedGen.XE>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.XE>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar n
-                                                   $ (IApp. IVar Prelude.Types.S
-                                                          $ IBindVar to_be_deceqed^^n0)
-                                                   $ IBindVar m
-                                                   $ IBindVar to_be_deceqed^^n1)
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^n0
-                                                   $ IVar n)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<m>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<p>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<k>") implicitTrue
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<^prim^.String>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ primVal (PrT StringType))
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0, 1, 2, 3]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:5}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.X" .$ var "{arg:2}" .$ var "{arg:3}" .$ var "{arg:4}" .$ var "{arg:5}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0, 1, 2, 3]"
+              [       var "<DerivedGen.X>[0, 1, 2, 3]"
+                   .$ bindVar "^fuel_arg^"
+                   .$ bindVar "inter^<{arg:2}>"
+                   .$ bindVar "inter^<{arg:3}>"
+                   .$ bindVar "inter^<{arg:4}>"
+                   .$ bindVar "inter^<{arg:5}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.XE>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:5}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:2}" .$ var "{arg:3}" .$ var "{arg:4}" .$ var "{arg:5}")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.XS>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:5}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:2}" .$ var "{arg:3}" .$ var "{arg:4}" .$ var "{arg:5}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.XE>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.XE>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ bindVar "n"
+                                     .$ (var "Prelude.Types.S" .$ bindVar "to_be_deceqed^^n0")
+                                     .$ bindVar "m"
+                                     .$ bindVar "to_be_deceqed^^n1"
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.XE>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ bindVar "n"
+                                             .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                             .$ bindVar "m"
+                                             .$ bindVar "to_be_deceqed^^n1"
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n1" .$ var "n"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [       var "<<DerivedGen.XE>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                                  .$ bindVar "m"
+                                                  .$ bindVar "n"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                               .= var "empty"
+                                             ,       var "<<DerivedGen.XE>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                                  .$ bindVar "m"
+                                                  .$ bindVar "to_be_deceqed^^n1"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.XE>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ (var "Prelude.Types.S" .$ bindVar "to_be_deceqed^^n0")
+                                          .$ bindVar "m"
+                                          .$ bindVar "to_be_deceqed^^n1"
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             , var "<<DerivedGen.XE>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.XS>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.XS>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ bindVar "n"
+                                     .$ bindVar "to_be_deceqed^^n0"
+                                     .$ bindVar "m"
+                                     .$ bindVar "to_be_deceqed^^m1"
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^m1" .$ var "m"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.XS>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ bindVar "n"
+                                             .$ bindVar "to_be_deceqed^^n0"
+                                             .$ bindVar "m"
+                                             .$ bindVar "m"
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [       var "<<DerivedGen.XS>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "m"
+                                                  .$ bindVar "m"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                               .= var "empty"
+                                             ,       var "<<DerivedGen.XS>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "to_be_deceqed^^n0"
+                                                  .$ bindVar "m"
+                                                  .$ bindVar "m"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.XS>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ bindVar "to_be_deceqed^^n0"
+                                          .$ bindVar "m"
+                                          .$ bindVar "to_be_deceqed^^m1"
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0, 1, 2, 3] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (   var "<<DerivedGen.XE>>"
+                                     .$ var "^fuel_arg^"
+                                     .$ var "inter^<{arg:2}>"
+                                     .$ var "inter^<{arg:3}>"
+                                     .$ var "inter^<{arg:4}>"
+                                     .$ var "inter^<{arg:5}>")
+                                 .$ (   var "::"
+                                     .$ (   var "<<DerivedGen.XS>>"
+                                         .$ var "^fuel_arg^"
+                                         .$ var "inter^<{arg:2}>"
+                                         .$ var "inter^<{arg:3}>"
+                                         .$ var "inter^<{arg:4}>"
+                                         .$ var "inter^<{arg:5}>")
+                                     .$ var "Nil")))
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0, 1, 2, 3]" .$ var "^outmost-fuel^" .$ var "outer^<n>" .$ var "outer^<m>" .$ var "outer^<p>" .$ var "outer^<k>"
+      }
 
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.XE>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ IBindVar n
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ IBindVar n)
-                                                                $ IBindVar m
-                                                                $ IBindVar to_be_deceqed^^n1
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^n1
-                                                                $ IVar n)
-
-                                                           []
-                                                           [ PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ (IApp. IVar Prelude.Types.S
-                                                                                   $ IBindVar n)
-                                                                            $ IBindVar m
-                                                                            $ IBindVar n
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl))
-                                                                       (IVar empty)
-                                                           , PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ (IApp. IVar Prelude.Types.S
-                                                                                   $ IBindVar n)
-                                                                            $ IBindVar m
-                                                                            $ IBindVar to_be_deceqed^^n1
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ (IApp. IVar Prelude.Types.S
-                                                                      $ IBindVar to_be_deceqed^^n0)
-                                                               $ IBindVar m
-                                                               $ IBindVar to_be_deceqed^^n1
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ]
-                                 , PatClause (IApp. IVar <<DerivedGen.XE>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.XS>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.XS>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar n
-                                                   $ IBindVar to_be_deceqed^^n0
-                                                   $ IBindVar m
-                                                   $ IBindVar to_be_deceqed^^m1)
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^m1
-                                                   $ IVar m)
-
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.XS>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ IBindVar n
-                                                                $ IBindVar to_be_deceqed^^n0
-                                                                $ IBindVar m
-                                                                $ IBindVar m
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^n0
-                                                                $ IVar n)
-
-                                                           []
-                                                           [ PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ IBindVar n
-                                                                            $ IBindVar m
-                                                                            $ IBindVar m
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl))
-                                                                       (IVar empty)
-                                                           , PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ IBindVar to_be_deceqed^^n0
-                                                                            $ IBindVar m
-                                                                            $ IBindVar m
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.XS>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ IBindVar to_be_deceqed^^n0
-                                                               $ IBindVar m
-                                                               $ IBindVar to_be_deceqed^^m1
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ] ] ]

--- a/tests/derivation/infra/ext print 001/expected
+++ b/tests/derivation/infra/ext print 001/expected
@@ -3,23 +3,31 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty String)} -> Gen MaybeEmpty XS
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                        -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                $ IPrimVal String))
-    => ILocal (IApp. IVar <AlternativeCore.XS>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <AlternativeCore.XS>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar AlternativeCore.XS)))
-         IDef <AlternativeCore.XS>[]
-              [ PatClause (IApp. IVar <AlternativeCore.XS>[] $ IBindVar fuel)
-                          (IApp. IVar <$>
-                               $ IVar MkXS
-                               $ (IApp. IVar external^<^prim^.String>[]
-                                      $ IVar ^outmost-fuel^)) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<^prim^.String>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ primVal (PrT StringType))
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<AlternativeCore.XS>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "AlternativeCore.XS"
+                 })
+          , IDef
+              emptyFC
+              "<AlternativeCore.XS>[]"
+              [var "<AlternativeCore.XS>[]" .$ bindVar "fuel" .= var "<$>" .$ var "MkXS" .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^")]
+          ]
+      , scope = var "<AlternativeCore.XS>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/ext print 002/expected
+++ b/tests/derivation/infra/ext print 002/expected
@@ -3,26 +3,35 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty String)} -> Gen MaybeEmpty XSS
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                        -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                $ IPrimVal String))
-    => ILocal (IApp. IVar <AlternativeCore.XSS>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <AlternativeCore.XSS>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar AlternativeCore.XSS)))
-         IDef <AlternativeCore.XSS>[]
-              [ PatClause (IApp. IVar <AlternativeCore.XSS>[] $ IBindVar fuel)
-                          (IApp. IVar <*>
-                               $ (IApp. IVar <$>
-                                      $ IVar MkXSS
-                                      $ (IApp. IVar external^<^prim^.String>[]
-                                             $ IVar ^outmost-fuel^))
-                               $ (IApp. IVar external^<^prim^.String>[]
-                                      $ IVar ^outmost-fuel^)) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<^prim^.String>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ primVal (PrT StringType))
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<AlternativeCore.XSS>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "AlternativeCore.XSS"
+                 })
+          , IDef
+              emptyFC
+              "<AlternativeCore.XSS>[]"
+              [    var "<AlternativeCore.XSS>[]" .$ bindVar "fuel"
+                .=    var "<*>"
+                   .$ (var "<$>" .$ var "MkXSS" .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^"))
+                   .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^")
+              ]
+          ]
+      , scope = var "<AlternativeCore.XSS>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/ext print 003/expected
+++ b/tests/derivation/infra/ext print 003/expected
@@ -3,30 +3,41 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty String)} -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty Nat)} -> Gen MaybeEmpty XSN
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                        -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                $ IPrimVal String))
-    => (MW AutoImplicit external^<Prelude.Types.Nat>[] : IPi.  (MW ExplicitArg {arg:2} : IVar Data.Fuel.Fuel)
-                                                            -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                    $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                    $ IVar Prelude.Types.Nat))
-    => ILocal (IApp. IVar <AlternativeCore.XSN>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <AlternativeCore.XSN>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar AlternativeCore.XSN)))
-         IDef <AlternativeCore.XSN>[]
-              [ PatClause (IApp. IVar <AlternativeCore.XSN>[] $ IBindVar fuel)
-                          (IApp. IVar <*>
-                               $ (IApp. IVar <$>
-                                      $ IVar MkXSN
-                                      $ (IApp. IVar external^<^prim^.String>[]
-                                             $ IVar ^outmost-fuel^))
-                               $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                      $ IVar ^outmost-fuel^)) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<^prim^.String>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ primVal (PrT StringType))
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<Prelude.Types.Nat>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<AlternativeCore.XSN>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "AlternativeCore.XSN"
+                 })
+          , IDef
+              emptyFC
+              "<AlternativeCore.XSN>[]"
+              [    var "<AlternativeCore.XSN>[]" .$ bindVar "fuel"
+                .=    var "<*>"
+                   .$ (var "<$>" .$ var "MkXSN" .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^"))
+                   .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+              ]
+          ]
+      , scope = var "<AlternativeCore.XSN>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/ext print 004/expected
+++ b/tests/derivation/infra/ext print 004/expected
@@ -3,50 +3,58 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty String)} -> (n : Nat) -> Gen MaybeEmpty (X'S n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                        -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                $ IPrimVal String))
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => ILocal (IApp. IVar <AlternativeCore.X'S>[0]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>)
-         IClaim MW
-                Export
-                []
-                (MkTy <AlternativeCore.X'S>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar AlternativeCore.X'S
-                                         $ IVar {arg:2}))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <AlternativeCore.X'S>[0]
-              [ PatClause (IApp. IVar <AlternativeCore.X'S>[0]
-                               $ IBindVar fuel
-                               $ Implicit True)
-                          (IApp. IVar <*>
-                               $ (IApp. IVar <$>
-                                      $ IVar MkXSN
-                                      $ (IApp. IVar external^<^prim^.String>[]
-                                             $ IVar ^outmost-fuel^))
-                               $ (IApp. IVar <Prelude.Types.Nat>[]
-                                      $ IVar fuel)) ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[] $ IBindVar fuel)
-                          (IApp. IVar <*>
-                               $ (IApp. IVar <$>
-                                      $ IVar MkXSN
-                                      $ (IApp. IVar external^<^prim^.String>[]
-                                             $ IVar ^outmost-fuel^))
-                               $ (IApp. IVar <Prelude.Types.Nat>[]
-                                      $ IVar fuel)) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<^prim^.String>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ primVal (PrT StringType))
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<AlternativeCore.X'S>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "AlternativeCore.X'S" .$ var "{arg:2}")
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<AlternativeCore.X'S>[0]"
+              [    var "<AlternativeCore.X'S>[0]" .$ bindVar "fuel" .$ implicitTrue
+                .=    var "<*>"
+                   .$ (var "<$>" .$ var "MkXSN" .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^"))
+                   .$ (var "<Prelude.Types.Nat>[]" .$ var "fuel")
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "fuel"
+                .=    var "<*>"
+                   .$ (var "<$>" .$ var "MkXSN" .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^"))
+                   .$ (var "<Prelude.Types.Nat>[]" .$ var "fuel")
+              ]
+          ]
+      , scope = var "<AlternativeCore.X'S>[0]" .$ var "^outmost-fuel^" .$ var "outer^<n>"
+      }
+

--- a/tests/derivation/infra/self print 001/expected
+++ b/tests/derivation/infra/self print 001/expected
@@ -3,18 +3,27 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty ()
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Builtin.Unit>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Builtin.Unit>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Builtin.Unit)))
-         IDef <Builtin.Unit>[]
-              [ PatClause (IApp. IVar <Builtin.Unit>[] $ IVar Dry) (IVar empty)
-              , PatClause (IApp. IVar <Builtin.Unit>[]
-                               $ (IApp. IVar More $ IBindVar fuel))
-                          (IApp. IVar <Builtin.Unit>[] $ IVar fuel) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Builtin.Unit>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                 })
+          , IDef
+              emptyFC
+              "<Builtin.Unit>[]"
+              [ var "<Builtin.Unit>[]" .$ var "Dry" .= var "empty"
+              , var "<Builtin.Unit>[]" .$ (var "More" .$ bindVar "fuel") .= var "<Builtin.Unit>[]" .$ var "fuel"
+              ]
+          ]
+      , scope = var "<Builtin.Unit>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/self print 002/expected
+++ b/tests/derivation/infra/self print 002/expected
@@ -3,36 +3,34 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (a : Type) -> Gen MaybeEmpty (Vect n a)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>
-                   $ IVar outer^<a>)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Vect.Vect>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg elem : IType)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Data.Vect.Vect
-                                         $ IVar len
-                                         $ IVar elem))))
-         IDef <Data.Vect.Vect>[0, 1]
-              [ PatClause (IApp. IVar <Data.Vect.Vect>[0, 1]
-                               $ IVar Dry
-                               $ Implicit True
-                               $ Implicit True)
-                          (IVar empty)
-              , PatClause (IApp. IVar <Data.Vect.Vect>[0, 1]
-                               $ (IApp. IVar More $ IBindVar fuel)
-                               $ IBindVar 0
-                               $ IBindVar 1)
-                          (IApp. IVar <Data.Vect.Vect>[0, 1]
-                               $ IVar fuel
-                               $ IVar 0
-                               $ IVar 1) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Vect.Vect>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "elem") type
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "Data.Vect.Vect" .$ var "len" .$ var "elem")
+                 })
+          , IDef
+              emptyFC
+              "<Data.Vect.Vect>[0, 1]"
+              [ var "<Data.Vect.Vect>[0, 1]" .$ var "Dry" .$ implicitTrue .$ implicitTrue .= var "empty"
+              ,    var "<Data.Vect.Vect>[0, 1]" .$ (var "More" .$ bindVar "fuel") .$ bindVar "0" .$ bindVar "1"
+                .= var "<Data.Vect.Vect>[0, 1]" .$ var "fuel" .$ var "0" .$ var "1"
+              ]
+          ]
+      , scope = var "<Data.Vect.Vect>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<n>" .$ var "outer^<a>"
+      }
+

--- a/tests/derivation/infra/self print 003/expected
+++ b/tests/derivation/infra/self print 003/expected
@@ -3,23 +3,33 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty Nat)} -> Gen MaybeEmpty Bool
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<Prelude.Types.Nat>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                            -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                    $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                    $ IVar Prelude.Types.Nat))
-    => ILocal (IApp. IVar <Prelude.Basics.Bool>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Basics.Bool>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Basics.Bool)))
-         IDef <Prelude.Basics.Bool>[]
-              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[] $ IVar Dry)
-                          (IVar empty)
-              , PatClause (IApp. IVar <Prelude.Basics.Bool>[]
-                               $ (IApp. IVar More $ IBindVar fuel))
-                          (IApp. IVar <Prelude.Basics.Bool>[] $ IVar fuel) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<Prelude.Types.Nat>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Basics.Bool>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                 })
+          , IDef
+              emptyFC
+              "<Prelude.Basics.Bool>[]"
+              [ var "<Prelude.Basics.Bool>[]" .$ var "Dry" .= var "empty"
+              , var "<Prelude.Basics.Bool>[]" .$ (var "More" .$ bindVar "fuel") .= var "<Prelude.Basics.Bool>[]" .$ var "fuel"
+              ]
+          ]
+      , scope = var "<Prelude.Basics.Bool>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/self print 004/expected
+++ b/tests/derivation/infra/self print 004/expected
@@ -3,27 +3,29 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen MaybeEmpty (X n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:1}))))
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ IVar Dry
-                               $ Implicit True)
-                          (IVar empty)
-              , PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ (IApp. IVar More $ IBindVar fuel)
-                               $ IBindVar 0)
-                          (IApp. IVar <DerivedGen.X>[0] $ IVar fuel $ IVar 0) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ (var "DerivedGen.X" .$ var "{arg:1}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0]"
+              [ var "<DerivedGen.X>[0]" .$ var "Dry" .$ implicitTrue .= var "empty"
+              , var "<DerivedGen.X>[0]" .$ (var "More" .$ bindVar "fuel") .$ bindVar "0" .= var "<DerivedGen.X>[0]" .$ var "fuel" .$ var "0"
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0]" .$ var "^outmost-fuel^" .$ var "outer^<n>"
+      }
+

--- a/tests/derivation/infra/self print 005/expected
+++ b/tests/derivation/infra/self print 005/expected
@@ -3,22 +3,31 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** X n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:1}))))))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IVar Dry) (IVar empty)
-              , PatClause (IApp. IVar <DerivedGen.X>[]
-                               $ (IApp. IVar More $ IBindVar fuel))
-                          (IApp. IVar <DerivedGen.X>[] $ IVar fuel) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat") .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [ var "<DerivedGen.X>[]" .$ var "Dry" .= var "empty"
+              , var "<DerivedGen.X>[]" .$ (var "More" .$ bindVar "fuel") .= var "<DerivedGen.X>[]" .$ var "fuel"
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/self print 006/expected
+++ b/tests/derivation/infra/self print 006/expected
@@ -3,33 +3,33 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Type) -> Gen MaybeEmpty (n : Nat ** Vect n a)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Vect.Vect>[1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg elem : IType)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Data.Vect.Vect
-                                                        $ IVar len
-                                                        $ IVar elem))))))
-         IDef <Data.Vect.Vect>[1]
-              [ PatClause (IApp. IVar <Data.Vect.Vect>[1]
-                               $ IVar Dry
-                               $ Implicit True)
-                          (IVar empty)
-              , PatClause (IApp. IVar <Data.Vect.Vect>[1]
-                               $ (IApp. IVar More $ IBindVar fuel)
-                               $ IBindVar 0)
-                          (IApp. IVar <Data.Vect.Vect>[1]
-                               $ IVar fuel
-                               $ IVar 0) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Vect.Vect>[1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "elem") type
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat") .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem"))
+                 })
+          , IDef
+              emptyFC
+              "<Data.Vect.Vect>[1]"
+              [ var "<Data.Vect.Vect>[1]" .$ var "Dry" .$ implicitTrue .= var "empty"
+              , var "<Data.Vect.Vect>[1]" .$ (var "More" .$ bindVar "fuel") .$ bindVar "0" .= var "<Data.Vect.Vect>[1]" .$ var "fuel" .$ var "0"
+              ]
+          ]
+      , scope = var "<Data.Vect.Vect>[1]" .$ var "^outmost-fuel^" .$ var "outer^<a>"
+      }
+

--- a/tests/derivation/infra/self print 007/expected
+++ b/tests/derivation/infra/self print 007/expected
@@ -3,26 +3,35 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** (b : Bool ** X n b))
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Basics.Bool
-                                                        $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Basics.Bool)
-                                                               => (IApp. IVar DerivedGen.X
-                                                                       $ IVar {arg:1}
-                                                                       $ IVar {arg:2}))))))))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IVar Dry) (IVar empty)
-              , PatClause (IApp. IVar <DerivedGen.X>[]
-                               $ (IApp. IVar More $ IBindVar fuel))
-                          (IApp. IVar <DerivedGen.X>[] $ IVar fuel) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Basics.Bool"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Basics.Bool")
+                                         .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [ var "<DerivedGen.X>[]" .$ var "Dry" .= var "empty"
+              , var "<DerivedGen.X>[]" .$ (var "More" .$ bindVar "fuel") .= var "<DerivedGen.X>[]" .$ var "fuel"
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/infra/self print 008/expected
+++ b/tests/derivation/infra/self print 008/expected
@@ -3,27 +3,34 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** (a : Type ** Vect n a))
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Data.Vect.Vect>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Vect.Vect>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg len : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IType
-                                                        $ (ILam.  (MW ExplicitArg elem : IType)
-                                                               => (IApp. IVar Data.Vect.Vect
-                                                                       $ IVar len
-                                                                       $ IVar elem))))))))
-         IDef <Data.Vect.Vect>[]
-              [ PatClause (IApp. IVar <Data.Vect.Vect>[] $ IVar Dry)
-                          (IVar empty)
-              , PatClause (IApp. IVar <Data.Vect.Vect>[]
-                               $ (IApp. IVar More $ IBindVar fuel))
-                          (IApp. IVar <Data.Vect.Vect>[] $ IVar fuel) ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Vect.Vect>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "len") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ type
+                                     .$ (MkArg MW ExplicitArg (Just "elem") type .=> var "Data.Vect.Vect" .$ var "len" .$ var "elem")))
+                 })
+          , IDef
+              emptyFC
+              "<Data.Vect.Vect>[]"
+              [ var "<Data.Vect.Vect>[]" .$ var "Dry" .= var "empty"
+              , var "<Data.Vect.Vect>[]" .$ (var "More" .$ bindVar "fuel") .= var "<Data.Vect.Vect>[]" .$ var "fuel"
+              ]
+          ]
+      , scope = var "<Data.Vect.Vect>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/001 trivial/expected
+++ b/tests/derivation/least-effort/print/adt/001 trivial/expected
@@ -3,39 +3,53 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty ()
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Builtin.Unit>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Builtin.Unit>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Builtin.Unit)))
-         IDef <Builtin.Unit>[]
-              [ PatClause (IApp. IVar <Builtin.Unit>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Builtin.Unit[] (non-recursive))
-                                       $ (IApp. IVar <<Builtin.MkUnit>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Builtin.MkUnit>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Builtin.Unit)))
-                            IDef <<Builtin.MkUnit>>
-                                 [ PatClause (IApp. IVar <<Builtin.MkUnit>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Builtin.MkUnit (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Builtin.MkUnit)) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Builtin.Unit>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                 })
+          , IDef
+              emptyFC
+              "<Builtin.Unit>[]"
+              [    var "<Builtin.Unit>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Builtin.MkUnit>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Builtin.MkUnit>>"
+                             [    var "<<Builtin.MkUnit>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Builtin.MkUnit (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Builtin.MkUnit")
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "Builtin.Unit[] (non-recursive)"))
+                         .$ (var "<<Builtin.MkUnit>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          ]
+      , scope = var "<Builtin.Unit>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/002 noparam/expected
+++ b/tests/derivation/least-effort/print/adt/002 noparam/expected
@@ -3,67 +3,76 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Bool
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Prelude.Basics.Bool>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Basics.Bool>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Basics.Bool)))
-         IDef <Prelude.Basics.Bool>[]
-              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Prelude.Basics.Bool[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<Prelude.Basics.False>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<Prelude.Basics.True>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.False>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.True>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IDef <<Prelude.Basics.False>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.False>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.False (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.False)) ]
-                            IDef <<Prelude.Basics.True>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.True>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.True (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.True)) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Basics.Bool>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                 })
+          , IDef
+              emptyFC
+              "<Prelude.Basics.Bool>[]"
+              [    var "<Prelude.Basics.Bool>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Basics.False>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Basics.True>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Basics.False>>"
+                             [    var "<<Prelude.Basics.False>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Basics.False (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Basics.False")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Basics.True>>"
+                             [    var "<<Prelude.Basics.True>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Basics.True (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Basics.True")
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "Prelude.Basics.Bool[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<Prelude.Basics.False>>" .$ var "^fuel_arg^")
+                                 .$ (var "::" .$ (var "<<Prelude.Basics.True>>" .$ var "^fuel_arg^") .$ var "Nil")))
+                     }
+              ]
+          ]
+      , scope = var "<Prelude.Basics.Bool>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/003 noparam/expected
+++ b/tests/derivation/least-effort/print/adt/003 noparam/expected
@@ -3,85 +3,95 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Nat
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Prelude.Types.Nat>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:1} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:1}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:1}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:1}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/004 noparam/expected
+++ b/tests/derivation/least-effort/print/adt/004 noparam/expected
@@ -3,169 +3,183 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty X
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.X)))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.X[] (dry fuel))
-                                                          $ (IApp. IVar <<DerivedGen.E>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.X[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.E>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.R>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.E>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.X)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.R>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.X)))
-                            IDef <<DerivedGen.E>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.E>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.E (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar DerivedGen.E)) ]
-                            IDef <<DerivedGen.R>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.R>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.R (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:1} : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg ^bnd^{arg:2} : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar DerivedGen.R
-                                                                                              $ IVar ^bnd^{arg:1}
-                                                                                              $ IVar ^bnd^{arg:2}))))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:3} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:3}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.E>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.R>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.E>>"
+                             [    var "<<DerivedGen.E>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.E (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "DerivedGen.E")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.R>>"
+                             [    var "<<DerivedGen.R>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.R (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:1}") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:2}") implicitFalse
+                                                  .=>    var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (var "DerivedGen.R" .$ var "^bnd^{arg:1}" .$ var "^bnd^{arg:2}"))))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (dry fuel)"))
+                                    .$ (var "<<DerivedGen.E>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<DerivedGen.E>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<DerivedGen.R>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:3}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:3}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/005 param/expected
+++ b/tests/derivation/least-effort/print/adt/005 param/expected
@@ -3,52 +3,60 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen MaybeEmpty (X n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:1}))))
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:1}))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ INamedApp (IVar DerivedGen.MkX)
-                                                                     n
-                                                                     (IVar n))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ (var "DerivedGen.X" .$ var "{arg:1}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0]"
+              [    var "<DerivedGen.X>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:1}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^" .$ bindVar "n"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "DerivedGen.MkX" .! ("n", var "n")))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0]" .$ var "^outmost-fuel^" .$ var "outer^<n>"
+      }
+

--- a/tests/derivation/least-effort/print/adt/006 param/expected
+++ b/tests/derivation/least-effort/print/adt/006 param/expected
@@ -3,135 +3,152 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** X n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.X>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:1}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkX)
-                                                                                           n
-                                                                                           (IVar n)))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:2} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:2}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat") .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkX" .! ("n", var "n")))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:2}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:2}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/007 right-to-left simple/expected
+++ b/tests/derivation/least-effort/print/adt/007 right-to-left simple/expected
@@ -3,181 +3,207 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:1}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ IBindVar ^bnd^{arg:2})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (IVar DerivedGen.MkY)
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:2})) ]))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkX)
-                                                                                           n
-                                                                                           (IVar n)))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:3} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:3}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat") .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY>>"
+                             [    var "<<DerivedGen.MkY>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "n" .$ bindVar "^bnd^{arg:2}"
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (var "DerivedGen.MkY" .! ("n", var "n") .$ var "^bnd^{arg:2}")
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkY>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkX" .! ("n", var "n")))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:3}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:3}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/008 right-to-left simple/expected
+++ b/tests/derivation/least-effort/print/adt/008 right-to-left simple/expected
@@ -3,181 +3,207 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:1}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ IBindVar ^bnd^{arg:2})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (IVar DerivedGen.MkY)
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:2})) ]))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkX)
-                                                                                           n
-                                                                                           (IVar n)))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:3} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:3}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat") .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY>>"
+                             [    var "<<DerivedGen.MkY>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "n" .$ bindVar "^bnd^{arg:2}"
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (var "DerivedGen.MkY" .! ("n", var "n") .$ var "^bnd^{arg:2}")
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkY>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X" .$ var "{arg:1}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkX" .! ("n", var "n")))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:3}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:3}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/009 left-to-right/expected
+++ b/tests/derivation/least-effort/print/adt/009 left-to-right/expected
@@ -3,179 +3,199 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:1}))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <DerivedGen.X>[0]
-                                                                               $ IVar ^outmost-fuel^
-                                                                               $ (IApp. IVar Prelude.Types.mult
-                                                                                      $ IVar n
-                                                                                      $ (IApp. IVar Prelude.Types.S
-                                                                                             $ (IApp. IVar Prelude.Types.S
-                                                                                                    $ IVar Prelude.Types.Z))))
-                                                                        $ (ILam.  (MW ExplicitArg ^bnd^{arg:2} : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. INamedApp (IVar DerivedGen.MkY)
-                                                                                                          n
-                                                                                                          (IVar n)
-                                                                                              $ IVar ^bnd^{arg:2}))))))) ] ]
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:1}))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ INamedApp (IVar DerivedGen.MkX)
-                                                                     n
-                                                                     (IVar n))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:3} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:3}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ (var "DerivedGen.X" .$ var "{arg:1}")
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY>>"
+                             [    var "<<DerivedGen.MkY>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (   var "<DerivedGen.X>[0]"
+                                                  .$ var "^outmost-fuel^"
+                                                  .$ (   var "Prelude.Types.mult"
+                                                      .$ var "n"
+                                                      .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z"))))
+                                              .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:2}") implicitFalse
+                                                  .=>    var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (var "DerivedGen.MkY" .! ("n", var "n") .$ var "^bnd^{arg:2}"))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkY>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0]"
+              [    var "<DerivedGen.X>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:1}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^" .$ bindVar "n"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "DerivedGen.MkX" .! ("n", var "n")))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:3}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:3}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/010 right-to-left long-dpair/expected
+++ b/tests/derivation/least-effort/print/adt/010 right-to-left long-dpair/expected
@@ -3,201 +3,223 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.X
-                                                                       $ IVar {arg:1}
-                                                                       $ IVar {arg:2}))))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar m
-                                                                                                 $ IBindVar ^bnd^{arg:3}))
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                        m
-                                                                                                                        (IVar m))
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:3})) ]))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:1}
-                                                                                          $ IVar {arg:2}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ INamedApp (INamedApp (IVar DerivedGen.MkX)
-                                                                                                                            n
-                                                                                                                            (IVar n))
-                                                                                                                 m
-                                                                                                                 (IVar m))))))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:4} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:4}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Types.Nat"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                         .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY>>"
+                             [    var "<<DerivedGen.MkY>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "n"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "m" .$ bindVar "^bnd^{arg:3}")
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (var "DerivedGen.MkY" .! ("m", var "m") .! ("n", var "n") .$ var "^bnd^{arg:3}")
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkY>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                                  .=>    var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (   var "Builtin.DPair.MkDPair"
+                                                          .$ implicitTrue
+                                                          .$ (   var "Builtin.DPair.MkDPair"
+                                                              .$ implicitTrue
+                                                              .$ (var "DerivedGen.MkX" .! ("n", var "n") .! ("m", var "m")))))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:4}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:4}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/011 right-to-left long-dpair/expected
+++ b/tests/derivation/least-effort/print/adt/011 right-to-left long-dpair/expected
@@ -3,235 +3,266 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Builtin.Unit
-                                                        $ (ILam.  (MW ExplicitArg {arg:2} : IVar Builtin.Unit)
-                                                               => (IApp. IVar DerivedGen.X
-                                                                       $ IVar {arg:1}
-                                                                       $ IVar {arg:2}))))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Builtin.Unit>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Builtin.Unit)))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar m
-                                                                                                 $ IBindVar ^bnd^{arg:3}))
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                        m
-                                                                                                                        (IVar m))
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:3})) ]))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Builtin.Unit
-                                                                           $ (ILam.  (MW ExplicitArg {arg:2} : IVar Builtin.Unit)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:1}
-                                                                                          $ IVar {arg:2}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Builtin.Unit>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ INamedApp (INamedApp (IVar DerivedGen.MkX)
-                                                                                                                            n
-                                                                                                                            (IVar n))
-                                                                                                                 m
-                                                                                                                 (IVar m))))))))) ] ]
-         IDef <Builtin.Unit>[]
-              [ PatClause (IApp. IVar <Builtin.Unit>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Builtin.Unit[] (non-recursive))
-                                       $ (IApp. IVar <<Builtin.MkUnit>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Builtin.MkUnit>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Builtin.Unit)))
-                            IDef <<Builtin.MkUnit>>
-                                 [ PatClause (IApp. IVar <<Builtin.MkUnit>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Builtin.MkUnit (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Builtin.MkUnit)) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:4} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:4}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Builtin.Unit"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Builtin.Unit")
+                                         .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Builtin.Unit>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY>>"
+                             [    var "<<DerivedGen.MkY>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "n"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "m" .$ bindVar "^bnd^{arg:3}")
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (var "DerivedGen.MkY" .! ("m", var "m") .! ("n", var "n") .$ var "^bnd^{arg:3}")
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkY>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Builtin.Unit"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Builtin.Unit")
+                                                        .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "<Builtin.Unit>[]" .$ var "^outmost-fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                                  .=>    var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (   var "Builtin.DPair.MkDPair"
+                                                          .$ implicitTrue
+                                                          .$ (   var "Builtin.DPair.MkDPair"
+                                                              .$ implicitTrue
+                                                              .$ (var "DerivedGen.MkX" .! ("n", var "n") .! ("m", var "m")))))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Builtin.Unit>[]"
+              [    var "<Builtin.Unit>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Builtin.MkUnit>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Builtin.MkUnit>>"
+                             [    var "<<Builtin.MkUnit>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Builtin.MkUnit (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Builtin.MkUnit")
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "Builtin.Unit[] (non-recursive)"))
+                         .$ (var "<<Builtin.MkUnit>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:4}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:4}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/012 right-to-left chained/expected
+++ b/tests/derivation/least-effort/print/adt/012 right-to-left chained/expected
@@ -3,235 +3,273 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X2>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X2
-                                                        $ IVar {arg:1}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X1>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X1
-                                                        $ IVar {arg:2}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X2>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ IBindVar ^bnd^{arg:3})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. INamedApp (IVar DerivedGen.MkY)
-                                                                                                             n
-                                                                                                             (IVar n)
-                                                                                                 $ IVar ^bnd^{arg:3})) ]))) ] ]
-         IDef <DerivedGen.X2>[]
-              [ PatClause (IApp. IVar <DerivedGen.X2>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X2[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX2>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX2>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X2
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.MkX2>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX2>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX2 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X1>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ IBindVar ^bnd^{arg:4})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ Implicit True
-                                                                                                 $ (IApp. IVar DerivedGen.MkX2
-                                                                                                        $ IVar n
-                                                                                                        $ IVar ^bnd^{arg:4}))) ]))) ] ]
-         IDef <DerivedGen.X1>[]
-              [ PatClause (IApp. IVar <DerivedGen.X1>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X1[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX1>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX1>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X1
-                                                                           $ IVar {arg:2}))))))
-                            IDef <<DerivedGen.MkX1>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX1>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX1 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar DerivedGen.MkX1
-                                                                                      $ IVar n)))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:5} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:5}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X2>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat") .=> var "DerivedGen.X2" .$ var "{arg:1}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X1>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat") .=> var "DerivedGen.X1" .$ var "{arg:2}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY>>"
+                             [    var "<<DerivedGen.MkY>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X2>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "n" .$ bindVar "^bnd^{arg:3}"
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (var "DerivedGen.MkY" .! ("n", var "n") .$ var "^bnd^{arg:3}")
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkY>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X2>[]"
+              [    var "<DerivedGen.X2>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX2>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X2" .$ var "{arg:1}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX2>>"
+                             [    var "<<DerivedGen.MkX2>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX2 (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X1>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "n" .$ bindVar "^bnd^{arg:4}"
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (   var "Builtin.DPair.MkDPair"
+                                                             .$ implicitTrue
+                                                             .$ (var "DerivedGen.MkX2" .$ var "n" .$ var "^bnd^{arg:4}"))
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X2[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX2>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X1>[]"
+              [    var "<DerivedGen.X1>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX1>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X1" .$ var "{arg:2}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX1>>"
+                             [    var "<<DerivedGen.MkX1>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX1 (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkX1" .$ var "n"))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X1[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX1>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:5}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:5}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/013 right-to-left nondet/expected
+++ b/tests/derivation/least-effort/print/adt/013 right-to-left nondet/expected
@@ -3,274 +3,300 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:1}
-                                                        $ IVar {arg:2}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.X
-                                                                       $ IVar {arg:1}
-                                                                       $ IVar {arg:2}))))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar k
-                                                                                                 $ IBindVar ^bnd^{arg:3}))
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar <DerivedGen.X>[0]
-                                                                                                 $ IVar ^outmost-fuel^
-                                                                                                 $ IVar n)
-                                                                                          $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                                                 => ICase (IVar {lamc:0})
-                                                                                                          (Implicit False)
-                                                                                                          [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                           $ IBindVar m
-                                                                                                                           $ IBindVar ^bnd^{arg:4})
-                                                                                                                      (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                                       f
-                                                                                                                                       (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                                            $ Implicit True)
-                                                                                                                           $ (IApp. INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                                                                    k
-                                                                                                                                                                    (IVar k))
-                                                                                                                                                         m
-                                                                                                                                                         (IVar m))
-                                                                                                                                              n
-                                                                                                                                              (IVar n)
-                                                                                                                                  $ IVar ^bnd^{arg:4}
-                                                                                                                                  $ IVar ^bnd^{arg:3})) ])) ]))) ] ]
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:1}
-                                                                           $ IVar {arg:2}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (INamedApp (IVar DerivedGen.MkX)
-                                                                                                      n
-                                                                                                      (IVar n))
-                                                                                           m
-                                                                                           (IVar m)))))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:1}
-                                                                                          $ IVar {arg:2}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ INamedApp (INamedApp (IVar DerivedGen.MkX)
-                                                                                                                            n
-                                                                                                                            (IVar n))
-                                                                                                                 m
-                                                                                                                 (IVar m))))))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:5} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:5}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Types.Nat"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                         .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY>>"
+                             [    var "<<DerivedGen.MkY>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "n"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "k" .$ bindVar "^bnd^{arg:3}")
+                                                      .=    var ">>="
+                                                         .$ (var "<DerivedGen.X>[0]" .$ var "^outmost-fuel^" .$ var "n")
+                                                         .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                                             .=> iCase
+                                                                   { sc = var "{lamc:0}"
+                                                                   , ty = implicitFalse
+                                                                   , clauses =
+                                                                       [    var "Builtin.DPair.MkDPair" .$ bindVar "m" .$ bindVar "^bnd^{arg:4}"
+                                                                         .=    var "Prelude.pure"
+                                                                            .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                            .$ (   var "DerivedGen.MkY"
+                                                                                .! ("k", var "k")
+                                                                                .! ("m", var "m")
+                                                                                .! ("n", var "n")
+                                                                                .$ var "^bnd^{arg:4}"
+                                                                                .$ var "^bnd^{arg:3}")
+                                                                       ]
+                                                                   })
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkY>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0]"
+              [    var "<DerivedGen.X>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^" .$ bindVar "n"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (   var "Builtin.DPair.MkDPair"
+                                                  .$ implicitTrue
+                                                  .$ (var "DerivedGen.MkX" .! ("n", var "n") .! ("m", var "m")))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                                  .=>    var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (   var "Builtin.DPair.MkDPair"
+                                                          .$ implicitTrue
+                                                          .$ (   var "Builtin.DPair.MkDPair"
+                                                              .$ implicitTrue
+                                                              .$ (var "DerivedGen.MkX" .! ("n", var "n") .! ("m", var "m")))))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:5}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:5}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/014 right-to-left nondet ext/expected
+++ b/tests/derivation/least-effort/print/adt/014 right-to-left nondet ext/expected
@@ -3,198 +3,225 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty String)} -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty Nat)} -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                        -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                $ IPrimVal String))
-    => (MW AutoImplicit external^<Prelude.Types.Nat>[] : IPi.  (MW ExplicitArg {arg:2} : IVar Data.Fuel.Fuel)
-                                                            -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                    $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                    $ IVar Prelude.Types.Nat))
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:3} : IPrimVal String)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X
-                                                        $ IVar {arg:3}
-                                                        $ IVar {arg:4}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IPrimVal String
-                                         $ (ILam.  (MW ExplicitArg {arg:3} : IPrimVal String)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.X
-                                                                       $ IVar {arg:3}
-                                                                       $ IVar {arg:4}))))))))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkY>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar k
-                                                                                                 $ IBindVar ^bnd^{arg:5}))
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar <DerivedGen.X>[0]
-                                                                                                 $ IVar ^outmost-fuel^
-                                                                                                 $ IVar n)
-                                                                                          $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                                                 => ICase (IVar {lamc:0})
-                                                                                                          (Implicit False)
-                                                                                                          [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                           $ IBindVar m
-                                                                                                                           $ IBindVar ^bnd^{arg:6})
-                                                                                                                      (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                                       f
-                                                                                                                                       (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                                            $ Implicit True)
-                                                                                                                           $ (IApp. INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                                                                    k
-                                                                                                                                                                    (IVar k))
-                                                                                                                                                         m
-                                                                                                                                                         (IVar m))
-                                                                                                                                              n
-                                                                                                                                              (IVar n)
-                                                                                                                                  $ IVar ^bnd^{arg:6}
-                                                                                                                                  $ IVar ^bnd^{arg:5})) ])) ]))) ] ]
-         IDef <DerivedGen.X>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:3}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3} : IPrimVal String)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X
-                                                                           $ IVar {arg:3}
-                                                                           $ IVar {arg:4}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar DerivedGen.MkX
-                                                                                      $ IVar n
-                                                                                      $ IVar m)))))) ] ]
-         IDef <DerivedGen.X>[]
-              [ PatClause (IApp. IVar <DerivedGen.X>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IPrimVal String
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IPrimVal String)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X
-                                                                                          $ IVar {arg:3}
-                                                                                          $ IVar {arg:4}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<^prim^.String>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ (IApp. IVar DerivedGen.MkX
-                                                                                                            $ IVar n
-                                                                                                            $ IVar m))))))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<^prim^.String>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ primVal (PrT StringType))
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<Prelude.Types.Nat>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:3}") (primVal (PrT StringType))
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.X" .$ var "{arg:3}" .$ var "{arg:4}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ primVal (PrT StringType)
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (primVal (PrT StringType))
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Types.Nat"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                         .=> var "DerivedGen.X" .$ var "{arg:3}" .$ var "{arg:4}")))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY>>"
+                             [    var "<<DerivedGen.MkY>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "n"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "k" .$ bindVar "^bnd^{arg:5}")
+                                                      .=    var ">>="
+                                                         .$ (var "<DerivedGen.X>[0]" .$ var "^outmost-fuel^" .$ var "n")
+                                                         .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                                             .=> iCase
+                                                                   { sc = var "{lamc:0}"
+                                                                   , ty = implicitFalse
+                                                                   , clauses =
+                                                                       [    var "Builtin.DPair.MkDPair" .$ bindVar "m" .$ bindVar "^bnd^{arg:6}"
+                                                                         .=    var "Prelude.pure"
+                                                                            .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                            .$ (   var "DerivedGen.MkY"
+                                                                                .! ("k", var "k")
+                                                                                .! ("m", var "m")
+                                                                                .! ("n", var "n")
+                                                                                .$ var "^bnd^{arg:6}"
+                                                                                .$ var "^bnd^{arg:5}")
+                                                                       ]
+                                                                   })
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkY>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0]"
+              [    var "<DerivedGen.X>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:3}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (primVal (PrT StringType))
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X" .$ var "{arg:3}" .$ var "{arg:4}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^" .$ bindVar "n"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkX" .$ var "n" .$ var "m"))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:3}>")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ primVal (PrT StringType)
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (primVal (PrT StringType))
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.X" .$ var "{arg:3}" .$ var "{arg:4}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                                  .=>    var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (   var "Builtin.DPair.MkDPair"
+                                                          .$ implicitTrue
+                                                          .$ (   var "Builtin.DPair.MkDPair"
+                                                              .$ implicitTrue
+                                                              .$ (var "DerivedGen.MkX" .$ var "n" .$ var "m"))))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/001 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/001 gadt/expected
@@ -3,114 +3,109 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> Gen MaybeEmpty (Fin n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => ILocal (IApp. IVar <Data.Fin.Fin>[0]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Fin.Fin>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Data.Fin.Fin $ IVar n))))
-         IDef <Data.Fin.Fin>[0]
-              [ PatClause (IApp. IVar <Data.Fin.Fin>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<n>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Fin.Fin[0] (dry fuel))
-                                                          $ (IApp. IVar <<Data.Fin.FZ>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<n>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Fin.Fin[0] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Data.Fin.FZ>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<n>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Data.Fin.FS>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<n>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Fin.FZ>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Data.Fin.Fin
-                                                            $ IVar n))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Fin.FS>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Data.Fin.Fin
-                                                            $ IVar n))))
-                            IDef <<Data.Fin.FZ>>
-                                 [ PatClause (IApp. IVar <<Data.Fin.FZ>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar k))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.Fin.FZ (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ INamedApp (IVar Data.Fin.FZ)
-                                                                     k
-                                                                     (IVar k)))
-                                 , PatClause (IApp. IVar <<Data.Fin.FZ>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<Data.Fin.FS>>
-                                 [ PatClause (IApp. IVar <<Data.Fin.FS>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar k))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.Fin.FS (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Data.Fin.Fin>[0]
-                                                                $ IVar ^cons_fuel^
-                                                                $ IVar k)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:1} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. INamedApp (IVar Data.Fin.FS)
-                                                                                           k
-                                                                                           (IVar k)
-                                                                               $ IVar ^bnd^{arg:1})))))
-                                 , PatClause (IApp. IVar <<Data.Fin.FS>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Fin.Fin>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ (var "Data.Fin.Fin" .$ var "n")
+                 })
+          , IDef
+              emptyFC
+              "<Data.Fin.Fin>[0]"
+              [    var "<Data.Fin.Fin>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<n>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Fin.FZ>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "Data.Fin.Fin" .$ var "n")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Fin.FS>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "Data.Fin.Fin" .$ var "n")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Data.Fin.FZ>>"
+                             [    var "<<Data.Fin.FZ>>" .$ bindVar "^cons_fuel^" .$ (var "Prelude.Types.S" .$ bindVar "k")
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.Fin.FZ (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Data.Fin.FZ" .! ("k", var "k")))
+                             , var "<<Data.Fin.FZ>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Data.Fin.FS>>"
+                             [    var "<<Data.Fin.FS>>" .$ bindVar "^cons_fuel^" .$ (var "Prelude.Types.S" .$ bindVar "k")
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.Fin.FS (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Data.Fin.Fin>[0]" .$ var "^cons_fuel^" .$ var "k")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:1}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Data.Fin.FS" .! ("k", var "k") .$ var "^bnd^{arg:1}")))
+                             , var "<<Data.Fin.FS>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (dry fuel)"))
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^" .$ var "inter^<n>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Data.Fin.FS>>" .$ var "^sub^fuel_arg^" .$ var "inter^<n>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<Data.Fin.Fin>[0]" .$ var "^outmost-fuel^" .$ var "outer^<n>"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/002 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/002 gadt/expected
@@ -3,193 +3,206 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** Fin n)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <Data.Fin.Fin>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <Data.Fin.Fin>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Data.Fin.Fin
-                                                        $ IVar n))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <Data.Fin.Fin>[]
-              [ PatClause (IApp. IVar <Data.Fin.Fin>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Fin.Fin[] (dry fuel))
-                                                          $ (IApp. IVar <<Data.Fin.FZ>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Data.Fin.Fin[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Data.Fin.FZ>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Data.Fin.FS>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Fin.FZ>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Data.Fin.Fin
-                                                                           $ IVar n))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Data.Fin.FS>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Data.Fin.Fin
-                                                                           $ IVar n))))))
-                            IDef <<Data.Fin.FZ>>
-                                 [ PatClause (IApp. IVar <<Data.Fin.FZ>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.Fin.FZ (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg k : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar Data.Fin.FZ)
-                                                                                           k
-                                                                                           (IVar k)))))) ]
-                            IDef <<Data.Fin.FS>>
-                                 [ PatClause (IApp. IVar <<Data.Fin.FS>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Data.Fin.FS (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Data.Fin.Fin>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar k
-                                                                                          $ IBindVar ^bnd^{arg:1})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ Implicit True
-                                                                                                 $ (IApp. INamedApp (IVar Data.Fin.FS)
-                                                                                                                    k
-                                                                                                                    (IVar k)
-                                                                                                        $ IVar ^bnd^{arg:1}))) ]))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:2} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:2}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Data.Fin.Fin>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat") .=> var "Data.Fin.Fin" .$ var "n"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<Data.Fin.Fin>[]"
+              [    var "<Data.Fin.Fin>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Fin.FZ>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat") .=> var "Data.Fin.Fin" .$ var "n"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Data.Fin.FS>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat") .=> var "Data.Fin.Fin" .$ var "n"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Data.Fin.FZ>>"
+                             [    var "<<Data.Fin.FZ>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.Fin.FZ (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "k") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "Data.Fin.FZ" .! ("k", var "k")))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Data.Fin.FS>>"
+                             [    var "<<Data.Fin.FS>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Data.Fin.FS (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Data.Fin.Fin>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "k" .$ bindVar "^bnd^{arg:1}"
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (   var "Builtin.DPair.MkDPair"
+                                                             .$ implicitTrue
+                                                             .$ (var "Data.Fin.FS" .! ("k", var "k") .$ var "^bnd^{arg:1}"))
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (dry fuel)"))
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Data.Fin.FS>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:2}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:2}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<Data.Fin.Fin>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
+++ b/tests/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
@@ -3,516 +3,513 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X_GADT>[1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X_GADT
-                                                        $ IVar {arg:2}
-                                                        $ IVar {arg:1}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X_GADT>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X_GADT
-                                                        $ IVar {arg:2}
-                                                        $ IVar {arg:1}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X_GADT>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.X_GADT
-                                                                       $ IVar {arg:2}
-                                                                       $ IVar {arg:1}))))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkY1>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkY2>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY1>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY2>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY1>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY1>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY1 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X_GADT>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar k
-                                                                                                 $ IBindVar ^bnd^{arg:3}))
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar <DerivedGen.X_GADT>[0]
-                                                                                                 $ IVar ^outmost-fuel^
-                                                                                                 $ IVar n)
-                                                                                          $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                                                 => ICase (IVar {lamc:0})
-                                                                                                          (Implicit False)
-                                                                                                          [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                           $ IBindVar m
-                                                                                                                           $ IBindVar ^bnd^{arg:4})
-                                                                                                                      (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                                       f
-                                                                                                                                       (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                                            $ Implicit True)
-                                                                                                                           $ (IApp. INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY1)
-                                                                                                                                                                    k
-                                                                                                                                                                    (IVar k))
-                                                                                                                                                         m
-                                                                                                                                                         (IVar m))
-                                                                                                                                              n
-                                                                                                                                              (IVar n)
-                                                                                                                                  $ IVar ^bnd^{arg:4}
-                                                                                                                                  $ IVar ^bnd^{arg:3})) ])) ]))) ]
-                            IDef <<DerivedGen.MkY2>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY2>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY2 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X_GADT>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar k
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar m
-                                                                                                 $ IBindVar ^bnd^{arg:5}))
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar <DerivedGen.X_GADT>[1]
-                                                                                                 $ IVar ^outmost-fuel^
-                                                                                                 $ IVar m)
-                                                                                          $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                                                 => ICase (IVar {lamc:0})
-                                                                                                          (Implicit False)
-                                                                                                          [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                           $ IBindVar n
-                                                                                                                           $ IBindVar ^bnd^{arg:6})
-                                                                                                                      (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                                       f
-                                                                                                                                       (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                                            $ Implicit True)
-                                                                                                                           $ (IApp. INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY2)
-                                                                                                                                                                    k
-                                                                                                                                                                    (IVar k))
-                                                                                                                                                         m
-                                                                                                                                                         (IVar m))
-                                                                                                                                              n
-                                                                                                                                              (IVar n)
-                                                                                                                                  $ IVar ^bnd^{arg:6}
-                                                                                                                                  $ IVar ^bnd^{arg:5})) ])) ]))) ] ]
-         IDef <DerivedGen.X_GADT>[1]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[1] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^
-                                                            $ IVar inter^<{arg:1}>)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^
-                                                                   $ IVar inter^<{arg:1}>)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:2}
-                                                                           $ IVar {arg:1}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:2}
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ (IApp. IVar Prelude.Types.S
-                                                                                     $ IVar Prelude.Types.Z))))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ IVar DerivedGen.MkXG_4)))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar m)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                            m
-                                                                            (IVar m)))) ] ]
-         IDef <DerivedGen.X_GADT>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:2}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[0] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^
-                                                            $ IVar inter^<{arg:2}>)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^
-                                                                   $ IVar inter^<{arg:2}>)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:2}
-                                                                           $ IVar {arg:1}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:2}
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ IVar Prelude.Types.Z)))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ IVar DerivedGen.MkXG_4)))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ (IApp. IVar Prelude.Types.S
-                                                                                     $ IVar Prelude.Types.Z))))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                                           m
-                                                                                           (IVar m))))))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
-         IDef <DerivedGen.X_GADT>[]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_GADT
-                                                                                          $ IVar {arg:2}
-                                                                                          $ IVar {arg:1}))))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_GADT
-                                                                                          $ IVar {arg:2}
-                                                                                          $ IVar {arg:1}))))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                       $ Implicit True
-                                                                       $ IVar DerivedGen.MkXG_4)))) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                      $ Implicit True
-                                                                                      $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                                                  m
-                                                                                                  (IVar m))))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:7} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:7}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X_GADT>[1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.X_GADT" .$ var "{arg:2}" .$ var "{arg:1}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X_GADT>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.X_GADT" .$ var "{arg:2}" .$ var "{arg:1}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X_GADT>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Types.Nat"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                         .=> var "DerivedGen.X_GADT" .$ var "{arg:2}" .$ var "{arg:1}")))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY1>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY2>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY1>>"
+                             [    var "<<DerivedGen.MkY1>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY1 (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X_GADT>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "n"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "k" .$ bindVar "^bnd^{arg:3}")
+                                                      .=    var ">>="
+                                                         .$ (var "<DerivedGen.X_GADT>[0]" .$ var "^outmost-fuel^" .$ var "n")
+                                                         .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                                             .=> iCase
+                                                                   { sc = var "{lamc:0}"
+                                                                   , ty = implicitFalse
+                                                                   , clauses =
+                                                                       [    var "Builtin.DPair.MkDPair" .$ bindVar "m" .$ bindVar "^bnd^{arg:4}"
+                                                                         .=    var "Prelude.pure"
+                                                                            .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                            .$ (   var "DerivedGen.MkY1"
+                                                                                .! ("k", var "k")
+                                                                                .! ("m", var "m")
+                                                                                .! ("n", var "n")
+                                                                                .$ var "^bnd^{arg:4}"
+                                                                                .$ var "^bnd^{arg:3}")
+                                                                       ]
+                                                                   })
+                                                    ]
+                                                }))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY2>>"
+                             [    var "<<DerivedGen.MkY2>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY2 (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X_GADT>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "k"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "m" .$ bindVar "^bnd^{arg:5}")
+                                                      .=    var ">>="
+                                                         .$ (var "<DerivedGen.X_GADT>[1]" .$ var "^outmost-fuel^" .$ var "m")
+                                                         .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                                             .=> iCase
+                                                                   { sc = var "{lamc:0}"
+                                                                   , ty = implicitFalse
+                                                                   , clauses =
+                                                                       [    var "Builtin.DPair.MkDPair" .$ bindVar "n" .$ bindVar "^bnd^{arg:6}"
+                                                                         .=    var "Prelude.pure"
+                                                                            .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                            .$ (   var "DerivedGen.MkY2"
+                                                                                .! ("k", var "k")
+                                                                                .! ("m", var "m")
+                                                                                .! ("n", var "n")
+                                                                                .$ var "^bnd^{arg:6}"
+                                                                                .$ var "^bnd^{arg:5}")
+                                                                       ]
+                                                                   })
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.MkY1>>" .$ var "^fuel_arg^")
+                                 .$ (var "::" .$ (var "<<DerivedGen.MkY2>>" .$ var "^fuel_arg^") .$ var "Nil")))
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X_GADT>[1]"
+              [    var "<DerivedGen.X_GADT>[1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_4>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X_GADT" .$ var "{arg:2}" .$ var "{arg:1}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_5>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X_GADT" .$ var "{arg:2}" .$ var "{arg:1}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_4>>"
+                             [       var "<<DerivedGen.MkXG_4>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (   var "Prelude.Types.S"
+                                      .$ (   var "Prelude.Types.S"
+                                          .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z")))))
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_4 (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ var "DerivedGen.MkXG_4"))
+                             , var "<<DerivedGen.MkXG_4>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_5>>"
+                             [    var "<<DerivedGen.MkXG_5>>" .$ bindVar "^cons_fuel^" .$ bindVar "m"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_5 (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkXG_5" .! ("m", var "m"))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X_GADT[1] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.MkXG_4>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
+                                 .$ (var "::" .$ (var "<<DerivedGen.MkXG_5>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>") .$ var "Nil")))
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X_GADT>[0]"
+              [    var "<DerivedGen.X_GADT>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:2}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_4>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X_GADT" .$ var "{arg:2}" .$ var "{arg:1}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_5>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X_GADT" .$ var "{arg:2}" .$ var "{arg:1}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_4>>"
+                             [       var "<<DerivedGen.MkXG_4>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (   var "Prelude.Types.S"
+                                      .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z"))))
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_4 (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ var "DerivedGen.MkXG_4"))
+                             , var "<<DerivedGen.MkXG_4>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_5>>"
+                             [       var "<<DerivedGen.MkXG_5>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (   var "Prelude.Types.S"
+                                      .$ (   var "Prelude.Types.S"
+                                          .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z")))))
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_5 (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkXG_5" .! ("m", var "m")))))
+                             , var "<<DerivedGen.MkXG_5>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X_GADT[0] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.MkXG_4>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:2}>")
+                                 .$ (var "::" .$ (var "<<DerivedGen.MkXG_5>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:2}>") .$ var "Nil")))
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X_GADT>[]"
+              [    var "<DerivedGen.X_GADT>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_4>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.X_GADT" .$ var "{arg:2}" .$ var "{arg:1}")))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_5>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.X_GADT" .$ var "{arg:2}" .$ var "{arg:1}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_4>>"
+                             [    var "<<DerivedGen.MkXG_4>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_4 (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (   var "Builtin.DPair.MkDPair"
+                                          .$ implicitTrue
+                                          .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ var "DerivedGen.MkXG_4")))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_5>>"
+                             [    var "<<DerivedGen.MkXG_5>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_5 (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (   var "Builtin.DPair.MkDPair"
+                                                  .$ implicitTrue
+                                                  .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkXG_5" .! ("m", var "m"))))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X_GADT[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.MkXG_4>>" .$ var "^fuel_arg^")
+                                 .$ (var "::" .$ (var "<<DerivedGen.MkXG_5>>" .$ var "^fuel_arg^") .$ var "Nil")))
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:7}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:7}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/004 right-to-left det/expected
+++ b/tests/derivation/least-effort/print/gadt/004 right-to-left det/expected
@@ -3,539 +3,551 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty Y
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.Y>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar DerivedGen.Y)))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X_ADT>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X_ADT
-                                                        $ IVar {arg:1}
-                                                        $ IVar {arg:2}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X_GADT>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.X_GADT
-                                                                       $ IVar {arg:3}
-                                                                       $ IVar {arg:4}))))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X_GADT>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.X_GADT
-                                                        $ IVar {arg:3}
-                                                        $ IVar {arg:4}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X_ADT>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.X_ADT
-                                                                       $ IVar {arg:1}
-                                                                       $ IVar {arg:2}))))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.Y>[]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Y[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkY_LR>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkY_RL>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY_LR>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkY_RL>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar DerivedGen.Y)))
-                            IDef <<DerivedGen.MkY_LR>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY_LR>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY_LR (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X_ADT>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar k
-                                                                                                 $ IBindVar ^bnd^{arg:5}))
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar <DerivedGen.X_GADT>[0]
-                                                                                                 $ IVar ^outmost-fuel^
-                                                                                                 $ IVar n)
-                                                                                          $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                                                 => ICase (IVar {lamc:0})
-                                                                                                          (Implicit False)
-                                                                                                          [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                           $ IBindVar m
-                                                                                                                           $ IBindVar ^bnd^{arg:6})
-                                                                                                                      (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                                       f
-                                                                                                                                       (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                                            $ Implicit True)
-                                                                                                                           $ (IApp. INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY_LR)
-                                                                                                                                                                    k
-                                                                                                                                                                    (IVar k))
-                                                                                                                                                         m
-                                                                                                                                                         (IVar m))
-                                                                                                                                              n
-                                                                                                                                              (IVar n)
-                                                                                                                                  $ IVar ^bnd^{arg:6}
-                                                                                                                                  $ IVar ^bnd^{arg:5})) ])) ]))) ]
-                            IDef <<DerivedGen.MkY_RL>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkY_RL>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkY_RL (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.X_GADT>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar k
-                                                                                                 $ IBindVar ^bnd^{arg:7}))
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar <DerivedGen.X_ADT>[0]
-                                                                                                 $ IVar ^outmost-fuel^
-                                                                                                 $ IVar n)
-                                                                                          $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                                                 => ICase (IVar {lamc:0})
-                                                                                                          (Implicit False)
-                                                                                                          [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                           $ IBindVar m
-                                                                                                                           $ IBindVar ^bnd^{arg:8})
-                                                                                                                      (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                                       f
-                                                                                                                                       (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                                            $ Implicit True)
-                                                                                                                           $ (IApp. INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY_RL)
-                                                                                                                                                                    k
-                                                                                                                                                                    (IVar k))
-                                                                                                                                                         m
-                                                                                                                                                         (IVar m))
-                                                                                                                                              n
-                                                                                                                                              (IVar n)
-                                                                                                                                  $ IVar ^bnd^{arg:8}
-                                                                                                                                  $ IVar ^bnd^{arg:7})) ])) ]))) ] ]
-         IDef <DerivedGen.X_ADT>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X_ADT>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_ADT[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_ADT
-                                                                           $ IVar {arg:1}
-                                                                           $ IVar {arg:2}))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar n)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar DerivedGen.MkX
-                                                                                      $ IVar n
-                                                                                      $ IVar m)))))) ] ]
-         IDef <DerivedGen.X_GADT>[]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_GADT
-                                                                                          $ IVar {arg:3}
-                                                                                          $ IVar {arg:4}))))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_GADT
-                                                                                          $ IVar {arg:3}
-                                                                                          $ IVar {arg:4}))))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                       $ Implicit True
-                                                                       $ IVar DerivedGen.MkXG_4)))) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                      $ Implicit True
-                                                                                      $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                                                  m
-                                                                                                  (IVar m))))))) ] ]
-         IDef <DerivedGen.X_GADT>[0]
-              [ PatClause (IApp. IVar <DerivedGen.X_GADT>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_GADT[0] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                            $ IVar ^fuel_arg^
-                                                            $ IVar inter^<{arg:3}>)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                                   $ IVar ^fuel_arg^
-                                                                   $ IVar inter^<{arg:3}>)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_4>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:3}
-                                                                           $ IVar {arg:4}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkXG_5>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.X_GADT
-                                                                           $ IVar {arg:3}
-                                                                           $ IVar {arg:4}))))))
-                            IDef <<DerivedGen.MkXG_4>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ IVar Prelude.Types.Z)))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_4 (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ IVar DerivedGen.MkXG_4)))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_4>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.MkXG_5>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ (IApp. IVar Prelude.Types.S
-                                                                       $ (IApp. IVar Prelude.Types.S
-                                                                              $ (IApp. IVar Prelude.Types.S
-                                                                                     $ IVar Prelude.Types.Z))))))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkXG_5 (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.MkXG_5)
-                                                                                           m
-                                                                                           (IVar m))))))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkXG_5>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
-         IDef <DerivedGen.X_ADT>[]
-              [ PatClause (IApp. IVar <DerivedGen.X_ADT>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X_ADT[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.X_ADT
-                                                                                          $ IVar {arg:1}
-                                                                                          $ IVar {arg:2}))))))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg m : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                              $ Implicit True
-                                                                                              $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                     $ Implicit True
-                                                                                                     $ (IApp. IVar DerivedGen.MkX
-                                                                                                            $ IVar n
-                                                                                                            $ IVar m))))))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:9} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:9}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X_ADT>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.X_ADT" .$ var "{arg:1}" .$ var "{arg:2}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X_GADT>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Types.Nat"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                         .=> var "DerivedGen.X_GADT" .$ var "{arg:3}" .$ var "{arg:4}")))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X_GADT>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.X_GADT" .$ var "{arg:3}" .$ var "{arg:4}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X_ADT>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Types.Nat"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                         .=> var "DerivedGen.X_ADT" .$ var "{arg:1}" .$ var "{arg:2}")))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[]"
+              [    var "<DerivedGen.Y>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY_LR>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkY_RL>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.Y"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY_LR>>"
+                             [    var "<<DerivedGen.MkY_LR>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY_LR (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X_ADT>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "n"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "k" .$ bindVar "^bnd^{arg:5}")
+                                                      .=    var ">>="
+                                                         .$ (var "<DerivedGen.X_GADT>[0]" .$ var "^outmost-fuel^" .$ var "n")
+                                                         .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                                             .=> iCase
+                                                                   { sc = var "{lamc:0}"
+                                                                   , ty = implicitFalse
+                                                                   , clauses =
+                                                                       [    var "Builtin.DPair.MkDPair" .$ bindVar "m" .$ bindVar "^bnd^{arg:6}"
+                                                                         .=    var "Prelude.pure"
+                                                                            .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                            .$ (   var "DerivedGen.MkY_LR"
+                                                                                .! ("k", var "k")
+                                                                                .! ("m", var "m")
+                                                                                .! ("n", var "n")
+                                                                                .$ var "^bnd^{arg:6}"
+                                                                                .$ var "^bnd^{arg:5}")
+                                                                       ]
+                                                                   })
+                                                    ]
+                                                }))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkY_RL>>"
+                             [    var "<<DerivedGen.MkY_RL>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkY_RL (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X_GADT>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "n"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "k" .$ bindVar "^bnd^{arg:7}")
+                                                      .=    var ">>="
+                                                         .$ (var "<DerivedGen.X_ADT>[0]" .$ var "^outmost-fuel^" .$ var "n")
+                                                         .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                                             .=> iCase
+                                                                   { sc = var "{lamc:0}"
+                                                                   , ty = implicitFalse
+                                                                   , clauses =
+                                                                       [    var "Builtin.DPair.MkDPair" .$ bindVar "m" .$ bindVar "^bnd^{arg:8}"
+                                                                         .=    var "Prelude.pure"
+                                                                            .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                            .$ (   var "DerivedGen.MkY_RL"
+                                                                                .! ("k", var "k")
+                                                                                .! ("m", var "m")
+                                                                                .! ("n", var "n")
+                                                                                .$ var "^bnd^{arg:8}"
+                                                                                .$ var "^bnd^{arg:7}")
+                                                                       ]
+                                                                   })
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.MkY_LR>>" .$ var "^fuel_arg^")
+                                 .$ (var "::" .$ (var "<<DerivedGen.MkY_RL>>" .$ var "^fuel_arg^") .$ var "Nil")))
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X_ADT>[0]"
+              [    var "<DerivedGen.X_ADT>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X_ADT" .$ var "{arg:1}" .$ var "{arg:2}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^" .$ bindVar "n"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkX" .$ var "n" .$ var "m"))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X_ADT[0] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X_GADT>[]"
+              [    var "<DerivedGen.X_GADT>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_4>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.X_GADT" .$ var "{arg:3}" .$ var "{arg:4}")))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_5>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.X_GADT" .$ var "{arg:3}" .$ var "{arg:4}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_4>>"
+                             [    var "<<DerivedGen.MkXG_4>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_4 (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (   var "Builtin.DPair.MkDPair"
+                                          .$ implicitTrue
+                                          .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ var "DerivedGen.MkXG_4")))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_5>>"
+                             [    var "<<DerivedGen.MkXG_5>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_5 (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (   var "Builtin.DPair.MkDPair"
+                                                  .$ implicitTrue
+                                                  .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkXG_5" .! ("m", var "m"))))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X_GADT[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.MkXG_4>>" .$ var "^fuel_arg^")
+                                 .$ (var "::" .$ (var "<<DerivedGen.MkXG_5>>" .$ var "^fuel_arg^") .$ var "Nil")))
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X_GADT>[0]"
+              [    var "<DerivedGen.X_GADT>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:3}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_4>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X_GADT" .$ var "{arg:3}" .$ var "{arg:4}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkXG_5>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.X_GADT" .$ var "{arg:3}" .$ var "{arg:4}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_4>>"
+                             [       var "<<DerivedGen.MkXG_4>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (   var "Prelude.Types.S"
+                                      .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z"))))
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_4 (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ var "DerivedGen.MkXG_4"))
+                             , var "<<DerivedGen.MkXG_4>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkXG_5>>"
+                             [       var "<<DerivedGen.MkXG_5>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (   var "Prelude.Types.S"
+                                      .$ (   var "Prelude.Types.S"
+                                          .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z")))))
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkXG_5 (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.MkXG_5" .! ("m", var "m")))))
+                             , var "<<DerivedGen.MkXG_5>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X_GADT[0] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<DerivedGen.MkXG_4>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:3}>")
+                                 .$ (var "::" .$ (var "<<DerivedGen.MkXG_5>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:3}>") .$ var "Nil")))
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.X_ADT>[]"
+              [    var "<DerivedGen.X_ADT>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.X_ADT" .$ var "{arg:1}" .$ var "{arg:2}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [    var "<<DerivedGen.MkX>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "m") implicitFalse
+                                                  .=>    var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (   var "Builtin.DPair.MkDPair"
+                                                          .$ implicitTrue
+                                                          .$ (   var "Builtin.DPair.MkDPair"
+                                                              .$ implicitTrue
+                                                              .$ (var "DerivedGen.MkX" .$ var "n" .$ var "m"))))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X_ADT[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:9}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:9}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/005 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/005 gadt/expected
@@ -3,289 +3,303 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty Nat)} -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty String)} -> Gen MaybeEmpty (b : Bool ** D b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<Prelude.Types.Nat>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                            -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                    $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                    $ IVar Prelude.Types.Nat))
-    => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:2} : IVar Data.Fuel.Fuel)
-                                                        -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                $ IPrimVal String))
-    => ILocal (IApp. IVar <DerivedGen.D>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.D>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Basics.Bool
-                                         $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                => (IApp. IVar DerivedGen.D
-                                                        $ IVar {arg:3}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Basics.Bool>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Basics.Bool)))
-         IDef <DerivedGen.D>[]
-              [ PatClause (IApp. IVar <DerivedGen.D>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.D[] (dry fuel))
-                                                          $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                                             em
-                                                                             (IVar MaybeEmpty)
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar <<DerivedGen.JJ>>
-                                                                               $ IVar Data.Fuel.Dry)
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar <<DerivedGen.TL>>
-                                                                                      $ IVar Data.Fuel.Dry)
-                                                                               $ IVar Nil))))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.D[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.JJ>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.FN>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ (IApp. IVar ::
-                                                                                      $ (IApp. IVar Builtin.MkPair
-                                                                                             $ IVar Data.Nat.Pos.one
-                                                                                             $ (IApp. IVar <<DerivedGen.TL>>
-                                                                                                    $ IVar ^fuel_arg^))
-                                                                                      $ (IApp. IVar ::
-                                                                                             $ (IApp. IVar Builtin.MkPair
-                                                                                                    $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                                           $ IVar ^sub^fuel_arg^)
-                                                                                                    $ (IApp. IVar <<DerivedGen.TR>>
-                                                                                                           $ IVar ^sub^fuel_arg^))
-                                                                                             $ IVar Nil)))))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.JJ>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.FN>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.TL>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.TR>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3}))))))
-                            IDef <<DerivedGen.JJ>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.JJ>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.JJ (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Basics.Bool>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg b : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg ^bnd^{arg:4} : Implicit False)
-                                                                               => (IApp. IVar >>=
-                                                                                       $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                                              $ IVar ^outmost-fuel^)
-                                                                                       $ (ILam.  (MW ExplicitArg ^bnd^{arg:5} : Implicit False)
-                                                                                              => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                  f
-                                                                                                                  (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                       $ Implicit True)
-                                                                                                      $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                             $ Implicit True
-                                                                                                             $ (IApp. INamedApp (IVar DerivedGen.JJ)
-                                                                                                                                b
-                                                                                                                                (IVar b)
-                                                                                                                    $ IVar ^bnd^{arg:4}
-                                                                                                                    $ IVar ^bnd^{arg:5})))))))))) ]
-                            IDef <<DerivedGen.FN>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.FN>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.FN (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.D>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar b
-                                                                                          $ IBindVar ^bnd^{arg:6})
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                                                 $ IVar ^outmost-fuel^)
-                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:7} : Implicit False)
-                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                     f
-                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                          $ Implicit True)
-                                                                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                $ Implicit True
-                                                                                                                $ (IApp. INamedApp (IVar DerivedGen.FN)
-                                                                                                                                   b
-                                                                                                                                   (IVar b)
-                                                                                                                       $ IVar ^bnd^{arg:7}
-                                                                                                                       $ IVar ^bnd^{arg:6}))))) ]))) ]
-                            IDef <<DerivedGen.TL>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.TL>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.TL (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<^prim^.String>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:8} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar DerivedGen.TL
-                                                                                      $ IVar ^bnd^{arg:8})))))) ]
-                            IDef <<DerivedGen.TR>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.TR>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.TR (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.D>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar b
-                                                                                          $ IBindVar ^bnd^{arg:9})
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar external^<^prim^.String>[]
-                                                                                                 $ IVar ^outmost-fuel^)
-                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:10} : Implicit False)
-                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                     f
-                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                          $ Implicit True)
-                                                                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                $ Implicit True
-                                                                                                                $ (IApp. INamedApp (IVar DerivedGen.TR)
-                                                                                                                                   b
-                                                                                                                                   (IVar b)
-                                                                                                                       $ IVar ^bnd^{arg:10}
-                                                                                                                       $ IVar ^bnd^{arg:9}))))) ]))) ] ]
-         IDef <Prelude.Basics.Bool>[]
-              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Prelude.Basics.Bool[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<Prelude.Basics.False>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<Prelude.Basics.True>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.False>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.True>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IDef <<Prelude.Basics.False>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.False>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.False (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.False)) ]
-                            IDef <<Prelude.Basics.True>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.True>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.True (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.True)) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<Prelude.Types.Nat>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<^prim^.String>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ primVal (PrT StringType))
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.D>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Basics.Bool"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool") .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Basics.Bool>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.D>[]"
+              [    var "<DerivedGen.D>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.JJ>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Basics.Bool"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                                .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.FN>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Basics.Bool"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                                .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.TL>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Basics.Bool"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                                .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.TR>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Basics.Bool"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                                .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.JJ>>"
+                             [    var "<<DerivedGen.JJ>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.JJ (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Basics.Bool>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "b") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:4}") implicitFalse
+                                                  .=>    var ">>="
+                                                      .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:5}") implicitFalse
+                                                          .=>    var "Prelude.pure"
+                                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                              .$ (   var "Builtin.DPair.MkDPair"
+                                                                  .$ implicitTrue
+                                                                  .$ (   var "DerivedGen.JJ"
+                                                                      .! ("b", var "b")
+                                                                      .$ var "^bnd^{arg:4}"
+                                                                      .$ var "^bnd^{arg:5}"))))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.FN>>"
+                             [    var "<<DerivedGen.FN>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.FN (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.D>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "b" .$ bindVar "^bnd^{arg:6}"
+                                                      .=    var ">>="
+                                                         .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                                         .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:7}") implicitFalse
+                                                             .=>    var "Prelude.pure"
+                                                                 .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                 .$ (   var "Builtin.DPair.MkDPair"
+                                                                     .$ implicitTrue
+                                                                     .$ (   var "DerivedGen.FN"
+                                                                         .! ("b", var "b")
+                                                                         .$ var "^bnd^{arg:7}"
+                                                                         .$ var "^bnd^{arg:6}")))
+                                                    ]
+                                                }))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.TL>>"
+                             [    var "<<DerivedGen.TL>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.TL (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:8}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.TL" .$ var "^bnd^{arg:8}"))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.TR>>"
+                             [    var "<<DerivedGen.TR>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.TR (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.D>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "b" .$ bindVar "^bnd^{arg:9}"
+                                                      .=    var ">>="
+                                                         .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^")
+                                                         .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:10}") implicitFalse
+                                                             .=>    var "Prelude.pure"
+                                                                 .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                 .$ (   var "Builtin.DPair.MkDPair"
+                                                                     .$ implicitTrue
+                                                                     .$ (   var "DerivedGen.TR"
+                                                                         .! ("b", var "b")
+                                                                         .$ var "^bnd^{arg:10}"
+                                                                         .$ var "^bnd^{arg:9}")))
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.D[] (dry fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                                        .! ("em", var "MaybeEmpty")
+                                        .$ (   var "::"
+                                            .$ (var "<<DerivedGen.JJ>>" .$ var "Data.Fuel.Dry")
+                                            .$ (var "::" .$ (var "<<DerivedGen.TL>>" .$ var "Data.Fuel.Dry") .$ var "Nil")))
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.D[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<DerivedGen.JJ>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<DerivedGen.FN>>" .$ var "^sub^fuel_arg^"))
+                                                .$ (   var "::"
+                                                    .$ (   var "Builtin.MkPair"
+                                                        .$ var "Data.Nat.Pos.one"
+                                                        .$ (var "<<DerivedGen.TL>>" .$ var "^fuel_arg^"))
+                                                    .$ (   var "::"
+                                                        .$ (   var "Builtin.MkPair"
+                                                            .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                            .$ (var "<<DerivedGen.TR>>" .$ var "^sub^fuel_arg^"))
+                                                        .$ var "Nil")))))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Basics.Bool>[]"
+              [    var "<Prelude.Basics.Bool>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Basics.False>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Basics.True>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Basics.False>>"
+                             [    var "<<Prelude.Basics.False>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Basics.False (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Basics.False")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Basics.True>>"
+                             [    var "<<Prelude.Basics.True>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Basics.True (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Basics.True")
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "Prelude.Basics.Bool[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<Prelude.Basics.False>>" .$ var "^fuel_arg^")
+                                 .$ (var "::" .$ (var "<<Prelude.Basics.True>>" .$ var "^fuel_arg^") .$ var "Nil")))
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.D>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/006 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/006 gadt/expected
@@ -3,508 +3,501 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty Nat)} -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty String)} -> (b : Bool) -> Gen MaybeEmpty (D b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<Prelude.Types.Nat>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                            -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                    $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                    $ IVar Prelude.Types.Nat))
-    => (MW AutoImplicit external^<^prim^.String>[] : IPi.  (MW ExplicitArg {arg:2} : IVar Data.Fuel.Fuel)
-                                                        -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                $ IPrimVal String))
-    => (MW ExplicitArg outer^<b> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.D>[0]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<b>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.D>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.D
-                                         $ IVar {arg:3}))))
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.D>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Basics.Bool
-                                         $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                => (IApp. IVar DerivedGen.D
-                                                        $ IVar {arg:3}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Basics.Bool>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Basics.Bool)))
-         IDef <DerivedGen.D>[0]
-              [ PatClause (IApp. IVar <DerivedGen.D>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:3}>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.D[0] (dry fuel))
-                                                          $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                                             em
-                                                                             (IVar MaybeEmpty)
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar <<DerivedGen.JJ>>
-                                                                               $ IVar Data.Fuel.Dry
-                                                                               $ IVar inter^<{arg:3}>)
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar <<DerivedGen.TL>>
-                                                                                      $ IVar Data.Fuel.Dry
-                                                                                      $ IVar inter^<{arg:3}>)
-                                                                               $ IVar Nil))))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.D[0] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.JJ>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<{arg:3}>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.FN>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<{arg:3}>))
-                                                                               $ (IApp. IVar ::
-                                                                                      $ (IApp. IVar Builtin.MkPair
-                                                                                             $ IVar Data.Nat.Pos.one
-                                                                                             $ (IApp. IVar <<DerivedGen.TL>>
-                                                                                                    $ IVar ^fuel_arg^
-                                                                                                    $ IVar inter^<{arg:3}>))
-                                                                                      $ (IApp. IVar ::
-                                                                                             $ (IApp. IVar Builtin.MkPair
-                                                                                                    $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                                           $ IVar ^sub^fuel_arg^)
-                                                                                                    $ (IApp. IVar <<DerivedGen.TR>>
-                                                                                                           $ IVar ^sub^fuel_arg^
-                                                                                                           $ IVar inter^<{arg:3}>))
-                                                                                             $ IVar Nil)))))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.JJ>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.D
-                                                            $ IVar {arg:3}))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.FN>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.D
-                                                            $ IVar {arg:3}))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.TL>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.D
-                                                            $ IVar {arg:3}))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.TR>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.D
-                                                            $ IVar {arg:3}))))
-                            IDef <<DerivedGen.JJ>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.JJ>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar b)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.JJ (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:4} : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg ^bnd^{arg:5} : Implicit False)
-                                                                               => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                   f
-                                                                                                   (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                        $ Implicit True)
-                                                                                       $ (IApp. INamedApp (IVar DerivedGen.JJ)
-                                                                                                          b
-                                                                                                          (IVar b)
-                                                                                              $ IVar ^bnd^{arg:4}
-                                                                                              $ IVar ^bnd^{arg:5}))))))) ]
-                            IDef <<DerivedGen.FN>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.FN>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IVar Prelude.Basics.False)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.FN (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.D>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar b
-                                                                                          $ IBindVar ^bnd^{arg:6})
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                                                 $ IVar ^outmost-fuel^)
-                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:7} : Implicit False)
-                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                     f
-                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                          $ Implicit True)
-                                                                                                         $ (IApp. INamedApp (IVar DerivedGen.FN)
-                                                                                                                            b
-                                                                                                                            (IVar b)
-                                                                                                                $ IVar ^bnd^{arg:7}
-                                                                                                                $ IVar ^bnd^{arg:6})))) ])))
-                                 , PatClause (IApp. IVar <<DerivedGen.FN>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.TL>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.TL>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IVar Prelude.Basics.True)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.TL (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<^prim^.String>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:8} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar DerivedGen.TL
-                                                                               $ IVar ^bnd^{arg:8})))))
-                                 , PatClause (IApp. IVar <<DerivedGen.TL>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.TR>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.TR>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IVar Prelude.Basics.True)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.TR (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.D>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar b
-                                                                                          $ IBindVar ^bnd^{arg:9})
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar external^<^prim^.String>[]
-                                                                                                 $ IVar ^outmost-fuel^)
-                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:10} : Implicit False)
-                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                     f
-                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                          $ Implicit True)
-                                                                                                         $ (IApp. INamedApp (IVar DerivedGen.TR)
-                                                                                                                            b
-                                                                                                                            (IVar b)
-                                                                                                                $ IVar ^bnd^{arg:10}
-                                                                                                                $ IVar ^bnd^{arg:9})))) ])))
-                                 , PatClause (IApp. IVar <<DerivedGen.TR>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
-         IDef <DerivedGen.D>[]
-              [ PatClause (IApp. IVar <DerivedGen.D>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.D[] (dry fuel))
-                                                          $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                                             em
-                                                                             (IVar MaybeEmpty)
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar <<DerivedGen.JJ>>
-                                                                               $ IVar Data.Fuel.Dry)
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar <<DerivedGen.TL>>
-                                                                                      $ IVar Data.Fuel.Dry)
-                                                                               $ IVar Nil))))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.D[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.JJ>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.FN>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ (IApp. IVar ::
-                                                                                      $ (IApp. IVar Builtin.MkPair
-                                                                                             $ IVar Data.Nat.Pos.one
-                                                                                             $ (IApp. IVar <<DerivedGen.TL>>
-                                                                                                    $ IVar ^fuel_arg^))
-                                                                                      $ (IApp. IVar ::
-                                                                                             $ (IApp. IVar Builtin.MkPair
-                                                                                                    $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                                           $ IVar ^sub^fuel_arg^)
-                                                                                                    $ (IApp. IVar <<DerivedGen.TR>>
-                                                                                                           $ IVar ^sub^fuel_arg^))
-                                                                                             $ IVar Nil)))))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.JJ>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.FN>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.TL>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.TR>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Basics.Bool
-                                                            $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Basics.Bool)
-                                                                   => (IApp. IVar DerivedGen.D
-                                                                           $ IVar {arg:3}))))))
-                            IDef <<DerivedGen.JJ>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.JJ>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.JJ (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Basics.Bool>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg b : Implicit False)
-                                                                => (IApp. IVar >>=
-                                                                        $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                               $ IVar ^outmost-fuel^)
-                                                                        $ (ILam.  (MW ExplicitArg ^bnd^{arg:4} : Implicit False)
-                                                                               => (IApp. IVar >>=
-                                                                                       $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                                              $ IVar ^outmost-fuel^)
-                                                                                       $ (ILam.  (MW ExplicitArg ^bnd^{arg:5} : Implicit False)
-                                                                                              => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                  f
-                                                                                                                  (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                       $ Implicit True)
-                                                                                                      $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                             $ Implicit True
-                                                                                                             $ (IApp. INamedApp (IVar DerivedGen.JJ)
-                                                                                                                                b
-                                                                                                                                (IVar b)
-                                                                                                                    $ IVar ^bnd^{arg:4}
-                                                                                                                    $ IVar ^bnd^{arg:5})))))))))) ]
-                            IDef <<DerivedGen.FN>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.FN>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.FN (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.D>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar b
-                                                                                          $ IBindVar ^bnd^{arg:6})
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                                                 $ IVar ^outmost-fuel^)
-                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:7} : Implicit False)
-                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                     f
-                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                          $ Implicit True)
-                                                                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                $ Implicit True
-                                                                                                                $ (IApp. INamedApp (IVar DerivedGen.FN)
-                                                                                                                                   b
-                                                                                                                                   (IVar b)
-                                                                                                                       $ IVar ^bnd^{arg:7}
-                                                                                                                       $ IVar ^bnd^{arg:6}))))) ]))) ]
-                            IDef <<DerivedGen.TL>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.TL>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.TL (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<^prim^.String>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:8} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar DerivedGen.TL
-                                                                                      $ IVar ^bnd^{arg:8})))))) ]
-                            IDef <<DerivedGen.TR>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.TR>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.TR (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.D>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar b
-                                                                                          $ IBindVar ^bnd^{arg:9})
-                                                                                     (IApp. IVar >>=
-                                                                                          $ (IApp. IVar external^<^prim^.String>[]
-                                                                                                 $ IVar ^outmost-fuel^)
-                                                                                          $ (ILam.  (MW ExplicitArg ^bnd^{arg:10} : Implicit False)
-                                                                                                 => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                                     f
-                                                                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                          $ Implicit True)
-                                                                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                                $ Implicit True
-                                                                                                                $ (IApp. INamedApp (IVar DerivedGen.TR)
-                                                                                                                                   b
-                                                                                                                                   (IVar b)
-                                                                                                                       $ IVar ^bnd^{arg:10}
-                                                                                                                       $ IVar ^bnd^{arg:9}))))) ]))) ] ]
-         IDef <Prelude.Basics.Bool>[]
-              [ PatClause (IApp. IVar <Prelude.Basics.Bool>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Prelude.Basics.Bool[] (non-recursive))
-                                       $ (IApp. INamedApp (IVar Test.DepTyCheck.Gen.oneOf)
-                                                          em
-                                                          (IVar MaybeEmpty)
-                                              $ (IApp. IVar ::
-                                                     $ (IApp. IVar <<Prelude.Basics.False>>
-                                                            $ IVar ^fuel_arg^)
-                                                     $ (IApp. IVar ::
-                                                            $ (IApp. IVar <<Prelude.Basics.True>>
-                                                                   $ IVar ^fuel_arg^)
-                                                            $ IVar Nil)))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.False>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Basics.True>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Basics.Bool)))
-                            IDef <<Prelude.Basics.False>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.False>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.False (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.False)) ]
-                            IDef <<Prelude.Basics.True>>
-                                 [ PatClause (IApp. IVar <<Prelude.Basics.True>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Basics.True (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Basics.True)) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<Prelude.Types.Nat>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<^prim^.String>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ primVal (PrT StringType))
+.=> MkArg MW ExplicitArg (Just "outer^<b>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.D>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ (var "DerivedGen.D" .$ var "{arg:3}")
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.D>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Basics.Bool"
+                             .$ (MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool") .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Basics.Bool>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.D>[0]"
+              [    var "<DerivedGen.D>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:3}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.JJ>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.D" .$ var "{arg:3}")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.FN>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.D" .$ var "{arg:3}")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.TL>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.D" .$ var "{arg:3}")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.TR>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.D" .$ var "{arg:3}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.JJ>>"
+                             [    var "<<DerivedGen.JJ>>" .$ bindVar "^cons_fuel^" .$ bindVar "b"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.JJ (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:4}") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:5}") implicitFalse
+                                                  .=>    var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (var "DerivedGen.JJ" .! ("b", var "b") .$ var "^bnd^{arg:4}" .$ var "^bnd^{arg:5}"))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.FN>>"
+                             [    var "<<DerivedGen.FN>>" .$ bindVar "^cons_fuel^" .$ var "Prelude.Basics.False"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.FN (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.D>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "b" .$ bindVar "^bnd^{arg:6}"
+                                                      .=    var ">>="
+                                                         .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                                         .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:7}") implicitFalse
+                                                             .=>    var "Prelude.pure"
+                                                                 .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                 .$ (   var "DerivedGen.FN"
+                                                                     .! ("b", var "b")
+                                                                     .$ var "^bnd^{arg:7}"
+                                                                     .$ var "^bnd^{arg:6}"))
+                                                    ]
+                                                }))
+                             , var "<<DerivedGen.FN>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.TL>>"
+                             [    var "<<DerivedGen.TL>>" .$ bindVar "^cons_fuel^" .$ var "Prelude.Basics.True"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.TL (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:8}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "DerivedGen.TL" .$ var "^bnd^{arg:8}")))
+                             , var "<<DerivedGen.TL>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.TR>>"
+                             [    var "<<DerivedGen.TR>>" .$ bindVar "^cons_fuel^" .$ var "Prelude.Basics.True"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.TR (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.D>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "b" .$ bindVar "^bnd^{arg:9}"
+                                                      .=    var ">>="
+                                                         .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^")
+                                                         .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:10}") implicitFalse
+                                                             .=>    var "Prelude.pure"
+                                                                 .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                 .$ (   var "DerivedGen.TR"
+                                                                     .! ("b", var "b")
+                                                                     .$ var "^bnd^{arg:10}"
+                                                                     .$ var "^bnd^{arg:9}"))
+                                                    ]
+                                                }))
+                             , var "<<DerivedGen.TR>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.D[0] (dry fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                                        .! ("em", var "MaybeEmpty")
+                                        .$ (   var "::"
+                                            .$ (var "<<DerivedGen.JJ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:3}>")
+                                            .$ (var "::" .$ (var "<<DerivedGen.TL>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:3}>") .$ var "Nil")))
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.D[0] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<DerivedGen.JJ>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:3}>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<DerivedGen.FN>>" .$ var "^sub^fuel_arg^" .$ var "inter^<{arg:3}>"))
+                                                .$ (   var "::"
+                                                    .$ (   var "Builtin.MkPair"
+                                                        .$ var "Data.Nat.Pos.one"
+                                                        .$ (var "<<DerivedGen.TL>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:3}>"))
+                                                    .$ (   var "::"
+                                                        .$ (   var "Builtin.MkPair"
+                                                            .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                            .$ (var "<<DerivedGen.TR>>" .$ var "^sub^fuel_arg^" .$ var "inter^<{arg:3}>"))
+                                                        .$ var "Nil")))))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<DerivedGen.D>[]"
+              [    var "<DerivedGen.D>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.JJ>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Basics.Bool"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                                .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.FN>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Basics.Bool"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                                .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.TL>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Basics.Bool"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                                .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.TR>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Basics.Bool"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Basics.Bool")
+                                                .=> var "DerivedGen.D" .$ var "{arg:3}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.JJ>>"
+                             [    var "<<DerivedGen.JJ>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.JJ (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Basics.Bool>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "b") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:4}") implicitFalse
+                                                  .=>    var ">>="
+                                                      .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:5}") implicitFalse
+                                                          .=>    var "Prelude.pure"
+                                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                              .$ (   var "Builtin.DPair.MkDPair"
+                                                                  .$ implicitTrue
+                                                                  .$ (   var "DerivedGen.JJ"
+                                                                      .! ("b", var "b")
+                                                                      .$ var "^bnd^{arg:4}"
+                                                                      .$ var "^bnd^{arg:5}"))))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.FN>>"
+                             [    var "<<DerivedGen.FN>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.FN (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.D>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "b" .$ bindVar "^bnd^{arg:6}"
+                                                      .=    var ">>="
+                                                         .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                                         .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:7}") implicitFalse
+                                                             .=>    var "Prelude.pure"
+                                                                 .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                 .$ (   var "Builtin.DPair.MkDPair"
+                                                                     .$ implicitTrue
+                                                                     .$ (   var "DerivedGen.FN"
+                                                                         .! ("b", var "b")
+                                                                         .$ var "^bnd^{arg:7}"
+                                                                         .$ var "^bnd^{arg:6}")))
+                                                    ]
+                                                }))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.TL>>"
+                             [    var "<<DerivedGen.TL>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.TL (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:8}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.TL" .$ var "^bnd^{arg:8}"))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.TR>>"
+                             [    var "<<DerivedGen.TR>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.TR (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.D>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "b" .$ bindVar "^bnd^{arg:9}"
+                                                      .=    var ">>="
+                                                         .$ (var "external^<^prim^.String>[]" .$ var "^outmost-fuel^")
+                                                         .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:10}") implicitFalse
+                                                             .=>    var "Prelude.pure"
+                                                                 .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                                 .$ (   var "Builtin.DPair.MkDPair"
+                                                                     .$ implicitTrue
+                                                                     .$ (   var "DerivedGen.TR"
+                                                                         .! ("b", var "b")
+                                                                         .$ var "^bnd^{arg:10}"
+                                                                         .$ var "^bnd^{arg:9}")))
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.D[] (dry fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                                        .! ("em", var "MaybeEmpty")
+                                        .$ (   var "::"
+                                            .$ (var "<<DerivedGen.JJ>>" .$ var "Data.Fuel.Dry")
+                                            .$ (var "::" .$ (var "<<DerivedGen.TL>>" .$ var "Data.Fuel.Dry") .$ var "Nil")))
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.D[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<DerivedGen.JJ>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<DerivedGen.FN>>" .$ var "^sub^fuel_arg^"))
+                                                .$ (   var "::"
+                                                    .$ (   var "Builtin.MkPair"
+                                                        .$ var "Data.Nat.Pos.one"
+                                                        .$ (var "<<DerivedGen.TL>>" .$ var "^fuel_arg^"))
+                                                    .$ (   var "::"
+                                                        .$ (   var "Builtin.MkPair"
+                                                            .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                            .$ (var "<<DerivedGen.TR>>" .$ var "^sub^fuel_arg^"))
+                                                        .$ var "Nil")))))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Basics.Bool>[]"
+              [    var "<Prelude.Basics.Bool>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Basics.False>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Basics.True>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Basics.Bool"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Basics.False>>"
+                             [    var "<<Prelude.Basics.False>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Basics.False (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Basics.False")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Basics.True>>"
+                             [    var "<<Prelude.Basics.True>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Basics.True (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Basics.True")
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "Prelude.Basics.Bool[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.oneOf"
+                             .! ("em", var "MaybeEmpty")
+                             .$ (   var "::"
+                                 .$ (var "<<Prelude.Basics.False>>" .$ var "^fuel_arg^")
+                                 .$ (var "::" .$ (var "<<Prelude.Basics.True>>" .$ var "^fuel_arg^") .$ var "Nil")))
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.D>[0]" .$ var "^outmost-fuel^" .$ var "outer^<b>"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/007 eq-n/expected
+++ b/tests/derivation/least-effort/print/gadt/007 eq-n/expected
@@ -3,146 +3,161 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> Gen MaybeEmpty (a : Nat ** (b : Nat ** EqualN a b))
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => ILocal (IApp. IVar <DerivedGen.EqualN>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.EqualN>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.EqualN
-                                                                       $ IVar {arg:1}
-                                                                       $ IVar {arg:2}))))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Prelude.Types.Nat>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Prelude.Types.Nat)))
-         IDef <DerivedGen.EqualN>[]
-              [ PatClause (IApp. IVar <DerivedGen.EqualN>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.EqualN[] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.ReflN>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.ReflN>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.EqualN
-                                                                                          $ IVar {arg:1}
-                                                                                          $ IVar {arg:2}))))))))
-                            IDef <<DerivedGen.ReflN>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.ReflN>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.ReflN (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg x : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                      $ Implicit True
-                                                                                      $ INamedApp (IVar DerivedGen.ReflN)
-                                                                                                  x
-                                                                                                  (IVar x))))))) ] ]
-         IDef <Prelude.Types.Nat>[]
-              [ PatClause (IApp. IVar <Prelude.Types.Nat>[]
-                               $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (dry fuel))
-                                                          $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal Prelude.Types.Nat[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<Prelude.Types.Z>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<Prelude.Types.S>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.Z>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Prelude.Types.S>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Prelude.Types.Nat)))
-                            IDef <<Prelude.Types.Z>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.Z>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.Z (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Prelude.Types.Z)) ]
-                            IDef <<Prelude.Types.S>>
-                                 [ PatClause (IApp. IVar <<Prelude.Types.S>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Prelude.Types.S (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Prelude.Types.Nat>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:3} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Prelude.Types.S
-                                                                               $ IVar ^bnd^{arg:3}))))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.EqualN>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Types.Nat"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                         .=> var "DerivedGen.EqualN" .$ var "{arg:1}" .$ var "{arg:2}")))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Prelude.Types.Nat>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.EqualN>[]"
+              [    var "<DerivedGen.EqualN>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.ReflN>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.EqualN" .$ var "{arg:1}" .$ var "{arg:2}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.ReflN>>"
+                             [    var "<<DerivedGen.ReflN>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.ReflN (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "x") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (   var "Builtin.DPair.MkDPair"
+                                                  .$ implicitTrue
+                                                  .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.ReflN" .! ("x", var "x"))))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.EqualN[] (non-recursive)"))
+                         .$ (var "<<DerivedGen.ReflN>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.Z>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Prelude.Types.S>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:3}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:3}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.EqualN>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/008 eq-n/expected
+++ b/tests/derivation/least-effort/print/gadt/008 eq-n/expected
@@ -3,62 +3,68 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Nat) -> Gen MaybeEmpty (b : Nat ** EqualN a b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.EqualN>[0]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.EqualN>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.EqualN
-                                                        $ IVar {arg:1}
-                                                        $ IVar {arg:2}))))))
-         IDef <DerivedGen.EqualN>[0]
-              [ PatClause (IApp. IVar <DerivedGen.EqualN>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.EqualN[0] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.ReflN>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.ReflN>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.EqualN
-                                                                           $ IVar {arg:1}
-                                                                           $ IVar {arg:2}))))))
-                            IDef <<DerivedGen.ReflN>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.ReflN>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar x)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.ReflN (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ INamedApp (IVar DerivedGen.ReflN)
-                                                                            x
-                                                                            (IVar x)))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.EqualN>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.EqualN" .$ var "{arg:1}" .$ var "{arg:2}"))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.EqualN>[0]"
+              [    var "<DerivedGen.EqualN>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.ReflN>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.EqualN" .$ var "{arg:1}" .$ var "{arg:2}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.ReflN>>"
+                             [    var "<<DerivedGen.ReflN>>" .$ bindVar "^cons_fuel^" .$ bindVar "x"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.ReflN (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.ReflN" .! ("x", var "x"))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.EqualN[0] (non-recursive)"))
+                         .$ (var "<<DerivedGen.ReflN>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.EqualN>[0]" .$ var "^outmost-fuel^" .$ var "outer^<a>"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/009 eq-n/expected
+++ b/tests/derivation/least-effort/print/gadt/009 eq-n/expected
@@ -3,62 +3,68 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (b : Nat) -> Gen MaybeEmpty (a : Nat ** EqualN a b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<b> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.EqualN>[1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<b>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.EqualN>[1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.EqualN
-                                                        $ IVar {arg:2}
-                                                        $ IVar {arg:1}))))))
-         IDef <DerivedGen.EqualN>[1]
-              [ PatClause (IApp. IVar <DerivedGen.EqualN>[1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.EqualN[1] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.ReflN>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.ReflN>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.EqualN
-                                                                           $ IVar {arg:2}
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.ReflN>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.ReflN>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar x)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.ReflN (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ INamedApp (IVar DerivedGen.ReflN)
-                                                                            x
-                                                                            (IVar x)))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<b>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.EqualN>[1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.EqualN" .$ var "{arg:2}" .$ var "{arg:1}"))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.EqualN>[1]"
+              [    var "<DerivedGen.EqualN>[1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.ReflN>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.EqualN" .$ var "{arg:2}" .$ var "{arg:1}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.ReflN>>"
+                             [    var "<<DerivedGen.ReflN>>" .$ bindVar "^cons_fuel^" .$ bindVar "x"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.ReflN (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.ReflN" .! ("x", var "x"))))
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.EqualN[1] (non-recursive)"))
+                         .$ (var "<<DerivedGen.ReflN>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.EqualN>[1]" .$ var "^outmost-fuel^" .$ var "outer^<b>"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/010 eq-n/expected
+++ b/tests/derivation/least-effort/print/gadt/010 eq-n/expected
@@ -3,80 +3,84 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Nat) -> (b : Nat) -> Gen MaybeEmpty (EqualN a b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => (MW ExplicitArg outer^<b> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.EqualN>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>
-                   $ IVar outer^<b>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.EqualN>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.EqualN
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}))))
-         IDef <DerivedGen.EqualN>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.EqualN>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.EqualN[0, 1] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.ReflN>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>
-                                              $ IVar inter^<{arg:2}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.ReflN>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.EqualN
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}))))
-                            IDef <<DerivedGen.ReflN>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.ReflN>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar x
-                                                   $ IBindVar to_be_deceqed^^x0)
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^x0
-                                                   $ IVar x)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<b>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.EqualN>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.EqualN" .$ var "{arg:1}" .$ var "{arg:2}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.EqualN>[0, 1]"
+              [    var "<DerivedGen.EqualN>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>" .$ bindVar "inter^<{arg:2}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.ReflN>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.EqualN" .$ var "{arg:1}" .$ var "{arg:2}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.ReflN>>"
+                             [ withClause
+                                 { lhs = var "<<DerivedGen.ReflN>>" .$ bindVar "^cons_fuel^" .$ bindVar "x" .$ bindVar "to_be_deceqed^^x0"
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^x0" .$ var "x"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [       var "<<DerivedGen.ReflN>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "x"
+                                          .$ bindVar "x"
+                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                       .=    var "Test.DepTyCheck.Gen.label"
+                                          .$ (var "fromString" .$ primVal (Str "DerivedGen.ReflN (orders)"))
+                                          .$ (   var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "DerivedGen.ReflN" .! ("x", var "x")))
+                                     ,       var "<<DerivedGen.ReflN>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "x"
+                                          .$ bindVar "to_be_deceqed^^x0"
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.EqualN[0, 1] (non-recursive)"))
+                         .$ (var "<<DerivedGen.ReflN>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.EqualN>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<a>" .$ var "outer^<b>"
+      }
 
-                                              []
-                                              [ PatClause (IApp. IVar <<DerivedGen.ReflN>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar x
-                                                               $ IBindVar x
-                                                               $ (IApp. IVar Prelude.Yes
-                                                                      $ IVar Builtin.Refl))
-                                                          (IApp. IVar Test.DepTyCheck.Gen.label
-                                                               $ (IApp. IVar fromString
-                                                                      $ IPrimVal DerivedGen.ReflN (orders))
-                                                               $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                                  f
-                                                                                  (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                       $ Implicit True)
-                                                                      $ INamedApp (IVar DerivedGen.ReflN)
-                                                                                  x
-                                                                                  (IVar x)))
-                                              , PatClause (IApp. IVar <<DerivedGen.ReflN>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar x
-                                                               $ IBindVar to_be_deceqed^^x0
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ] ] ]

--- a/tests/derivation/least-effort/print/gadt/011 eq deepcons/expected
+++ b/tests/derivation/least-effort/print/gadt/011 eq deepcons/expected
@@ -3,137 +3,148 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel) -> Gen MaybeEmpty Nat)} -> Gen MaybeEmpty (a : Nat ** (b : Nat ** LT2 a b))
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW AutoImplicit external^<Prelude.Types.Nat>[] : IPi.  (MW ExplicitArg {arg:1} : IVar Data.Fuel.Fuel)
-                                                            -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                    $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                                    $ IVar Prelude.Types.Nat))
-    => ILocal (IApp. IVar <DerivedGen.LT2>[] $ IVar ^outmost-fuel^)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.LT2>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar Prelude.Types.Nat
-                                                        $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                                               => (IApp. IVar DerivedGen.LT2
-                                                                       $ IVar {arg:2}
-                                                                       $ IVar {arg:3}))))))))
-         IDef <DerivedGen.LT2>[]
-              [ PatClause (IApp. IVar <DerivedGen.LT2>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.LT2[] (dry fuel))
-                                                          $ (IApp. IVar <<DerivedGen.Base>>
-                                                                 $ IVar Data.Fuel.Dry))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.LT2[] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.Base>>
-                                                                                      $ IVar ^fuel_arg^))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.Step>>
-                                                                                             $ IVar ^sub^fuel_arg^))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.Base>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.LT2
-                                                                                          $ IVar {arg:2}
-                                                                                          $ IVar {arg:3}))))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.Step>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar Prelude.Types.Nat
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                                                                  => (IApp. IVar DerivedGen.LT2
-                                                                                          $ IVar {arg:2}
-                                                                                          $ IVar {arg:3}))))))))
-                            IDef <<DerivedGen.Base>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.Base>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.Base (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar external^<Prelude.Types.Nat>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg x : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                      $ Implicit True
-                                                                                      $ INamedApp (IVar DerivedGen.Base)
-                                                                                                  x
-                                                                                                  (IVar x))))))) ]
-                            IDef <<DerivedGen.Step>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.Step>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.Step (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.LT2>[]
-                                                                $ IVar ^cons_fuel^)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar x
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar y
-                                                                                                 $ IBindVar ^bnd^{arg:4}))
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ Implicit True
-                                                                                                 $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                        $ Implicit True
-                                                                                                        $ (IApp. INamedApp (INamedApp (IVar DerivedGen.Step)
-                                                                                                                                      y
-                                                                                                                                      (IVar y))
-                                                                                                                           x
-                                                                                                                           (IVar x)
-                                                                                                               $ IVar ^bnd^{arg:4})))) ]))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg
+      MW
+      AutoImplicit
+      (Just "external^<Prelude.Types.Nat>[]")
+      (    MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fuel.Fuel")
+       .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat")
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.LT2>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "Prelude.Types.Nat"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                         .=> var "DerivedGen.LT2" .$ var "{arg:2}" .$ var "{arg:3}")))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.LT2>[]"
+              [    var "<DerivedGen.LT2>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.Base>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.LT2" .$ var "{arg:2}" .$ var "{arg:3}")))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.Step>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "Prelude.Types.Nat"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                                        .=> var "DerivedGen.LT2" .$ var "{arg:2}" .$ var "{arg:3}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.Base>>"
+                             [    var "<<DerivedGen.Base>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.Base (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "external^<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "x") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (   var "Builtin.DPair.MkDPair"
+                                                  .$ implicitTrue
+                                                  .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.Base" .! ("x", var "x"))))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.Step>>"
+                             [    var "<<DerivedGen.Step>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.Step (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.LT2>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "x"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "y" .$ bindVar "^bnd^{arg:4}")
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (   var "Builtin.DPair.MkDPair"
+                                                             .$ implicitTrue
+                                                             .$ (   var "Builtin.DPair.MkDPair"
+                                                                 .$ implicitTrue
+                                                                 .$ (   var "DerivedGen.Step"
+                                                                     .! ("y", var "y")
+                                                                     .! ("x", var "x")
+                                                                     .$ var "^bnd^{arg:4}")))
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[] (dry fuel)"))
+                                    .$ (var "<<DerivedGen.Base>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat.Pos.one" .$ (var "<<DerivedGen.Base>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<DerivedGen.Step>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.LT2>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/012 eq deepcons/expected
+++ b/tests/derivation/least-effort/print/gadt/012 eq deepcons/expected
@@ -3,128 +3,127 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Nat) -> Gen MaybeEmpty (b : Nat ** LT2 a b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.LT2>[0]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.LT2>[0]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.LT2
-                                                        $ IVar {arg:1}
-                                                        $ IVar {arg:2}))))))
-         IDef <DerivedGen.LT2>[0]
-              [ PatClause (IApp. IVar <DerivedGen.LT2>[0]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.LT2[0] (dry fuel))
-                                                          $ (IApp. IVar <<DerivedGen.Base>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<{arg:1}>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.LT2[0] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.Base>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<{arg:1}>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.Step>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<{arg:1}>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.Base>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.LT2
-                                                                           $ IVar {arg:1}
-                                                                           $ IVar {arg:2}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.Step>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.LT2
-                                                                           $ IVar {arg:1}
-                                                                           $ IVar {arg:2}))))))
-                            IDef <<DerivedGen.Base>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.Base>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar x)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.Base (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ INamedApp (IVar DerivedGen.Base)
-                                                                            x
-                                                                            (IVar x)))) ]
-                            IDef <<DerivedGen.Step>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.Step>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar x)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.Step (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.LT2>[0]
-                                                                $ IVar ^cons_fuel^
-                                                                $ IVar x)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar y
-                                                                                          $ IBindVar ^bnd^{arg:3})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ Implicit True
-                                                                                                 $ (IApp. INamedApp (INamedApp (IVar DerivedGen.Step)
-                                                                                                                               y
-                                                                                                                               (IVar y))
-                                                                                                                    x
-                                                                                                                    (IVar x)
-                                                                                                        $ IVar ^bnd^{arg:3}))) ]))) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.LT2>[0]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.LT2" .$ var "{arg:1}" .$ var "{arg:2}"))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.LT2>[0]"
+              [    var "<DerivedGen.LT2>[0]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.Base>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.LT2" .$ var "{arg:1}" .$ var "{arg:2}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.Step>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.LT2" .$ var "{arg:1}" .$ var "{arg:2}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.Base>>"
+                             [    var "<<DerivedGen.Base>>" .$ bindVar "^cons_fuel^" .$ bindVar "x"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.Base (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.Base" .! ("x", var "x"))))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.Step>>"
+                             [    var "<<DerivedGen.Step>>" .$ bindVar "^cons_fuel^" .$ bindVar "x"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.Step (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.LT2>[0]" .$ var "^cons_fuel^" .$ var "x")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "y" .$ bindVar "^bnd^{arg:3}"
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (   var "Builtin.DPair.MkDPair"
+                                                             .$ implicitTrue
+                                                             .$ (var "DerivedGen.Step" .! ("y", var "y") .! ("x", var "x") .$ var "^bnd^{arg:3}"))
+                                                    ]
+                                                }))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[0] (dry fuel)"))
+                                    .$ (var "<<DerivedGen.Base>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[0] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<DerivedGen.Base>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<DerivedGen.Step>>" .$ var "^sub^fuel_arg^" .$ var "inter^<{arg:1}>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.LT2>[0]" .$ var "^outmost-fuel^" .$ var "outer^<a>"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/013 eq deepcons/expected
+++ b/tests/derivation/least-effort/print/gadt/013 eq deepcons/expected
@@ -3,139 +3,131 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (b : Nat) -> Gen MaybeEmpty (a : Nat ** LT2 a b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<b> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.LT2>[1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<b>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.LT2>[1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Prelude.Types.Nat
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                => (IApp. IVar DerivedGen.LT2
-                                                        $ IVar {arg:2}
-                                                        $ IVar {arg:1}))))))
-         IDef <DerivedGen.LT2>[1]
-              [ PatClause (IApp. IVar <DerivedGen.LT2>[1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.LT2[1] (dry fuel))
-                                                          $ (IApp. IVar <<DerivedGen.Base>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<{arg:1}>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.LT2[1] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.Base>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<{arg:1}>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.Step>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<{arg:1}>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.Base>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.LT2
-                                                                           $ IVar {arg:2}
-                                                                           $ IVar {arg:1}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.Step>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Prelude.Types.Nat
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                                                   => (IApp. IVar DerivedGen.LT2
-                                                                           $ IVar {arg:2}
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.Base>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.Base>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ IBindVar x)))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.Base (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ INamedApp (IVar DerivedGen.Base)
-                                                                            x
-                                                                            (IVar x))))
-                                 , PatClause (IApp. IVar <<DerivedGen.Base>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.Step>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.Step>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar y))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.Step (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.LT2>[1]
-                                                                $ IVar ^cons_fuel^
-                                                                $ IVar y)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar x
-                                                                                          $ IBindVar ^bnd^{arg:3})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ Implicit True
-                                                                                                 $ (IApp. INamedApp (INamedApp (IVar DerivedGen.Step)
-                                                                                                                               y
-                                                                                                                               (IVar y))
-                                                                                                                    x
-                                                                                                                    (IVar x)
-                                                                                                        $ IVar ^bnd^{arg:3}))) ])))
-                                 , PatClause (IApp. IVar <<DerivedGen.Step>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<b>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.LT2>[1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Prelude.Types.Nat"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                 .=> var "DerivedGen.LT2" .$ var "{arg:2}" .$ var "{arg:1}"))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.LT2>[1]"
+              [    var "<DerivedGen.LT2>[1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.Base>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.LT2" .$ var "{arg:2}" .$ var "{arg:1}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.Step>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Prelude.Types.Nat"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                                .=> var "DerivedGen.LT2" .$ var "{arg:2}" .$ var "{arg:1}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.Base>>"
+                             [       var "<<DerivedGen.Base>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ bindVar "x"))
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.Base (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.Base" .! ("x", var "x"))))
+                             , var "<<DerivedGen.Base>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.Step>>"
+                             [    var "<<DerivedGen.Step>>" .$ bindVar "^cons_fuel^" .$ (var "Prelude.Types.S" .$ bindVar "y")
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.Step (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.LT2>[1]" .$ var "^cons_fuel^" .$ var "y")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "x" .$ bindVar "^bnd^{arg:3}"
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (   var "Builtin.DPair.MkDPair"
+                                                             .$ implicitTrue
+                                                             .$ (var "DerivedGen.Step" .! ("y", var "y") .! ("x", var "x") .$ var "^bnd^{arg:3}"))
+                                                    ]
+                                                }))
+                             , var "<<DerivedGen.Step>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[1] (dry fuel)"))
+                                    .$ (var "<<DerivedGen.Base>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[1] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<DerivedGen.Base>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<DerivedGen.Step>>" .$ var "^sub^fuel_arg^" .$ var "inter^<{arg:1}>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.LT2>[1]" .$ var "^outmost-fuel^" .$ var "outer^<b>"
+      }
+

--- a/tests/derivation/least-effort/print/gadt/014 eq deepcons/expected
+++ b/tests/derivation/least-effort/print/gadt/014 eq deepcons/expected
@@ -3,158 +3,144 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Nat) -> (b : Nat) -> Gen MaybeEmpty (LT2 a b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => (MW ExplicitArg outer^<b> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.LT2>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>
-                   $ IVar outer^<b>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.LT2>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.LT2
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}))))
-         IDef <DerivedGen.LT2>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.LT2>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.LT2[0, 1] (dry fuel))
-                                                          $ (IApp. IVar <<DerivedGen.Base>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<{arg:1}>
-                                                                 $ IVar inter^<{arg:2}>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.LT2[0, 1] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.Base>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<{arg:1}>
-                                                                                      $ IVar inter^<{arg:2}>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.Step>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<{arg:1}>
-                                                                                             $ IVar inter^<{arg:2}>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.Base>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.LT2
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.Step>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.LT2
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}))))
-                            IDef <<DerivedGen.Base>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.Base>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar x
-                                                   $ (IApp. IVar Prelude.Types.S
-                                                          $ (IApp. IVar Prelude.Types.S
-                                                                 $ IBindVar to_be_deceqed^^x0)))
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^x0
-                                                   $ IVar x)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<b>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.LT2>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.LT2" .$ var "{arg:1}" .$ var "{arg:2}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.LT2>[0, 1]"
+              [    var "<DerivedGen.LT2>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>" .$ bindVar "inter^<{arg:2}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.Base>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.LT2" .$ var "{arg:1}" .$ var "{arg:2}")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.Step>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.LT2" .$ var "{arg:1}" .$ var "{arg:2}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.Base>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.Base>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ bindVar "x"
+                                     .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ bindVar "to_be_deceqed^^x0"))
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^x0" .$ var "x"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [       var "<<DerivedGen.Base>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "x"
+                                          .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ bindVar "x"))
+                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                       .=    var "Test.DepTyCheck.Gen.label"
+                                          .$ (var "fromString" .$ primVal (Str "DerivedGen.Base (orders)"))
+                                          .$ (   var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "DerivedGen.Base" .! ("x", var "x")))
+                                     ,       var "<<DerivedGen.Base>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "x"
+                                          .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ bindVar "to_be_deceqed^^x0"))
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             , var "<<DerivedGen.Base>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.Step>>"
+                             [    var "<<DerivedGen.Step>>" .$ bindVar "^cons_fuel^" .$ bindVar "x" .$ (var "Prelude.Types.S" .$ bindVar "y")
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.Step (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.LT2>[0, 1]" .$ var "^cons_fuel^" .$ var "x" .$ var "y")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:3}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "DerivedGen.Step" .! ("y", var "y") .! ("x", var "x") .$ var "^bnd^{arg:3}")))
+                             , var "<<DerivedGen.Step>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[0, 1] (dry fuel)"))
+                                    .$ (var "<<DerivedGen.Base>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[0, 1] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (   var "<<DerivedGen.Base>>"
+                                                    .$ var "^fuel_arg^"
+                                                    .$ var "inter^<{arg:1}>"
+                                                    .$ var "inter^<{arg:2}>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (   var "<<DerivedGen.Step>>"
+                                                        .$ var "^sub^fuel_arg^"
+                                                        .$ var "inter^<{arg:1}>"
+                                                        .$ var "inter^<{arg:2}>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.LT2>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<a>" .$ var "outer^<b>"
+      }
 
-                                              []
-                                              [ PatClause (IApp. IVar <<DerivedGen.Base>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar x
-                                                               $ (IApp. IVar Prelude.Types.S
-                                                                      $ (IApp. IVar Prelude.Types.S
-                                                                             $ IBindVar x))
-                                                               $ (IApp. IVar Prelude.Yes
-                                                                      $ IVar Builtin.Refl))
-                                                          (IApp. IVar Test.DepTyCheck.Gen.label
-                                                               $ (IApp. IVar fromString
-                                                                      $ IPrimVal DerivedGen.Base (orders))
-                                                               $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                                  f
-                                                                                  (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                       $ Implicit True)
-                                                                      $ INamedApp (IVar DerivedGen.Base)
-                                                                                  x
-                                                                                  (IVar x)))
-                                              , PatClause (IApp. IVar <<DerivedGen.Base>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar x
-                                                               $ (IApp. IVar Prelude.Types.S
-                                                                      $ (IApp. IVar Prelude.Types.S
-                                                                             $ IBindVar to_be_deceqed^^x0))
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ]
-                                 , PatClause (IApp. IVar <<DerivedGen.Base>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.Step>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.Step>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IBindVar x
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar y))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.Step (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.LT2>[0, 1]
-                                                                $ IVar ^cons_fuel^
-                                                                $ IVar x
-                                                                $ IVar y)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:3} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. INamedApp (INamedApp (IVar DerivedGen.Step)
-                                                                                                      y
-                                                                                                      (IVar y))
-                                                                                           x
-                                                                                           (IVar x)
-                                                                               $ IVar ^bnd^{arg:3})))))
-                                 , PatClause (IApp. IVar <<DerivedGen.Step>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]

--- a/tests/derivation/least-effort/print/regression/dependent-givens-big/expected
+++ b/tests/derivation/least-effort/print/regression/dependent-givens-big/expected
@@ -3,199 +3,183 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (v : VectMaybeAnyType n) -> Gen MaybeEmpty (i : Fin n ** (t : MaybeAnyType ** AtIndex n i t v))
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => (MW ExplicitArg outer^<v> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>
-                   $ IVar outer^<v>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:1} : IApp. IVar DerivedGen.VectMaybeAnyType.VectMaybeAnyType
-                                                              $ IVar n)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ (IApp. IVar Data.Fin.Fin $ IVar n)
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IApp. IVar Data.Fin.Fin
-                                                                                    $ IVar n)
-                                                => (IApp. IVar Builtin.DPair.DPair
-                                                        $ IVar DerivedGen.MaybeAnyType.MaybeAnyType
-                                                        $ (ILam.  (MW ExplicitArg {arg:3} : IVar DerivedGen.MaybeAnyType.MaybeAnyType)
-                                                               => (IApp. IVar DerivedGen.VectMaybeAnyType.AtIndex
-                                                                       $ IVar n
-                                                                       $ IVar {arg:2}
-                                                                       $ IVar {arg:3}
-                                                                       $ IVar {arg:1}))))))))
-         IDef <DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]
-              [ PatClause (IApp. IVar <DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<n>
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.VectMaybeAnyType.AtIndex[0, 3] (dry fuel))
-                                                          $ (IApp. IVar <<DerivedGen.VectMaybeAnyType.Here>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<n>
-                                                                 $ IVar inter^<{arg:1}>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.VectMaybeAnyType.AtIndex[0, 3] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.VectMaybeAnyType.Here>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<n>
-                                                                                      $ IVar inter^<{arg:1}>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.VectMaybeAnyType.There>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<n>
-                                                                                             $ IVar inter^<{arg:1}>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.VectMaybeAnyType.Here>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:1} : IApp. IVar DerivedGen.VectMaybeAnyType.VectMaybeAnyType
-                                                                                 $ IVar n)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ (IApp. IVar Data.Fin.Fin
-                                                                   $ IVar n)
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IApp. IVar Data.Fin.Fin
-                                                                                                       $ IVar n)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar DerivedGen.MaybeAnyType.MaybeAnyType
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3} : IVar DerivedGen.MaybeAnyType.MaybeAnyType)
-                                                                                  => (IApp. IVar DerivedGen.VectMaybeAnyType.AtIndex
-                                                                                          $ IVar n
-                                                                                          $ IVar {arg:2}
-                                                                                          $ IVar {arg:3}
-                                                                                          $ IVar {arg:1}))))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.VectMaybeAnyType.There>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:1} : IApp. IVar DerivedGen.VectMaybeAnyType.VectMaybeAnyType
-                                                                                 $ IVar n)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ (IApp. IVar Data.Fin.Fin
-                                                                   $ IVar n)
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IApp. IVar Data.Fin.Fin
-                                                                                                       $ IVar n)
-                                                                   => (IApp. IVar Builtin.DPair.DPair
-                                                                           $ IVar DerivedGen.MaybeAnyType.MaybeAnyType
-                                                                           $ (ILam.  (MW ExplicitArg {arg:3} : IVar DerivedGen.MaybeAnyType.MaybeAnyType)
-                                                                                  => (IApp. IVar DerivedGen.VectMaybeAnyType.AtIndex
-                                                                                          $ IVar n
-                                                                                          $ IVar {arg:2}
-                                                                                          $ IVar {arg:3}
-                                                                                          $ IVar {arg:1}))))))))
-                            IDef <<DerivedGen.VectMaybeAnyType.Here>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.VectMaybeAnyType.Here>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar n)
-                                                  $ (IApp. INamedApp (IVar DerivedGen.VectMaybeAnyType.(::))
-                                                                     n
-                                                                     (Implicit True)
-                                                         $ IBindVar x
-                                                         $ IBindVar xs))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.VectMaybeAnyType.Here (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                $ Implicit True
-                                                                $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                       $ Implicit True
-                                                                       $ INamedApp (INamedApp (INamedApp (IVar DerivedGen.VectMaybeAnyType.Here)
-                                                                                                         n
-                                                                                                         (IVar n))
-                                                                                              xs
-                                                                                              (IVar xs))
-                                                                                   x
-                                                                                   (IVar x)))))
-                                 , PatClause (IApp. IVar <<DerivedGen.VectMaybeAnyType.Here>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.VectMaybeAnyType.There>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.VectMaybeAnyType.There>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar n)
-                                                  $ (IApp. INamedApp (IVar DerivedGen.VectMaybeAnyType.(::))
-                                                                     n
-                                                                     (Implicit True)
-                                                         $ IBindVar z
-                                                         $ IBindVar zs))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.VectMaybeAnyType.There (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]
-                                                                $ IVar ^cons_fuel^
-                                                                $ IVar n
-                                                                $ IVar zs)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar i
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ IBindVar x
-                                                                                                 $ IBindVar ^bnd^{arg:4}))
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ Implicit True
-                                                                                                 $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                        $ Implicit True
-                                                                                                        $ (IApp. INamedApp (INamedApp (INamedApp (INamedApp (INamedApp (IVar DerivedGen.VectMaybeAnyType.There)
-                                                                                                                                                                       z
-                                                                                                                                                                       (IVar z))
-                                                                                                                                                            n
-                                                                                                                                                            (IVar n))
-                                                                                                                                                 zs
-                                                                                                                                                 (IVar zs))
-                                                                                                                                      x
-                                                                                                                                      (IVar x))
-                                                                                                                           i
-                                                                                                                           (IVar i)
-                                                                                                               $ IVar ^bnd^{arg:4})))) ])))
-                                 , PatClause (IApp. IVar <<DerivedGen.VectMaybeAnyType.There>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<v>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.VectMaybeAnyType.VectMaybeAnyType" .$ var "n")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ (var "Data.Fin.Fin" .$ var "n")
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.Fin.Fin" .$ var "n")
+                                 .=>    var "Builtin.DPair.DPair"
+                                     .$ var "DerivedGen.MaybeAnyType.MaybeAnyType"
+                                     .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "DerivedGen.MaybeAnyType.MaybeAnyType")
+                                         .=>    var "DerivedGen.VectMaybeAnyType.AtIndex"
+                                             .$ var "n"
+                                             .$ var "{arg:2}"
+                                             .$ var "{arg:3}"
+                                             .$ var "{arg:1}")))
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]"
+              [    var "<DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<n>" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.VectMaybeAnyType.Here>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.VectMaybeAnyType.VectMaybeAnyType" .$ var "n")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ (var "Data.Fin.Fin" .$ var "n")
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.Fin.Fin" .$ var "n")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "DerivedGen.MaybeAnyType.MaybeAnyType"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "DerivedGen.MaybeAnyType.MaybeAnyType")
+                                                        .=>    var "DerivedGen.VectMaybeAnyType.AtIndex"
+                                                            .$ var "n"
+                                                            .$ var "{arg:2}"
+                                                            .$ var "{arg:3}"
+                                                            .$ var "{arg:1}")))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.VectMaybeAnyType.There>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.VectMaybeAnyType.VectMaybeAnyType" .$ var "n")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ (var "Data.Fin.Fin" .$ var "n")
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Data.Fin.Fin" .$ var "n")
+                                                .=>    var "Builtin.DPair.DPair"
+                                                    .$ var "DerivedGen.MaybeAnyType.MaybeAnyType"
+                                                    .$ (    MkArg MW ExplicitArg (Just "{arg:3}") (var "DerivedGen.MaybeAnyType.MaybeAnyType")
+                                                        .=>    var "DerivedGen.VectMaybeAnyType.AtIndex"
+                                                            .$ var "n"
+                                                            .$ var "{arg:2}"
+                                                            .$ var "{arg:3}"
+                                                            .$ var "{arg:1}")))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.VectMaybeAnyType.Here>>"
+                             [       var "<<DerivedGen.VectMaybeAnyType.Here>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                  .$ (var "DerivedGen.VectMaybeAnyType.(::)" .! ("n", implicitTrue) .$ bindVar "x" .$ bindVar "xs")
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.VectMaybeAnyType.Here (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (   var "Builtin.DPair.MkDPair"
+                                          .$ implicitTrue
+                                          .$ (   var "Builtin.DPair.MkDPair"
+                                              .$ implicitTrue
+                                              .$ (var "DerivedGen.VectMaybeAnyType.Here" .! ("n", var "n") .! ("xs", var "xs") .! ("x", var "x")))))
+                             , var "<<DerivedGen.VectMaybeAnyType.Here>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.VectMaybeAnyType.There>>"
+                             [       var "<<DerivedGen.VectMaybeAnyType.There>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                  .$ (var "DerivedGen.VectMaybeAnyType.(::)" .! ("n", implicitTrue) .$ bindVar "z" .$ bindVar "zs")
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.VectMaybeAnyType.There (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]" .$ var "^cons_fuel^" .$ var "n" .$ var "zs")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [       var "Builtin.DPair.MkDPair"
+                                                         .$ bindVar "i"
+                                                         .$ (var "Builtin.DPair.MkDPair" .$ bindVar "x" .$ bindVar "^bnd^{arg:4}")
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (   var "Builtin.DPair.MkDPair"
+                                                             .$ implicitTrue
+                                                             .$ (   var "Builtin.DPair.MkDPair"
+                                                                 .$ implicitTrue
+                                                                 .$ (   var "DerivedGen.VectMaybeAnyType.There"
+                                                                     .! ("z", var "z")
+                                                                     .! ("n", var "n")
+                                                                     .! ("zs", var "zs")
+                                                                     .! ("x", var "x")
+                                                                     .! ("i", var "i")
+                                                                     .$ var "^bnd^{arg:4}")))
+                                                    ]
+                                                }))
+                             , var "<<DerivedGen.VectMaybeAnyType.There>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.VectMaybeAnyType.AtIndex[0, 3] (dry fuel)"))
+                                    .$ (   var "<<DerivedGen.VectMaybeAnyType.Here>>"
+                                        .$ var "Data.Fuel.Dry"
+                                        .$ var "inter^<n>"
+                                        .$ var "inter^<{arg:1}>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.VectMaybeAnyType.AtIndex[0, 3] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (   var "<<DerivedGen.VectMaybeAnyType.Here>>"
+                                                    .$ var "^fuel_arg^"
+                                                    .$ var "inter^<n>"
+                                                    .$ var "inter^<{arg:1}>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (   var "<<DerivedGen.VectMaybeAnyType.There>>"
+                                                        .$ var "^sub^fuel_arg^"
+                                                        .$ var "inter^<n>"
+                                                        .$ var "inter^<{arg:1}>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.VectMaybeAnyType.AtIndex>[0, 3]" .$ var "^outmost-fuel^" .$ var "outer^<n>" .$ var "outer^<v>"
+      }
+

--- a/tests/derivation/least-effort/print/regression/dependent-givens-small-deep/expected
+++ b/tests/derivation/least-effort/print/regression/dependent-givens-small-deep/expected
@@ -3,77 +3,71 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (f : Fin n) -> Gen MaybeEmpty (X n f)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => (MW ExplicitArg outer^<f> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>
-                   $ IVar outer^<f>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:1} : IApp. IVar Data.Fin.Fin
-                                                              $ IVar n)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar n
-                                         $ IVar {arg:1}))))
-         IDef <DerivedGen.X>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<n>
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0, 1] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<n>
-                                              $ IVar inter^<{arg:1}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:1} : IApp. IVar Data.Fin.Fin
-                                                                                 $ IVar n)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar n
-                                                            $ IVar {arg:1}))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ (IApp. IVar Prelude.Types.S
-                                                                $ IBindVar n))
-                                                  $ (IApp. INamedApp (IVar Data.Fin.FS)
-                                                                     k
-                                                                     (IApp. IVar Prelude.Types.S
-                                                                          $ Implicit True)
-                                                         $ (IApp. INamedApp (IVar Data.Fin.FS)
-                                                                            k
-                                                                            (Implicit True)
-                                                                $ IBindVar f)))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar DerivedGen.MkX
-                                                                $ IVar n
-                                                                $ IVar f)))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<f>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fin.Fin" .$ var "n")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.X" .$ var "n" .$ var "{arg:1}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0, 1]"
+              [    var "<DerivedGen.X>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<n>" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fin.Fin" .$ var "n")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "n" .$ var "{arg:1}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [       var "<<DerivedGen.MkX>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ bindVar "n"))
+                                  .$ (   var "Data.Fin.FS"
+                                      .! ("k", var "Prelude.Types.S" .$ implicitTrue)
+                                      .$ (var "Data.Fin.FS" .! ("k", implicitTrue) .$ bindVar "f"))
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "DerivedGen.MkX" .$ var "n" .$ var "f"))
+                             , var "<<DerivedGen.MkX>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0, 1] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^" .$ var "inter^<n>" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<n>" .$ var "outer^<f>"
+      }
+

--- a/tests/derivation/least-effort/print/regression/dependent-givens-small-shallow/expected
+++ b/tests/derivation/least-effort/print/regression/dependent-givens-small-shallow/expected
@@ -3,72 +3,69 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (n : Nat) -> (f : Fin n) -> Gen MaybeEmpty (X n f)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<n> : Implicit True)
-    => (MW ExplicitArg outer^<f> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<n>
-                   $ IVar outer^<f>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:1} : IApp. IVar Data.Fin.Fin
-                                                              $ IVar n)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar n
-                                         $ IVar {arg:1}))))
-         IDef <DerivedGen.X>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<n>
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0, 1] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<n>
-                                              $ IVar inter^<{arg:1}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg n : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:1} : IApp. IVar Data.Fin.Fin
-                                                                                 $ IVar n)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar n
-                                                            $ IVar {arg:1}))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar Prelude.Types.S
-                                                         $ IBindVar n)
-                                                  $ (IApp. INamedApp (IVar Data.Fin.FS)
-                                                                     k
-                                                                     (Implicit True)
-                                                         $ IBindVar f))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.MkX (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ (IApp. IVar DerivedGen.MkX
-                                                                $ IVar n
-                                                                $ IVar f)))
-                                 , PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<n>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<f>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fin.Fin" .$ var "n")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.X" .$ var "n" .$ var "{arg:1}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0, 1]"
+              [    var "<DerivedGen.X>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<n>" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "n") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Data.Fin.Fin" .$ var "n")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "n" .$ var "{arg:1}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [       var "<<DerivedGen.MkX>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (var "Prelude.Types.S" .$ bindVar "n")
+                                  .$ (var "Data.Fin.FS" .! ("k", implicitTrue) .$ bindVar "f")
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (var "DerivedGen.MkX" .$ var "n" .$ var "f"))
+                             , var "<<DerivedGen.MkX>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0, 1] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkX>>" .$ var "^fuel_arg^" .$ var "inter^<n>" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<n>" .$ var "outer^<f>"
+      }
+

--- a/tests/derivation/least-effort/print/regression/lost-deceq-four-occurences/expected
+++ b/tests/derivation/least-effort/print/regression/lost-deceq-four-occurences/expected
@@ -3,160 +3,164 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> (x4 : Nat) -> Gen MaybeEmpty (X x1 x2 x3 x4)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<x1> : Implicit True)
-    => (MW ExplicitArg outer^<x2> : Implicit True)
-    => (MW ExplicitArg outer^<x3> : Implicit True)
-    => (MW ExplicitArg outer^<x4> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<x1>
-                   $ IVar outer^<x2>
-                   $ IVar outer^<x3>
-                   $ IVar outer^<x4>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0, 1, 2, 3]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}
-                                         $ IVar {arg:3}
-                                         $ IVar {arg:4}))))
-         IDef <DerivedGen.X>[0, 1, 2, 3]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2, 3]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>
-                               $ IBindVar inter^<{arg:3}>
-                               $ IBindVar inter^<{arg:4}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0, 1, 2, 3] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>
-                                              $ IVar inter^<{arg:2}>
-                                              $ IVar inter^<{arg:3}>
-                                              $ IVar inter^<{arg:4}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:4} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}
-                                                            $ IVar {arg:3}
-                                                            $ IVar {arg:4}))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.MkX>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar n
-                                                   $ IBindVar to_be_deceqed^^n0
-                                                   $ IBindVar to_be_deceqed^^n1
-                                                   $ IBindVar to_be_deceqed^^n2)
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^n0
-                                                   $ IVar n)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<x1>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<x2>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<x3>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<x4>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0, 1, 2, 3]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}" .$ var "{arg:3}" .$ var "{arg:4}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0, 1, 2, 3]"
+              [       var "<DerivedGen.X>[0, 1, 2, 3]"
+                   .$ bindVar "^fuel_arg^"
+                   .$ bindVar "inter^<{arg:1}>"
+                   .$ bindVar "inter^<{arg:2}>"
+                   .$ bindVar "inter^<{arg:3}>"
+                   .$ bindVar "inter^<{arg:4}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:4}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}" .$ var "{arg:3}" .$ var "{arg:4}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.MkX>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ bindVar "n"
+                                     .$ bindVar "to_be_deceqed^^n0"
+                                     .$ bindVar "to_be_deceqed^^n1"
+                                     .$ bindVar "to_be_deceqed^^n2"
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.MkX>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ bindVar "n"
+                                             .$ bindVar "n"
+                                             .$ bindVar "to_be_deceqed^^n1"
+                                             .$ bindVar "to_be_deceqed^^n2"
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n1" .$ var "n"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [ withClause
+                                                 { lhs =
+                                                        var "<<DerivedGen.MkX>>"
+                                                     .$ bindVar "^cons_fuel^"
+                                                     .$ bindVar "n"
+                                                     .$ bindVar "n"
+                                                     .$ bindVar "n"
+                                                     .$ bindVar "to_be_deceqed^^n2"
+                                                     .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                     .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                 , rig = MW
+                                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n2" .$ var "n"
+                                                 , prf = Nothing
+                                                 , flags = []
+                                                 , clauses =
+                                                     [       var "<<DerivedGen.MkX>>"
+                                                          .$ bindVar "^cons_fuel^"
+                                                          .$ bindVar "n"
+                                                          .$ bindVar "n"
+                                                          .$ bindVar "n"
+                                                          .$ bindVar "n"
+                                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                       .=    var "Test.DepTyCheck.Gen.label"
+                                                          .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                                          .$ (   var "Prelude.pure"
+                                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                              .$ (var "DerivedGen.MkX" .! ("n", var "n")))
+                                                     ,       var "<<DerivedGen.MkX>>"
+                                                          .$ bindVar "^cons_fuel^"
+                                                          .$ bindVar "n"
+                                                          .$ bindVar "n"
+                                                          .$ bindVar "n"
+                                                          .$ bindVar "to_be_deceqed^^n2"
+                                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                                       .= var "empty"
+                                                     ]
+                                                 }
+                                             ,       var "<<DerivedGen.MkX>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "to_be_deceqed^^n1"
+                                                  .$ bindVar "to_be_deceqed^^n2"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.MkX>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ bindVar "to_be_deceqed^^n0"
+                                          .$ bindVar "to_be_deceqed^^n1"
+                                          .$ bindVar "to_be_deceqed^^n2"
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0, 1, 2, 3] (non-recursive)"))
+                         .$ (   var "<<DerivedGen.MkX>>"
+                             .$ var "^fuel_arg^"
+                             .$ var "inter^<{arg:1}>"
+                             .$ var "inter^<{arg:2}>"
+                             .$ var "inter^<{arg:3}>"
+                             .$ var "inter^<{arg:4}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0, 1, 2, 3]" .$ var "^outmost-fuel^" .$ var "outer^<x1>" .$ var "outer^<x2>" .$ var "outer^<x3>" .$ var "outer^<x4>"
+      }
 
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.MkX>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ IBindVar n
-                                                                $ IBindVar n
-                                                                $ IBindVar to_be_deceqed^^n1
-                                                                $ IBindVar to_be_deceqed^^n2
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^n1
-                                                                $ IVar n)
-
-                                                           []
-                                                           [ WithClause (IApp. IVar <<DerivedGen.MkX>>
-                                                                             $ IBindVar ^cons_fuel^
-                                                                             $ IBindVar n
-                                                                             $ IBindVar n
-                                                                             $ IBindVar n
-                                                                             $ IBindVar to_be_deceqed^^n2
-                                                                             $ (IApp. IVar Prelude.Yes
-                                                                                    $ IVar Builtin.Refl)
-                                                                             $ (IApp. IVar Prelude.Yes
-                                                                                    $ IVar Builtin.Refl))
-                                                                        MW
-                                                                        (IApp. IVar Decidable.Equality.decEq
-                                                                             $ IVar to_be_deceqed^^n2
-                                                                             $ IVar n)
-
-                                                                        []
-                                                                        [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                                                         $ IBindVar ^cons_fuel^
-                                                                                         $ IBindVar n
-                                                                                         $ IBindVar n
-                                                                                         $ IBindVar n
-                                                                                         $ IBindVar n
-                                                                                         $ (IApp. IVar Prelude.Yes
-                                                                                                $ IVar Builtin.Refl)
-                                                                                         $ (IApp. IVar Prelude.Yes
-                                                                                                $ IVar Builtin.Refl)
-                                                                                         $ (IApp. IVar Prelude.Yes
-                                                                                                $ IVar Builtin.Refl))
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.label
-                                                                                         $ (IApp. IVar fromString
-                                                                                                $ IPrimVal DerivedGen.MkX (orders))
-                                                                                         $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                            f
-                                                                                                            (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                                 $ Implicit True)
-                                                                                                $ INamedApp (IVar DerivedGen.MkX)
-                                                                                                            n
-                                                                                                            (IVar n)))
-                                                                        , PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                                                         $ IBindVar ^cons_fuel^
-                                                                                         $ IBindVar n
-                                                                                         $ IBindVar n
-                                                                                         $ IBindVar n
-                                                                                         $ IBindVar to_be_deceqed^^n2
-                                                                                         $ (IApp. IVar Prelude.Yes
-                                                                                                $ IVar Builtin.Refl)
-                                                                                         $ (IApp. IVar Prelude.Yes
-                                                                                                $ IVar Builtin.Refl)
-                                                                                         $ (IApp. IVar Prelude.No
-                                                                                                $ Implicit True))
-                                                                                    (IVar empty) ]
-                                                           , PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ IBindVar n
-                                                                            $ IBindVar to_be_deceqed^^n1
-                                                                            $ IBindVar to_be_deceqed^^n2
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ IBindVar to_be_deceqed^^n0
-                                                               $ IBindVar to_be_deceqed^^n1
-                                                               $ IBindVar to_be_deceqed^^n2
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ] ] ]

--- a/tests/derivation/least-effort/print/regression/lost-deceq-three-occurences/expected
+++ b/tests/derivation/least-effort/print/regression/lost-deceq-three-occurences/expected
@@ -3,116 +3,126 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (x1 : Nat) -> (x2 : Nat) -> (x3 : Nat) -> Gen MaybeEmpty (X x1 x2 x3)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<x1> : Implicit True)
-    => (MW ExplicitArg outer^<x2> : Implicit True)
-    => (MW ExplicitArg outer^<x3> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.X>[0, 1, 2]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<x1>
-                   $ IVar outer^<x2>
-                   $ IVar outer^<x3>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.X>[0, 1, 2]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                          -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.X
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}
-                                         $ IVar {arg:3}))))
-         IDef <DerivedGen.X>[0, 1, 2]
-              [ PatClause (IApp. IVar <DerivedGen.X>[0, 1, 2]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>
-                               $ IBindVar inter^<{arg:3}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.X[0, 1, 2] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkX>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>
-                                              $ IVar inter^<{arg:2}>
-                                              $ IVar inter^<{arg:3}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkX>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:2} : IVar Prelude.Types.Nat)
-                                             -> (MW ExplicitArg {arg:3} : IVar Prelude.Types.Nat)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.X
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}
-                                                            $ IVar {arg:3}))))
-                            IDef <<DerivedGen.MkX>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.MkX>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ IBindVar n
-                                                   $ IBindVar to_be_deceqed^^n0
-                                                   $ IBindVar to_be_deceqed^^n1)
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^n0
-                                                   $ IVar n)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<x1>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<x2>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<x3>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.X>[0, 1, 2]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                     .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}" .$ var "{arg:3}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[0, 1, 2]"
+              [       var "<DerivedGen.X>[0, 1, 2]"
+                   .$ bindVar "^fuel_arg^"
+                   .$ bindVar "inter^<{arg:1}>"
+                   .$ bindVar "inter^<{arg:2}>"
+                   .$ bindVar "inter^<{arg:3}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkX>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "Prelude.Types.Nat")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:3}") (var "Prelude.Types.Nat")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.X" .$ var "{arg:1}" .$ var "{arg:2}" .$ var "{arg:3}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkX>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.MkX>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ bindVar "n"
+                                     .$ bindVar "to_be_deceqed^^n0"
+                                     .$ bindVar "to_be_deceqed^^n1"
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.MkX>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ bindVar "n"
+                                             .$ bindVar "n"
+                                             .$ bindVar "to_be_deceqed^^n1"
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n1" .$ var "n"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [       var "<<DerivedGen.MkX>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "n"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                               .=    var "Test.DepTyCheck.Gen.label"
+                                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkX (orders)"))
+                                                  .$ (   var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (var "DerivedGen.MkX" .! ("n", var "n")))
+                                             ,       var "<<DerivedGen.MkX>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "n"
+                                                  .$ bindVar "to_be_deceqed^^n1"
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.MkX>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ bindVar "n"
+                                          .$ bindVar "to_be_deceqed^^n0"
+                                          .$ bindVar "to_be_deceqed^^n1"
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[0, 1, 2] (non-recursive)"))
+                         .$ (   var "<<DerivedGen.MkX>>"
+                             .$ var "^fuel_arg^"
+                             .$ var "inter^<{arg:1}>"
+                             .$ var "inter^<{arg:2}>"
+                             .$ var "inter^<{arg:3}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[0, 1, 2]" .$ var "^outmost-fuel^" .$ var "outer^<x1>" .$ var "outer^<x2>" .$ var "outer^<x3>"
+      }
 
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.MkX>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ IBindVar n
-                                                                $ IBindVar n
-                                                                $ IBindVar to_be_deceqed^^n1
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^n1
-                                                                $ IVar n)
-
-                                                           []
-                                                           [ PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ IBindVar n
-                                                                            $ IBindVar n
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl))
-                                                                       (IApp. IVar Test.DepTyCheck.Gen.label
-                                                                            $ (IApp. IVar fromString
-                                                                                   $ IPrimVal DerivedGen.MkX (orders))
-                                                                            $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                                               f
-                                                                                               (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                    $ Implicit True)
-                                                                                   $ INamedApp (IVar DerivedGen.MkX)
-                                                                                               n
-                                                                                               (IVar n)))
-                                                           , PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ IBindVar n
-                                                                            $ IBindVar n
-                                                                            $ IBindVar to_be_deceqed^^n1
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.MkX>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ IBindVar n
-                                                               $ IBindVar to_be_deceqed^^n0
-                                                               $ IBindVar to_be_deceqed^^n1
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ] ] ]

--- a/tests/derivation/least-effort/print/regression/too-early-rename-multiple-complex/expected
+++ b/tests/derivation/least-effort/print/regression/too-early-rename-multiple-complex/expected
@@ -3,250 +3,185 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Z) -> (b : Z) -> Gen MaybeEmpty (W a b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => (MW ExplicitArg outer^<b> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.W>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>
-                   $ IVar outer^<b>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.W>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar DerivedGen.Z)
-                          -> (MW ExplicitArg {arg:2} : IVar DerivedGen.Z)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.W
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}))))
-         IDef <DerivedGen.W>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.W>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.W[0, 1] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkW>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>
-                                              $ IVar inter^<{arg:2}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkW>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar DerivedGen.Z)
-                                             -> (MW ExplicitArg {arg:2} : IVar DerivedGen.Z)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.W
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}))))
-                            IDef <<DerivedGen.MkW>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.MkW>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                    $ (IApp. IVar DerivedGen.MkX
-                                                                           $ IBindVar n
-                                                                           $ IVar Prelude.Basics.False)
-                                                                    $ (IApp. IVar DerivedGen.MkX
-                                                                           $ IBindVar m
-                                                                           $ IVar Prelude.Basics.False))
-                                                               {conArg:1}
-                                                               (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                m
-                                                                                                (Implicit True))
-                                                                                     b
-                                                                                     (IVar Prelude.Basics.False))
-                                                                          n
-                                                                          (Implicit True))
-                                                   $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                    $ (IApp. IVar DerivedGen.MkX
-                                                                           $ IBindVar to_be_deceqed^^n0
-                                                                           $ IVar Prelude.Basics.True)
-                                                                    $ (IApp. IVar DerivedGen.MkX
-                                                                           $ IBindVar to_be_deceqed^^m1
-                                                                           $ IVar Prelude.Basics.True))
-                                                               {conArg:1}
-                                                               (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                m
-                                                                                                (Implicit True))
-                                                                                     b
-                                                                                     (IVar Prelude.Basics.True))
-                                                                          n
-                                                                          (Implicit True)))
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^m1
-                                                   $ IVar m)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<b>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.W>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.Z")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "DerivedGen.Z")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.W" .$ var "{arg:1}" .$ var "{arg:2}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.W>[0, 1]"
+              [    var "<DerivedGen.W>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>" .$ bindVar "inter^<{arg:2}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkW>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.Z")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "DerivedGen.Z")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.W" .$ var "{arg:1}" .$ var "{arg:2}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkW>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.MkW>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ (   var "DerivedGen.MkZ"
+                                         .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.False")
+                                         .$ (var "DerivedGen.MkX" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                         .! ( "{conArg:1}"
+                                            , var "DerivedGen.MkY" .! ("m", implicitTrue) .! ("b", var "Prelude.Basics.False") .! ("n", implicitTrue)
+                                            ))
+                                     .$ (   var "DerivedGen.MkZ"
+                                         .$ (var "DerivedGen.MkX" .$ bindVar "to_be_deceqed^^n0" .$ var "Prelude.Basics.True")
+                                         .$ (var "DerivedGen.MkX" .$ bindVar "to_be_deceqed^^m1" .$ var "Prelude.Basics.True")
+                                         .! ( "{conArg:1}"
+                                            , var "DerivedGen.MkY" .! ("m", implicitTrue) .! ("b", var "Prelude.Basics.True") .! ("n", implicitTrue)
+                                            ))
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^m1" .$ var "m"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.MkW>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ (   var "DerivedGen.MkZ"
+                                                 .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.False")
+                                                 .$ (var "DerivedGen.MkX" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                                 .! ( "{conArg:1}"
+                                                    ,    var "DerivedGen.MkY"
+                                                      .! ("m", implicitTrue)
+                                                      .! ("b", var "Prelude.Basics.False")
+                                                      .! ("n", implicitTrue)
+                                                    ))
+                                             .$ (   var "DerivedGen.MkZ"
+                                                 .$ (var "DerivedGen.MkX" .$ bindVar "to_be_deceqed^^n0" .$ var "Prelude.Basics.True")
+                                                 .$ (var "DerivedGen.MkX" .$ bindVar "m" .$ var "Prelude.Basics.True")
+                                                 .! ( "{conArg:1}"
+                                                    ,    var "DerivedGen.MkY"
+                                                      .! ("m", implicitTrue)
+                                                      .! ("b", var "Prelude.Basics.True")
+                                                      .! ("n", implicitTrue)
+                                                    ))
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [       var "<<DerivedGen.MkW>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ (   var "DerivedGen.MkZ"
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.False")
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                                      .! ( "{conArg:1}"
+                                                         ,    var "DerivedGen.MkY"
+                                                           .! ("m", implicitTrue)
+                                                           .! ("b", var "Prelude.Basics.False")
+                                                           .! ("n", implicitTrue)
+                                                         ))
+                                                  .$ (   var "DerivedGen.MkZ"
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.True")
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "m" .$ var "Prelude.Basics.True")
+                                                      .! ( "{conArg:1}"
+                                                         ,    var "DerivedGen.MkY"
+                                                           .! ("m", implicitTrue)
+                                                           .! ("b", var "Prelude.Basics.True")
+                                                           .! ("n", implicitTrue)
+                                                         ))
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                               .=    var "Test.DepTyCheck.Gen.label"
+                                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkW (orders)"))
+                                                  .$ (   var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (var "DerivedGen.MkW" .! ("m", var "m") .! ("n", var "n")))
+                                             ,       var "<<DerivedGen.MkW>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ (   var "DerivedGen.MkZ"
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.False")
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                                      .! ( "{conArg:1}"
+                                                         ,    var "DerivedGen.MkY"
+                                                           .! ("m", implicitTrue)
+                                                           .! ("b", var "Prelude.Basics.False")
+                                                           .! ("n", implicitTrue)
+                                                         ))
+                                                  .$ (   var "DerivedGen.MkZ"
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "to_be_deceqed^^n0" .$ var "Prelude.Basics.True")
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "m" .$ var "Prelude.Basics.True")
+                                                      .! ( "{conArg:1}"
+                                                         ,    var "DerivedGen.MkY"
+                                                           .! ("m", implicitTrue)
+                                                           .! ("b", var "Prelude.Basics.True")
+                                                           .! ("n", implicitTrue)
+                                                         ))
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.MkW>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ (   var "DerivedGen.MkZ"
+                                              .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.False")
+                                              .$ (var "DerivedGen.MkX" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                              .! ( "{conArg:1}"
+                                                 ,    var "DerivedGen.MkY"
+                                                   .! ("m", implicitTrue)
+                                                   .! ("b", var "Prelude.Basics.False")
+                                                   .! ("n", implicitTrue)
+                                                 ))
+                                          .$ (   var "DerivedGen.MkZ"
+                                              .$ (var "DerivedGen.MkX" .$ bindVar "to_be_deceqed^^n0" .$ var "Prelude.Basics.True")
+                                              .$ (var "DerivedGen.MkX" .$ bindVar "to_be_deceqed^^m1" .$ var "Prelude.Basics.True")
+                                              .! ( "{conArg:1}"
+                                                 ,    var "DerivedGen.MkY"
+                                                   .! ("m", implicitTrue)
+                                                   .! ("b", var "Prelude.Basics.True")
+                                                   .! ("n", implicitTrue)
+                                                 ))
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             , var "<<DerivedGen.MkW>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.W[0, 1] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkW>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.W>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<a>" .$ var "outer^<b>"
+      }
 
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.MkW>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                 $ (IApp. IVar DerivedGen.MkX
-                                                                                        $ IBindVar n
-                                                                                        $ IVar Prelude.Basics.False)
-                                                                                 $ (IApp. IVar DerivedGen.MkX
-                                                                                        $ IBindVar m
-                                                                                        $ IVar Prelude.Basics.False))
-                                                                            {conArg:1}
-                                                                            (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                             m
-                                                                                                             (Implicit True))
-                                                                                                  b
-                                                                                                  (IVar Prelude.Basics.False))
-                                                                                       n
-                                                                                       (Implicit True))
-                                                                $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                 $ (IApp. IVar DerivedGen.MkX
-                                                                                        $ IBindVar to_be_deceqed^^n0
-                                                                                        $ IVar Prelude.Basics.True)
-                                                                                 $ (IApp. IVar DerivedGen.MkX
-                                                                                        $ IBindVar m
-                                                                                        $ IVar Prelude.Basics.True))
-                                                                            {conArg:1}
-                                                                            (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                             m
-                                                                                                             (Implicit True))
-                                                                                                  b
-                                                                                                  (IVar Prelude.Basics.True))
-                                                                                       n
-                                                                                       (Implicit True))
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^n0
-                                                                $ IVar n)
-
-                                                           []
-                                                           [ PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar n
-                                                                                                    $ IVar Prelude.Basics.False)
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar m
-                                                                                                    $ IVar Prelude.Basics.False))
-                                                                                        {conArg:1}
-                                                                                        (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                         m
-                                                                                                                         (Implicit True))
-                                                                                                              b
-                                                                                                              (IVar Prelude.Basics.False))
-                                                                                                   n
-                                                                                                   (Implicit True))
-                                                                            $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar n
-                                                                                                    $ IVar Prelude.Basics.True)
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar m
-                                                                                                    $ IVar Prelude.Basics.True))
-                                                                                        {conArg:1}
-                                                                                        (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                         m
-                                                                                                                         (Implicit True))
-                                                                                                              b
-                                                                                                              (IVar Prelude.Basics.True))
-                                                                                                   n
-                                                                                                   (Implicit True))
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl))
-                                                                       (IApp. IVar Test.DepTyCheck.Gen.label
-                                                                            $ (IApp. IVar fromString
-                                                                                   $ IPrimVal DerivedGen.MkW (orders))
-                                                                            $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                                               f
-                                                                                               (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                    $ Implicit True)
-                                                                                   $ INamedApp (INamedApp (IVar DerivedGen.MkW)
-                                                                                                          m
-                                                                                                          (IVar m))
-                                                                                               n
-                                                                                               (IVar n)))
-                                                           , PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar n
-                                                                                                    $ IVar Prelude.Basics.False)
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar m
-                                                                                                    $ IVar Prelude.Basics.False))
-                                                                                        {conArg:1}
-                                                                                        (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                         m
-                                                                                                                         (Implicit True))
-                                                                                                              b
-                                                                                                              (IVar Prelude.Basics.False))
-                                                                                                   n
-                                                                                                   (Implicit True))
-                                                                            $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar to_be_deceqed^^n0
-                                                                                                    $ IVar Prelude.Basics.True)
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar m
-                                                                                                    $ IVar Prelude.Basics.True))
-                                                                                        {conArg:1}
-                                                                                        (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                         m
-                                                                                                                         (Implicit True))
-                                                                                                              b
-                                                                                                              (IVar Prelude.Basics.True))
-                                                                                                   n
-                                                                                                   (Implicit True))
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar n
-                                                                                       $ IVar Prelude.Basics.False)
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar m
-                                                                                       $ IVar Prelude.Basics.False))
-                                                                           {conArg:1}
-                                                                           (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                            m
-                                                                                                            (Implicit True))
-                                                                                                 b
-                                                                                                 (IVar Prelude.Basics.False))
-                                                                                      n
-                                                                                      (Implicit True))
-                                                               $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar to_be_deceqed^^n0
-                                                                                       $ IVar Prelude.Basics.True)
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar to_be_deceqed^^m1
-                                                                                       $ IVar Prelude.Basics.True))
-                                                                           {conArg:1}
-                                                                           (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                            m
-                                                                                                            (Implicit True))
-                                                                                                 b
-                                                                                                 (IVar Prelude.Basics.True))
-                                                                                      n
-                                                                                      (Implicit True))
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ]
-                                 , PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]

--- a/tests/derivation/least-effort/print/regression/too-early-rename-multiple-simple/expected
+++ b/tests/derivation/least-effort/print/regression/too-early-rename-multiple-simple/expected
@@ -3,230 +3,184 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Z) -> (b : Z) -> Gen MaybeEmpty (W a b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => (MW ExplicitArg outer^<b> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.W>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>
-                   $ IVar outer^<b>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.W>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar DerivedGen.Z)
-                          -> (MW ExplicitArg {arg:2} : IVar DerivedGen.Z)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.W
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}))))
-         IDef <DerivedGen.W>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.W>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.W[0, 1] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkW>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>
-                                              $ IVar inter^<{arg:2}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkW>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar DerivedGen.Z)
-                                             -> (MW ExplicitArg {arg:2} : IVar DerivedGen.Z)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.W
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}))))
-                            IDef <<DerivedGen.MkW>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.MkW>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                    $ (IApp. IVar DerivedGen.MkX
-                                                                           $ IBindVar n
-                                                                           $ IBindVar m
-                                                                           $ IVar Prelude.Basics.False))
-                                                               {conArg:1}
-                                                               (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                b
-                                                                                                (IVar Prelude.Basics.False))
-                                                                                     m
-                                                                                     (Implicit True))
-                                                                          n
-                                                                          (Implicit True))
-                                                   $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                    $ (IApp. IVar DerivedGen.MkX
-                                                                           $ IBindVar to_be_deceqed^^n0
-                                                                           $ IBindVar to_be_deceqed^^m1
-                                                                           $ IVar Prelude.Basics.True))
-                                                               {conArg:1}
-                                                               (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                b
-                                                                                                (IVar Prelude.Basics.True))
-                                                                                     m
-                                                                                     (Implicit True))
-                                                                          n
-                                                                          (Implicit True)))
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^m1
-                                                   $ IVar m)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<b>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.W>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.Z")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "DerivedGen.Z")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.W" .$ var "{arg:1}" .$ var "{arg:2}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.W>[0, 1]"
+              [    var "<DerivedGen.W>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>" .$ bindVar "inter^<{arg:2}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkW>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.Z")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "DerivedGen.Z")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.W" .$ var "{arg:1}" .$ var "{arg:2}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkW>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.MkW>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ (   var "DerivedGen.MkZ"
+                                         .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                         .! ( "{conArg:1}"
+                                            , var "DerivedGen.MkY" .! ("b", var "Prelude.Basics.False") .! ("m", implicitTrue) .! ("n", implicitTrue)
+                                            ))
+                                     .$ (   var "DerivedGen.MkZ"
+                                         .$ (   var "DerivedGen.MkX"
+                                             .$ bindVar "to_be_deceqed^^n0"
+                                             .$ bindVar "to_be_deceqed^^m1"
+                                             .$ var "Prelude.Basics.True")
+                                         .! ( "{conArg:1}"
+                                            , var "DerivedGen.MkY" .! ("b", var "Prelude.Basics.True") .! ("m", implicitTrue) .! ("n", implicitTrue)
+                                            ))
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^m1" .$ var "m"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.MkW>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ (   var "DerivedGen.MkZ"
+                                                 .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                                 .! ( "{conArg:1}"
+                                                    ,    var "DerivedGen.MkY"
+                                                      .! ("b", var "Prelude.Basics.False")
+                                                      .! ("m", implicitTrue)
+                                                      .! ("n", implicitTrue)
+                                                    ))
+                                             .$ (   var "DerivedGen.MkZ"
+                                                 .$ (var "DerivedGen.MkX" .$ bindVar "to_be_deceqed^^n0" .$ bindVar "m" .$ var "Prelude.Basics.True")
+                                                 .! ( "{conArg:1}"
+                                                    ,    var "DerivedGen.MkY"
+                                                      .! ("b", var "Prelude.Basics.True")
+                                                      .! ("m", implicitTrue)
+                                                      .! ("n", implicitTrue)
+                                                    ))
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [       var "<<DerivedGen.MkW>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ (   var "DerivedGen.MkZ"
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                                      .! ( "{conArg:1}"
+                                                         ,    var "DerivedGen.MkY"
+                                                           .! ("b", var "Prelude.Basics.False")
+                                                           .! ("m", implicitTrue)
+                                                           .! ("n", implicitTrue)
+                                                         ))
+                                                  .$ (   var "DerivedGen.MkZ"
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ bindVar "m" .$ var "Prelude.Basics.True")
+                                                      .! ( "{conArg:1}"
+                                                         ,    var "DerivedGen.MkY"
+                                                           .! ("b", var "Prelude.Basics.True")
+                                                           .! ("m", implicitTrue)
+                                                           .! ("n", implicitTrue)
+                                                         ))
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                               .=    var "Test.DepTyCheck.Gen.label"
+                                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkW (orders)"))
+                                                  .$ (   var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (var "DerivedGen.MkW" .! ("m", var "m") .! ("n", var "n")))
+                                             ,       var "<<DerivedGen.MkW>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ (   var "DerivedGen.MkZ"
+                                                      .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                                      .! ( "{conArg:1}"
+                                                         ,    var "DerivedGen.MkY"
+                                                           .! ("b", var "Prelude.Basics.False")
+                                                           .! ("m", implicitTrue)
+                                                           .! ("n", implicitTrue)
+                                                         ))
+                                                  .$ (   var "DerivedGen.MkZ"
+                                                      .$ (   var "DerivedGen.MkX"
+                                                          .$ bindVar "to_be_deceqed^^n0"
+                                                          .$ bindVar "m"
+                                                          .$ var "Prelude.Basics.True")
+                                                      .! ( "{conArg:1}"
+                                                         ,    var "DerivedGen.MkY"
+                                                           .! ("b", var "Prelude.Basics.True")
+                                                           .! ("m", implicitTrue)
+                                                           .! ("n", implicitTrue)
+                                                         ))
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.MkW>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ (   var "DerivedGen.MkZ"
+                                              .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ bindVar "m" .$ var "Prelude.Basics.False")
+                                              .! ( "{conArg:1}"
+                                                 ,    var "DerivedGen.MkY"
+                                                   .! ("b", var "Prelude.Basics.False")
+                                                   .! ("m", implicitTrue)
+                                                   .! ("n", implicitTrue)
+                                                 ))
+                                          .$ (   var "DerivedGen.MkZ"
+                                              .$ (   var "DerivedGen.MkX"
+                                                  .$ bindVar "to_be_deceqed^^n0"
+                                                  .$ bindVar "to_be_deceqed^^m1"
+                                                  .$ var "Prelude.Basics.True")
+                                              .! ( "{conArg:1}"
+                                                 ,    var "DerivedGen.MkY"
+                                                   .! ("b", var "Prelude.Basics.True")
+                                                   .! ("m", implicitTrue)
+                                                   .! ("n", implicitTrue)
+                                                 ))
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             , var "<<DerivedGen.MkW>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.W[0, 1] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkW>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.W>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<a>" .$ var "outer^<b>"
+      }
 
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.MkW>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                 $ (IApp. IVar DerivedGen.MkX
-                                                                                        $ IBindVar n
-                                                                                        $ IBindVar m
-                                                                                        $ IVar Prelude.Basics.False))
-                                                                            {conArg:1}
-                                                                            (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                             b
-                                                                                                             (IVar Prelude.Basics.False))
-                                                                                                  m
-                                                                                                  (Implicit True))
-                                                                                       n
-                                                                                       (Implicit True))
-                                                                $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                 $ (IApp. IVar DerivedGen.MkX
-                                                                                        $ IBindVar to_be_deceqed^^n0
-                                                                                        $ IBindVar m
-                                                                                        $ IVar Prelude.Basics.True))
-                                                                            {conArg:1}
-                                                                            (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                             b
-                                                                                                             (IVar Prelude.Basics.True))
-                                                                                                  m
-                                                                                                  (Implicit True))
-                                                                                       n
-                                                                                       (Implicit True))
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^n0
-                                                                $ IVar n)
-
-                                                           []
-                                                           [ PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar n
-                                                                                                    $ IBindVar m
-                                                                                                    $ IVar Prelude.Basics.False))
-                                                                                        {conArg:1}
-                                                                                        (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                         b
-                                                                                                                         (IVar Prelude.Basics.False))
-                                                                                                              m
-                                                                                                              (Implicit True))
-                                                                                                   n
-                                                                                                   (Implicit True))
-                                                                            $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar n
-                                                                                                    $ IBindVar m
-                                                                                                    $ IVar Prelude.Basics.True))
-                                                                                        {conArg:1}
-                                                                                        (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                         b
-                                                                                                                         (IVar Prelude.Basics.True))
-                                                                                                              m
-                                                                                                              (Implicit True))
-                                                                                                   n
-                                                                                                   (Implicit True))
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl))
-                                                                       (IApp. IVar Test.DepTyCheck.Gen.label
-                                                                            $ (IApp. IVar fromString
-                                                                                   $ IPrimVal DerivedGen.MkW (orders))
-                                                                            $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                                               f
-                                                                                               (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                    $ Implicit True)
-                                                                                   $ INamedApp (INamedApp (IVar DerivedGen.MkW)
-                                                                                                          m
-                                                                                                          (IVar m))
-                                                                                               n
-                                                                                               (IVar n)))
-                                                           , PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar n
-                                                                                                    $ IBindVar m
-                                                                                                    $ IVar Prelude.Basics.False))
-                                                                                        {conArg:1}
-                                                                                        (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                         b
-                                                                                                                         (IVar Prelude.Basics.False))
-                                                                                                              m
-                                                                                                              (Implicit True))
-                                                                                                   n
-                                                                                                   (Implicit True))
-                                                                            $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                             $ (IApp. IVar DerivedGen.MkX
-                                                                                                    $ IBindVar to_be_deceqed^^n0
-                                                                                                    $ IBindVar m
-                                                                                                    $ IVar Prelude.Basics.True))
-                                                                                        {conArg:1}
-                                                                                        (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                                         b
-                                                                                                                         (IVar Prelude.Basics.True))
-                                                                                                              m
-                                                                                                              (Implicit True))
-                                                                                                   n
-                                                                                                   (Implicit True))
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar n
-                                                                                       $ IBindVar m
-                                                                                       $ IVar Prelude.Basics.False))
-                                                                           {conArg:1}
-                                                                           (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                            b
-                                                                                                            (IVar Prelude.Basics.False))
-                                                                                                 m
-                                                                                                 (Implicit True))
-                                                                                      n
-                                                                                      (Implicit True))
-                                                               $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar to_be_deceqed^^n0
-                                                                                       $ IBindVar to_be_deceqed^^m1
-                                                                                       $ IVar Prelude.Basics.True))
-                                                                           {conArg:1}
-                                                                           (INamedApp (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                            b
-                                                                                                            (IVar Prelude.Basics.True))
-                                                                                                 m
-                                                                                                 (Implicit True))
-                                                                                      n
-                                                                                      (Implicit True))
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ]
-                                 , PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]

--- a/tests/derivation/least-effort/print/regression/too-early-rename-single-dependency/expected
+++ b/tests/derivation/least-effort/print/regression/too-early-rename-single-dependency/expected
@@ -3,139 +3,101 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (a : Z) -> (b : Z) -> Gen MaybeEmpty (W a b)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<a> : Implicit True)
-    => (MW ExplicitArg outer^<b> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.W>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<a>
-                   $ IVar outer^<b>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.W>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar DerivedGen.Z)
-                          -> (MW ExplicitArg {arg:2} : IVar DerivedGen.Z)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.W
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}))))
-         IDef <DerivedGen.W>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.W>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.W[0, 1] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkW>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>
-                                              $ IVar inter^<{arg:2}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkW>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar DerivedGen.Z)
-                                             -> (MW ExplicitArg {arg:2} : IVar DerivedGen.Z)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.W
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}))))
-                            IDef <<DerivedGen.MkW>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.MkW>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                    $ (IApp. IVar DerivedGen.MkX
-                                                                           $ IBindVar n
-                                                                           $ IVar Prelude.Basics.False))
-                                                               {conArg:1}
-                                                               (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                     b
-                                                                                     (IVar Prelude.Basics.False))
-                                                                          n
-                                                                          (Implicit True))
-                                                   $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                    $ (IApp. IVar DerivedGen.MkX
-                                                                           $ IBindVar to_be_deceqed^^n0
-                                                                           $ IVar Prelude.Basics.True))
-                                                               {conArg:1}
-                                                               (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                     b
-                                                                                     (IVar Prelude.Basics.True))
-                                                                          n
-                                                                          (Implicit True)))
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^n0
-                                                   $ IVar n)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<a>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<b>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.W>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.Z")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "DerivedGen.Z")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.W" .$ var "{arg:1}" .$ var "{arg:2}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.W>[0, 1]"
+              [    var "<DerivedGen.W>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>" .$ bindVar "inter^<{arg:2}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkW>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.Z")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "DerivedGen.Z")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.W" .$ var "{arg:1}" .$ var "{arg:2}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkW>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.MkW>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ (   var "DerivedGen.MkZ"
+                                         .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.False")
+                                         .! ("{conArg:1}", var "DerivedGen.MkY" .! ("b", var "Prelude.Basics.False") .! ("n", implicitTrue)))
+                                     .$ (   var "DerivedGen.MkZ"
+                                         .$ (var "DerivedGen.MkX" .$ bindVar "to_be_deceqed^^n0" .$ var "Prelude.Basics.True")
+                                         .! ("{conArg:1}", var "DerivedGen.MkY" .! ("b", var "Prelude.Basics.True") .! ("n", implicitTrue)))
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^n0" .$ var "n"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [       var "<<DerivedGen.MkW>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ (   var "DerivedGen.MkZ"
+                                              .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.False")
+                                              .! ("{conArg:1}", var "DerivedGen.MkY" .! ("b", var "Prelude.Basics.False") .! ("n", implicitTrue)))
+                                          .$ (   var "DerivedGen.MkZ"
+                                              .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.True")
+                                              .! ("{conArg:1}", var "DerivedGen.MkY" .! ("b", var "Prelude.Basics.True") .! ("n", implicitTrue)))
+                                          .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                       .=    var "Test.DepTyCheck.Gen.label"
+                                          .$ (var "fromString" .$ primVal (Str "DerivedGen.MkW (orders)"))
+                                          .$ (   var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "DerivedGen.MkW" .! ("n", var "n")))
+                                     ,       var "<<DerivedGen.MkW>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ (   var "DerivedGen.MkZ"
+                                              .$ (var "DerivedGen.MkX" .$ bindVar "n" .$ var "Prelude.Basics.False")
+                                              .! ("{conArg:1}", var "DerivedGen.MkY" .! ("b", var "Prelude.Basics.False") .! ("n", implicitTrue)))
+                                          .$ (   var "DerivedGen.MkZ"
+                                              .$ (var "DerivedGen.MkX" .$ bindVar "to_be_deceqed^^n0" .$ var "Prelude.Basics.True")
+                                              .! ("{conArg:1}", var "DerivedGen.MkY" .! ("b", var "Prelude.Basics.True") .! ("n", implicitTrue)))
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             , var "<<DerivedGen.MkW>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.W[0, 1] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkW>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.W>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<a>" .$ var "outer^<b>"
+      }
 
-                                              []
-                                              [ PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar n
-                                                                                       $ IVar Prelude.Basics.False))
-                                                                           {conArg:1}
-                                                                           (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                 b
-                                                                                                 (IVar Prelude.Basics.False))
-                                                                                      n
-                                                                                      (Implicit True))
-                                                               $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar n
-                                                                                       $ IVar Prelude.Basics.True))
-                                                                           {conArg:1}
-                                                                           (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                 b
-                                                                                                 (IVar Prelude.Basics.True))
-                                                                                      n
-                                                                                      (Implicit True))
-                                                               $ (IApp. IVar Prelude.Yes
-                                                                      $ IVar Builtin.Refl))
-                                                          (IApp. IVar Test.DepTyCheck.Gen.label
-                                                               $ (IApp. IVar fromString
-                                                                      $ IPrimVal DerivedGen.MkW (orders))
-                                                               $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                                  f
-                                                                                  (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                       $ Implicit True)
-                                                                      $ INamedApp (IVar DerivedGen.MkW)
-                                                                                  n
-                                                                                  (IVar n)))
-                                              , PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar n
-                                                                                       $ IVar Prelude.Basics.False))
-                                                                           {conArg:1}
-                                                                           (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                 b
-                                                                                                 (IVar Prelude.Basics.False))
-                                                                                      n
-                                                                                      (Implicit True))
-                                                               $ INamedApp (IApp. IVar DerivedGen.MkZ
-                                                                                $ (IApp. IVar DerivedGen.MkX
-                                                                                       $ IBindVar to_be_deceqed^^n0
-                                                                                       $ IVar Prelude.Basics.True))
-                                                                           {conArg:1}
-                                                                           (INamedApp (INamedApp (IVar DerivedGen.MkY)
-                                                                                                 b
-                                                                                                 (IVar Prelude.Basics.True))
-                                                                                      n
-                                                                                      (Implicit True))
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ]
-                                 , PatClause (IApp. IVar <<DerivedGen.MkW>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]

--- a/tests/derivation/least-effort/print/regression/unification-mismatch-dependent/expected
+++ b/tests/derivation/least-effort/print/regression/unification-mismatch-dependent/expected
@@ -3,129 +3,111 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (x : X) -> (x' : X) -> Gen MaybeEmpty (Z x x')
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<x> : Implicit True)
-    => (MW ExplicitArg outer^<x'> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.Z>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<x>
-                   $ IVar outer^<x'>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Z>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar DerivedGen.X)
-                          -> (MW ExplicitArg {arg:2} : IVar DerivedGen.X)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.Z
-                                         $ IVar {arg:1}
-                                         $ IVar {arg:2}))))
-         IDef <DerivedGen.Z>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.Z>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>
-                               $ IBindVar inter^<{arg:2}>)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal DerivedGen.Z[0, 1] (non-recursive))
-                                       $ (IApp. IVar <<DerivedGen.MkZ>>
-                                              $ IVar ^fuel_arg^
-                                              $ IVar inter^<{arg:1}>
-                                              $ IVar inter^<{arg:2}>)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.MkZ>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar DerivedGen.X)
-                                             -> (MW ExplicitArg {arg:2} : IVar DerivedGen.X)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.Z
-                                                            $ IVar {arg:1}
-                                                            $ IVar {arg:2}))))
-                            IDef <<DerivedGen.MkZ>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.MkZ>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ (IApp. IVar DerivedGen.Cons
-                                                          $ IBindVar x
-                                                          $ IBindVar prf)
-                                                   $ (IApp. IVar DerivedGen.Cons
-                                                          $ IBindVar to_be_deceqed^^x0
-                                                          $ IBindVar to_be_deceqed^^prf1))
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^x0
-                                                   $ IVar x)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<x>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<x'>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Z>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.X")
+                     .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "DerivedGen.X")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.Z" .$ var "{arg:1}" .$ var "{arg:2}")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Z>[0, 1]"
+              [    var "<DerivedGen.Z>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>" .$ bindVar "inter^<{arg:2}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.MkZ>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.X")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:2}") (var "DerivedGen.X")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.Z" .$ var "{arg:1}" .$ var "{arg:2}")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.MkZ>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.MkZ>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ (var "DerivedGen.Cons" .$ bindVar "x" .$ bindVar "prf")
+                                     .$ (var "DerivedGen.Cons" .$ bindVar "to_be_deceqed^^x0" .$ bindVar "to_be_deceqed^^prf1")
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^x0" .$ var "x"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.MkZ>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ (var "DerivedGen.Cons" .$ bindVar "x" .$ bindVar "prf")
+                                             .$ (var "DerivedGen.Cons" .$ bindVar "x" .$ bindVar "to_be_deceqed^^prf1")
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^prf1" .$ var "prf"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [       var "<<DerivedGen.MkZ>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ (var "DerivedGen.Cons" .$ bindVar "x" .$ bindVar "prf")
+                                                  .$ (var "DerivedGen.Cons" .$ bindVar "x" .$ bindVar "prf")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                               .=    var "Test.DepTyCheck.Gen.label"
+                                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.MkZ (orders)"))
+                                                  .$ (   var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (var "DerivedGen.MkZ" .! ("x", var "x") .$ var "prf"))
+                                             ,       var "<<DerivedGen.MkZ>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ (var "DerivedGen.Cons" .$ bindVar "x" .$ bindVar "prf")
+                                                  .$ (var "DerivedGen.Cons" .$ bindVar "x" .$ bindVar "to_be_deceqed^^prf1")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.MkZ>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ (var "DerivedGen.Cons" .$ bindVar "x" .$ bindVar "prf")
+                                          .$ (var "DerivedGen.Cons" .$ bindVar "to_be_deceqed^^x0" .$ bindVar "to_be_deceqed^^prf1")
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             , var "<<DerivedGen.MkZ>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.Z[0, 1] (non-recursive)"))
+                         .$ (var "<<DerivedGen.MkZ>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Z>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<x>" .$ var "outer^<x'>"
+      }
 
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.MkZ>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ (IApp. IVar DerivedGen.Cons
-                                                                       $ IBindVar x
-                                                                       $ IBindVar prf)
-                                                                $ (IApp. IVar DerivedGen.Cons
-                                                                       $ IBindVar x
-                                                                       $ IBindVar to_be_deceqed^^prf1)
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^prf1
-                                                                $ IVar prf)
-
-                                                           []
-                                                           [ PatClause (IApp. IVar <<DerivedGen.MkZ>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ (IApp. IVar DerivedGen.Cons
-                                                                                   $ IBindVar x
-                                                                                   $ IBindVar prf)
-                                                                            $ (IApp. IVar DerivedGen.Cons
-                                                                                   $ IBindVar x
-                                                                                   $ IBindVar prf)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl))
-                                                                       (IApp. IVar Test.DepTyCheck.Gen.label
-                                                                            $ (IApp. IVar fromString
-                                                                                   $ IPrimVal DerivedGen.MkZ (orders))
-                                                                            $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                                               f
-                                                                                               (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                    $ Implicit True)
-                                                                                   $ (IApp. INamedApp (IVar DerivedGen.MkZ)
-                                                                                                      x
-                                                                                                      (IVar x)
-                                                                                          $ IVar prf)))
-                                                           , PatClause (IApp. IVar <<DerivedGen.MkZ>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ (IApp. IVar DerivedGen.Cons
-                                                                                   $ IBindVar x
-                                                                                   $ IBindVar prf)
-                                                                            $ (IApp. IVar DerivedGen.Cons
-                                                                                   $ IBindVar x
-                                                                                   $ IBindVar to_be_deceqed^^prf1)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.MkZ>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ (IApp. IVar DerivedGen.Cons
-                                                                      $ IBindVar x
-                                                                      $ IBindVar prf)
-                                                               $ (IApp. IVar DerivedGen.Cons
-                                                                      $ IBindVar to_be_deceqed^^x0
-                                                                      $ IBindVar to_be_deceqed^^prf1)
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ]
-                                 , PatClause (IApp. IVar <<DerivedGen.MkZ>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]

--- a/tests/derivation/least-effort/print/regression/unification-name-mismatch/expected
+++ b/tests/derivation/least-effort/print/regression/unification-name-mismatch/expected
@@ -3,204 +3,168 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (xs : X) -> (ys : X) -> Gen MaybeEmpty (Y xs ys)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<xs> : Implicit True)
-    => (MW ExplicitArg outer^<ys> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.Y>[0, 1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<xs>
-                   $ IVar outer^<ys>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[0, 1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg xs : IVar DerivedGen.X)
-                          -> (MW ExplicitArg ys : IVar DerivedGen.X)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar DerivedGen.Y
-                                         $ IVar xs
-                                         $ IVar ys))))
-         IDef <DerivedGen.Y>[0, 1]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[0, 1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<xs>
-                               $ IBindVar inter^<ys>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.Y[0, 1] (dry fuel))
-                                                          $ (IApp. IVar <<DerivedGen.A>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<xs>
-                                                                 $ IVar inter^<ys>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.Y[0, 1] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.A>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<xs>
-                                                                                      $ IVar inter^<ys>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.B>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<xs>
-                                                                                             $ IVar inter^<ys>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.A>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg xs : IVar DerivedGen.X)
-                                             -> (MW ExplicitArg ys : IVar DerivedGen.X)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.Y
-                                                            $ IVar xs
-                                                            $ IVar ys))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.B>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg xs : IVar DerivedGen.X)
-                                             -> (MW ExplicitArg ys : IVar DerivedGen.X)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar DerivedGen.Y
-                                                            $ IVar xs
-                                                            $ IVar ys))))
-                            IDef <<DerivedGen.A>>
-                                 [ WithClause (IApp. IVar <<DerivedGen.A>>
-                                                   $ IBindVar ^cons_fuel^
-                                                   $ (IApp. IVar DerivedGen.(::)
-                                                          $ IBindVar x
-                                                          $ IBindVar xs)
-                                                   $ (IApp. IVar DerivedGen.(::)
-                                                          $ IBindVar to_be_deceqed^^x0
-                                                          $ IBindVar to_be_deceqed^^xs1))
-                                              MW
-                                              (IApp. IVar Decidable.Equality.decEq
-                                                   $ IVar to_be_deceqed^^xs1
-                                                   $ IVar xs)
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<xs>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<ys>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[0, 1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "xs") (var "DerivedGen.X")
+                     .-> MkArg MW ExplicitArg (Just "ys") (var "DerivedGen.X")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (var "DerivedGen.Y" .$ var "xs" .$ var "ys")
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[0, 1]"
+              [    var "<DerivedGen.Y>[0, 1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<xs>" .$ bindVar "inter^<ys>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.A>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "xs") (var "DerivedGen.X")
+                                    .-> MkArg MW ExplicitArg (Just "ys") (var "DerivedGen.X")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.Y" .$ var "xs" .$ var "ys")
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.B>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "xs") (var "DerivedGen.X")
+                                    .-> MkArg MW ExplicitArg (Just "ys") (var "DerivedGen.X")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (var "DerivedGen.Y" .$ var "xs" .$ var "ys")
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.A>>"
+                             [ withClause
+                                 { lhs =
+                                        var "<<DerivedGen.A>>"
+                                     .$ bindVar "^cons_fuel^"
+                                     .$ (var "DerivedGen.(::)" .$ bindVar "x" .$ bindVar "xs")
+                                     .$ (var "DerivedGen.(::)" .$ bindVar "to_be_deceqed^^x0" .$ bindVar "to_be_deceqed^^xs1")
+                                 , rig = MW
+                                 , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^xs1" .$ var "xs"
+                                 , prf = Nothing
+                                 , flags = []
+                                 , clauses =
+                                     [ withClause
+                                         { lhs =
+                                                var "<<DerivedGen.A>>"
+                                             .$ bindVar "^cons_fuel^"
+                                             .$ (var "DerivedGen.(::)" .$ bindVar "x" .$ bindVar "xs")
+                                             .$ (var "DerivedGen.(::)" .$ bindVar "to_be_deceqed^^x0" .$ bindVar "xs")
+                                             .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                         , rig = MW
+                                         , wval = var "Decidable.Equality.decEq" .$ var "to_be_deceqed^^x0" .$ var "x"
+                                         , prf = Nothing
+                                         , flags = []
+                                         , clauses =
+                                             [       var "<<DerivedGen.A>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ (var "DerivedGen.(::)" .$ bindVar "x" .$ bindVar "xs")
+                                                  .$ (var "DerivedGen.(::)" .$ bindVar "x" .$ bindVar "xs")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                               .=    var "Test.DepTyCheck.Gen.label"
+                                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.A (orders)"))
+                                                  .$ (   var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (var "DerivedGen.A" .! ("xs", var "xs") .! ("x", var "x")))
+                                             ,       var "<<DerivedGen.A>>"
+                                                  .$ bindVar "^cons_fuel^"
+                                                  .$ (var "DerivedGen.(::)" .$ bindVar "x" .$ bindVar "xs")
+                                                  .$ (var "DerivedGen.(::)" .$ bindVar "to_be_deceqed^^x0" .$ bindVar "xs")
+                                                  .$ (var "Prelude.Yes" .$ var "Builtin.Refl")
+                                                  .$ (var "Prelude.No" .$ implicitTrue)
+                                               .= var "empty"
+                                             ]
+                                         }
+                                     ,       var "<<DerivedGen.A>>"
+                                          .$ bindVar "^cons_fuel^"
+                                          .$ (var "DerivedGen.(::)" .$ bindVar "x" .$ bindVar "xs")
+                                          .$ (var "DerivedGen.(::)" .$ bindVar "to_be_deceqed^^x0" .$ bindVar "to_be_deceqed^^xs1")
+                                          .$ (var "Prelude.No" .$ implicitTrue)
+                                       .= var "empty"
+                                     ]
+                                 }
+                             , var "<<DerivedGen.A>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.B>>"
+                             [       var "<<DerivedGen.B>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (var "DerivedGen.(::)" .$ bindVar "x" .$ bindVar "xs")
+                                  .$ (var "DerivedGen.(::)" .$ bindVar "y" .$ bindVar "ys")
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.B (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.Y>[0, 1]" .$ var "^cons_fuel^" .$ var "xs" .$ var "ys")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:1}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (   var "DerivedGen.B"
+                                                  .! ("x", var "x")
+                                                  .! ("y", var "y")
+                                                  .! ("ys", var "ys")
+                                                  .! ("xs", var "xs")
+                                                  .$ var "^bnd^{arg:1}")))
+                             , var "<<DerivedGen.B>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[0, 1] (dry fuel)"))
+                                    .$ (var "<<DerivedGen.A>>" .$ var "Data.Fuel.Dry" .$ var "inter^<xs>" .$ var "inter^<ys>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[0, 1] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<DerivedGen.A>>" .$ var "^fuel_arg^" .$ var "inter^<xs>" .$ var "inter^<ys>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<DerivedGen.B>>" .$ var "^sub^fuel_arg^" .$ var "inter^<xs>" .$ var "inter^<ys>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[0, 1]" .$ var "^outmost-fuel^" .$ var "outer^<xs>" .$ var "outer^<ys>"
+      }
 
-                                              []
-                                              [ WithClause (IApp. IVar <<DerivedGen.A>>
-                                                                $ IBindVar ^cons_fuel^
-                                                                $ (IApp. IVar DerivedGen.(::)
-                                                                       $ IBindVar x
-                                                                       $ IBindVar xs)
-                                                                $ (IApp. IVar DerivedGen.(::)
-                                                                       $ IBindVar to_be_deceqed^^x0
-                                                                       $ IBindVar xs)
-                                                                $ (IApp. IVar Prelude.Yes
-                                                                       $ IVar Builtin.Refl))
-                                                           MW
-                                                           (IApp. IVar Decidable.Equality.decEq
-                                                                $ IVar to_be_deceqed^^x0
-                                                                $ IVar x)
-
-                                                           []
-                                                           [ PatClause (IApp. IVar <<DerivedGen.A>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ (IApp. IVar DerivedGen.(::)
-                                                                                   $ IBindVar x
-                                                                                   $ IBindVar xs)
-                                                                            $ (IApp. IVar DerivedGen.(::)
-                                                                                   $ IBindVar x
-                                                                                   $ IBindVar xs)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl))
-                                                                       (IApp. IVar Test.DepTyCheck.Gen.label
-                                                                            $ (IApp. IVar fromString
-                                                                                   $ IPrimVal DerivedGen.A (orders))
-                                                                            $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                                               f
-                                                                                               (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                    $ Implicit True)
-                                                                                   $ INamedApp (INamedApp (IVar DerivedGen.A)
-                                                                                                          xs
-                                                                                                          (IVar xs))
-                                                                                               x
-                                                                                               (IVar x)))
-                                                           , PatClause (IApp. IVar <<DerivedGen.A>>
-                                                                            $ IBindVar ^cons_fuel^
-                                                                            $ (IApp. IVar DerivedGen.(::)
-                                                                                   $ IBindVar x
-                                                                                   $ IBindVar xs)
-                                                                            $ (IApp. IVar DerivedGen.(::)
-                                                                                   $ IBindVar to_be_deceqed^^x0
-                                                                                   $ IBindVar xs)
-                                                                            $ (IApp. IVar Prelude.Yes
-                                                                                   $ IVar Builtin.Refl)
-                                                                            $ (IApp. IVar Prelude.No
-                                                                                   $ Implicit True))
-                                                                       (IVar empty) ]
-                                              , PatClause (IApp. IVar <<DerivedGen.A>>
-                                                               $ IBindVar ^cons_fuel^
-                                                               $ (IApp. IVar DerivedGen.(::)
-                                                                      $ IBindVar x
-                                                                      $ IBindVar xs)
-                                                               $ (IApp. IVar DerivedGen.(::)
-                                                                      $ IBindVar to_be_deceqed^^x0
-                                                                      $ IBindVar to_be_deceqed^^xs1)
-                                                               $ (IApp. IVar Prelude.No
-                                                                      $ Implicit True))
-                                                          (IVar empty) ]
-                                 , PatClause (IApp. IVar <<DerivedGen.A>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.B>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.B>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ (IApp. IVar DerivedGen.(::)
-                                                         $ IBindVar x
-                                                         $ IBindVar xs)
-                                                  $ (IApp. IVar DerivedGen.(::)
-                                                         $ IBindVar y
-                                                         $ IBindVar ys))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.B (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.Y>[0, 1]
-                                                                $ IVar ^cons_fuel^
-                                                                $ IVar xs
-                                                                $ IVar ys)
-                                                         $ (ILam.  (MW ExplicitArg ^bnd^{arg:1} : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. INamedApp (INamedApp (INamedApp (INamedApp (IVar DerivedGen.B)
-                                                                                                                            x
-                                                                                                                            (IVar x))
-                                                                                                                 y
-                                                                                                                 (IVar y))
-                                                                                                      ys
-                                                                                                      (IVar ys))
-                                                                                           xs
-                                                                                           (IVar xs)
-                                                                               $ IVar ^bnd^{arg:1})))))
-                                 , PatClause (IApp. IVar <<DerivedGen.B>>
-                                                  $ Implicit True
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]

--- a/tests/derivation/least-effort/print/regression/unnamed-auto-implicit/expected
+++ b/tests/derivation/least-effort/print/regression/unnamed-auto-implicit/expected
@@ -3,181 +3,182 @@
 3/3: Building DerivedGen (DerivedGen.idr)
 LOG gen.auto.derive.infra:0: type: (arg : Fuel) -> (f : X) -> Gen MaybeEmpty (u : () ** Y u f)
 LOG gen.auto.derive.infra:0: 
-ILam.  (MW ExplicitArg ^outmost-fuel^ : IVar Data.Fuel.Fuel)
-    => (MW ExplicitArg outer^<f> : Implicit True)
-    => ILocal (IApp. IVar <DerivedGen.Y>[1]
-                   $ IVar ^outmost-fuel^
-                   $ IVar outer^<f>)
-         IClaim MW
-                Export
-                []
-                (MkTy <DerivedGen.Y>[1]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (MW ExplicitArg {arg:1} : IVar DerivedGen.X)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ (IApp. IVar Builtin.DPair.DPair
-                                         $ IVar Builtin.Unit
-                                         $ (ILam.  (MW ExplicitArg {arg:2} : IVar Builtin.Unit)
-                                                => (IApp. IVar DerivedGen.Y
-                                                        $ IVar {arg:2}
-                                                        $ IVar {arg:1}))))))
-         IClaim MW
-                Export
-                []
-                (MkTy <Builtin.Unit>[]
-                      (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                          -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                  $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                  $ IVar Builtin.Unit)))
-         IDef <DerivedGen.Y>[1]
-              [ PatClause (IApp. IVar <DerivedGen.Y>[1]
-                               $ IBindVar ^fuel_arg^
-                               $ IBindVar inter^<{arg:1}>)
-                          (ILocal (ICase (IVar ^fuel_arg^)
-                                         (IVar Data.Fuel.Fuel)
-                                         [ PatClause (IVar Data.Fuel.Dry)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.Y[1] (dry fuel))
-                                                          $ (IApp. IVar <<DerivedGen.A>>
-                                                                 $ IVar Data.Fuel.Dry
-                                                                 $ IVar inter^<{arg:1}>))
-                                         , PatClause (IApp. IVar Data.Fuel.More
-                                                          $ IBindVar ^sub^fuel_arg^)
-                                                     (IApp. IVar Test.DepTyCheck.Gen.label
-                                                          $ (IApp. IVar fromString
-                                                                 $ IPrimVal DerivedGen.Y[1] (spend fuel))
-                                                          $ (IApp. IVar Test.DepTyCheck.Gen.frequency
-                                                                 $ (IApp. IVar ::
-                                                                        $ (IApp. IVar Builtin.MkPair
-                                                                               $ IVar Data.Nat.Pos.one
-                                                                               $ (IApp. IVar <<DerivedGen.A>>
-                                                                                      $ IVar ^fuel_arg^
-                                                                                      $ IVar inter^<{arg:1}>))
-                                                                        $ (IApp. IVar ::
-                                                                               $ (IApp. IVar Builtin.MkPair
-                                                                                      $ (IApp. IVar Deriving.DepTyCheck.Util.Reflection.leftDepth
-                                                                                             $ IVar ^sub^fuel_arg^)
-                                                                                      $ (IApp. IVar <<DerivedGen.B>>
-                                                                                             $ IVar ^sub^fuel_arg^
-                                                                                             $ IVar inter^<{arg:1}>))
-                                                                               $ IVar Nil)))) ]))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.A>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar DerivedGen.X)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Builtin.Unit
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Builtin.Unit)
-                                                                   => (IApp. IVar DerivedGen.Y
-                                                                           $ IVar {arg:2}
-                                                                           $ IVar {arg:1}))))))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<DerivedGen.B>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (MW ExplicitArg {arg:1} : IVar DerivedGen.X)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ (IApp. IVar Builtin.DPair.DPair
-                                                            $ IVar Builtin.Unit
-                                                            $ (ILam.  (MW ExplicitArg {arg:2} : IVar Builtin.Unit)
-                                                                   => (IApp. IVar DerivedGen.Y
-                                                                           $ IVar {arg:2}
-                                                                           $ IVar {arg:1}))))))
-                            IDef <<DerivedGen.A>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.A>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ IVar DerivedGen.Nil)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.A (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <Builtin.Unit>[]
-                                                                $ IVar ^outmost-fuel^)
-                                                         $ (ILam.  (MW ExplicitArg n : Implicit False)
-                                                                => (IApp. INamedApp (IVar Prelude.pure)
-                                                                                    f
-                                                                                    (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                         $ Implicit True)
-                                                                        $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                               $ Implicit True
-                                                                               $ INamedApp (IVar DerivedGen.A)
-                                                                                           n
-                                                                                           (IVar n))))))
-                                 , PatClause (IApp. IVar <<DerivedGen.A>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ]
-                            IDef <<DerivedGen.B>>
-                                 [ PatClause (IApp. IVar <<DerivedGen.B>>
-                                                  $ IBindVar ^cons_fuel^
-                                                  $ INamedApp (IApp. IVar DerivedGen.(::)
-                                                                   $ IBindVar x
-                                                                   $ IBindVar xs)
-                                                              {conArg:1}
-                                                              (IBindVar ^bnd^{conArg:2}))
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal DerivedGen.B (orders))
-                                                  $ (IApp. IVar >>=
-                                                         $ (IApp. IVar <DerivedGen.Y>[1]
-                                                                $ IVar ^cons_fuel^
-                                                                $ IVar xs)
-                                                         $ (ILam.  (MW ExplicitArg {lamc:0} : Implicit False)
-                                                                => ICase (IVar {lamc:0})
-                                                                         (Implicit False)
-                                                                         [ PatClause (IApp. IVar Builtin.DPair.MkDPair
-                                                                                          $ IBindVar n
-                                                                                          $ IBindVar ^bnd^{arg:3})
-                                                                                     (IApp. INamedApp (IVar Prelude.pure)
-                                                                                                      f
-                                                                                                      (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                                                           $ Implicit True)
-                                                                                          $ (IApp. IVar Builtin.DPair.MkDPair
-                                                                                                 $ Implicit True
-                                                                                                 $ IAutoApp (IApp. INamedApp (INamedApp (INamedApp (IVar DerivedGen.B)
-                                                                                                                                                   x
-                                                                                                                                                   (IVar x))
-                                                                                                                                        xs
-                                                                                                                                        (IVar xs))
-                                                                                                                             n
-                                                                                                                             (IVar n)
-                                                                                                                 $ IVar ^bnd^{arg:3})
-                                                                                                            (IVar ^bnd^{conArg:2}))) ])))
-                                 , PatClause (IApp. IVar <<DerivedGen.B>>
-                                                  $ Implicit True
-                                                  $ Implicit True)
-                                             (IVar empty) ] ]
-         IDef <Builtin.Unit>[]
-              [ PatClause (IApp. IVar <Builtin.Unit>[] $ IBindVar ^fuel_arg^)
-                          (ILocal (IApp. IVar Test.DepTyCheck.Gen.label
-                                       $ (IApp. IVar fromString
-                                              $ IPrimVal Builtin.Unit[] (non-recursive))
-                                       $ (IApp. IVar <<Builtin.MkUnit>>
-                                              $ IVar ^fuel_arg^)))
-                            IClaim MW
-                                   Export
-                                   []
-                                   (MkTy <<Builtin.MkUnit>>
-                                         (IPi.  (MW ExplicitArg : IVar Data.Fuel.Fuel)
-                                             -> (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                     $ IVar Test.DepTyCheck.Gen.Emptiness.MaybeEmpty
-                                                     $ IVar Builtin.Unit)))
-                            IDef <<Builtin.MkUnit>>
-                                 [ PatClause (IApp. IVar <<Builtin.MkUnit>>
-                                                  $ IBindVar ^cons_fuel^)
-                                             (IApp. IVar Test.DepTyCheck.Gen.label
-                                                  $ (IApp. IVar fromString
-                                                         $ IPrimVal Builtin.MkUnit (orders))
-                                                  $ (IApp. INamedApp (IVar Prelude.pure)
-                                                                     f
-                                                                     (IApp. IVar Test.DepTyCheck.Gen.Gen
-                                                                          $ Implicit True)
-                                                         $ IVar Builtin.MkUnit)) ] ]
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<f>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<DerivedGen.Y>[1]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.X")
+                     .->    var "Test.DepTyCheck.Gen.Gen"
+                         .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                         .$ (   var "Builtin.DPair.DPair"
+                             .$ var "Builtin.Unit"
+                             .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Builtin.Unit")
+                                 .=> var "DerivedGen.Y" .$ var "{arg:2}" .$ var "{arg:1}"))
+                 })
+          , IClaim
+              emptyFC
+              MW
+              Export
+              []
+              (mkTy
+                 { name = "<Builtin.Unit>[]"
+                 , type =
+                         MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                     .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.Y>[1]"
+              [    var "<DerivedGen.Y>[1]" .$ bindVar "^fuel_arg^" .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.A>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.X")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Builtin.Unit"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Builtin.Unit")
+                                                .=> var "DerivedGen.Y" .$ var "{arg:2}" .$ var "{arg:1}"))
+                                })
+                         , IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<DerivedGen.B>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.X")
+                                    .->    var "Test.DepTyCheck.Gen.Gen"
+                                        .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                        .$ (   var "Builtin.DPair.DPair"
+                                            .$ var "Builtin.Unit"
+                                            .$ (    MkArg MW ExplicitArg (Just "{arg:2}") (var "Builtin.Unit")
+                                                .=> var "DerivedGen.Y" .$ var "{arg:2}" .$ var "{arg:1}"))
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.A>>"
+                             [    var "<<DerivedGen.A>>" .$ bindVar "^cons_fuel^" .$ var "DerivedGen.Nil"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.A (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Builtin.Unit>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "n") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Builtin.DPair.MkDPair" .$ implicitTrue .$ (var "DerivedGen.A" .! ("n", var "n")))))
+                             , var "<<DerivedGen.A>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.B>>"
+                             [       var "<<DerivedGen.B>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (var "DerivedGen.(::)" .$ bindVar "x" .$ bindVar "xs" .! ("{conArg:1}", bindVar "^bnd^{conArg:2}"))
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.B (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.Y>[1]" .$ var "^cons_fuel^" .$ var "xs")
+                                      .$ (    MkArg MW ExplicitArg (Just "{lamc:0}") implicitFalse
+                                          .=> iCase
+                                                { sc = var "{lamc:0}"
+                                                , ty = implicitFalse
+                                                , clauses =
+                                                    [    var "Builtin.DPair.MkDPair" .$ bindVar "n" .$ bindVar "^bnd^{arg:3}"
+                                                      .=    var "Prelude.pure"
+                                                         .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                         .$ (   var "Builtin.DPair.MkDPair"
+                                                             .$ implicitTrue
+                                                             .$ (   var "DerivedGen.B"
+                                                                 .! ("x", var "x")
+                                                                 .! ("xs", var "xs")
+                                                                 .! ("n", var "n")
+                                                                 .$ var "^bnd^{arg:3}"
+                                                                 .@ var "^bnd^{conArg:2}"))
+                                                    ]
+                                                }))
+                             , var "<<DerivedGen.B>>" .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[1] (dry fuel)"))
+                                    .$ (var "<<DerivedGen.A>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[1] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ var "Data.Nat.Pos.one"
+                                                .$ (var "<<DerivedGen.A>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<DerivedGen.B>>" .$ var "^sub^fuel_arg^" .$ var "inter^<{arg:1}>"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Builtin.Unit>[]"
+              [    var "<Builtin.Unit>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             emptyFC
+                             MW
+                             Export
+                             []
+                             (mkTy
+                                { name = "<<Builtin.MkUnit>>"
+                                , type =
+                                        MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                    .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Builtin.Unit"
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Builtin.MkUnit>>"
+                             [    var "<<Builtin.MkUnit>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Builtin.MkUnit (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Builtin.MkUnit")
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "Builtin.Unit[] (non-recursive)"))
+                         .$ (var "<<Builtin.MkUnit>>" .$ var "^fuel_arg^")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.Y>[1]" .$ var "^outmost-fuel^" .$ var "outer^<f>"
+      }
+

--- a/tests/derivation/utils/arg-deps/_common/Infra.idr
+++ b/tests/derivation/utils/arg-deps/_common/Infra.idr
@@ -4,10 +4,11 @@ import DepsCheck
 
 import Deriving.DepTyCheck.Util
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Compat
 
 %language ElabReflection
+
+%hide Language.Reflection.Syntax.piAll
 
 ppTy : Type -> Elab Unit
 ppTy ty = do

--- a/tests/derivation/utils/canonicsig/_common/Infra.idr
+++ b/tests/derivation/utils/canonicsig/_common/Infra.idr
@@ -6,7 +6,7 @@ import public Deriving.DepTyCheck.Gen.Core
 
 import public Test.DepTyCheck.Gen
 
-import public Language.Reflection.Types
+import public Language.Reflection.Compat
 
 %default total
 
@@ -19,7 +19,7 @@ TestCaseDesc : Type
 TestCaseDesc = (String, TestCaseData)
 
 export
-chk : (ty : TypeInfo) -> List (Fin ty.args.length) -> Type -> TestCaseData
+chk : (ty : TypeInfo) -> List (Fin ty.tyArgs.length) -> Type -> TestCaseData
 chk ty giv expr = (canonicSig (MkGenSignature ty $ fromList giv), Fuel -> expr)
 
 export

--- a/tests/derivation/utils/cons-analysis/deep-cons-app-001/ConsApps.idr
+++ b/tests/derivation/utils/cons-analysis/deep-cons-app-001/ConsApps.idr
@@ -1,7 +1,6 @@
 module ConsApps
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Compat
 
 %default total
 

--- a/tests/derivation/utils/cons-analysis/deep-cons-app-002-neg/ConsApps.idr
+++ b/tests/derivation/utils/cons-analysis/deep-cons-app-002-neg/ConsApps.idr
@@ -1,7 +1,6 @@
 module ConsApps
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Compat
 
 %default total
 

--- a/tests/derivation/utils/cons-analysis/deep-cons-app-003/ConsApps.idr
+++ b/tests/derivation/utils/cons-analysis/deep-cons-app-003/ConsApps.idr
@@ -1,7 +1,6 @@
 module ConsApps
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Compat
 
 %default total
 

--- a/tests/derivation/utils/cons-analysis/deep-cons-app-004/ConsApps.idr
+++ b/tests/derivation/utils/cons-analysis/deep-cons-app-004/ConsApps.idr
@@ -1,7 +1,6 @@
 module ConsApps
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Compat
 
 %default total
 

--- a/tests/derivation/utils/cons-analysis/deep-cons-app-005-neg/ConsApps.idr
+++ b/tests/derivation/utils/cons-analysis/deep-cons-app-005-neg/ConsApps.idr
@@ -1,7 +1,6 @@
 module ConsApps
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Compat
 
 %default total
 

--- a/tests/derivation/utils/cons-analysis/deep-cons-app-006/ConsApps.idr
+++ b/tests/derivation/utils/cons-analysis/deep-cons-app-006/ConsApps.idr
@@ -2,9 +2,7 @@ module ConsApps
 
 import public Data.Vect.Views.Extra
 
-import Language.Reflection
-import Language.Reflection.Syntax
-import Language.Reflection.Types
+import Language.Reflection.Compat
 
 %default total
 

--- a/tests/derivation/utils/involved-types/_common-involved-types/Infra.idr
+++ b/tests/derivation/utils/involved-types/_common-involved-types/Infra.idr
@@ -13,7 +13,7 @@ printInvolvedTypesVerdict tyName minRig expected = do
   logMsg "gen.auto.involved-types" 0 "given type: \{show tyName}"
   invTys <- allInvolvedTypes minRig !(getInfo' tyName)
   let invTys   = sortBy (comparing show) $ invTys <&> name
-  expected <- for expected $ map name . getInfo'
+  expected <- for expected $ map TypeInfo.name . getInfo'
   let expected = sortBy (comparing show) expected
   when (invTys /= expected) $ do
     logMsg "gen.auto.involved-types" 0 "-------- !!! --------"

--- a/tests/derivation/utils/involved-types/norec-001/TypesAndInvolved.idr
+++ b/tests/derivation/utils/involved-types/norec-001/TypesAndInvolved.idr
@@ -1,7 +1,6 @@
 module TypesAndInvolved
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Compat
 
 %default total
 

--- a/tests/derivation/utils/involved-types/rec-001/TypesAndInvolved.idr
+++ b/tests/derivation/utils/involved-types/rec-001/TypesAndInvolved.idr
@@ -1,7 +1,6 @@
 module TypesAndInvolved
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Compat
 
 %default total
 

--- a/tests/derivation/utils/involved-types/rec-002/TypesAndInvolved.idr
+++ b/tests/derivation/utils/involved-types/rec-002/TypesAndInvolved.idr
@@ -2,8 +2,7 @@ module TypesAndInvolved
 
 import public Data.List.Alternating
 
-import Language.Reflection
-import Language.Reflection.Syntax
+import Language.Reflection.Compat
 
 %default total
 


### PR DESCRIPTION
I got a permission from Stefan Höck, main author and copyright holder or the `elab-util` library, to copy some parts of [pre-overhaul `elab-util`](https://github.com/stefan-hoeck/idris2-elab-util/pull/56) to this codebase in order to ease transition from old pre-overhaul to the modern version of the `elab-util` library.

Partially addresses #136.