### PR TITLE
[ cleanup ] Use the modern `Arg` type from `elab-util`

### DIFF
--- a/src/Deriving/DepTyCheck/Gen/Checked.idr
+++ b/src/Deriving/DepTyCheck/Gen/Checked.idr
@@ -54,6 +54,7 @@ public export
 record ExternalGenSignature where
   constructor MkExternalGenSignature
   targetType : TypeInfo
+  {auto 0 targetTypeCorrect : AllTyArgsNamed targetType}
   givenParams : SortedMap (Fin targetType.args.length) (ArgExplicitness, Name)
 
 namespace ExternalGenSignature

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
@@ -67,6 +67,7 @@ namespace NonObligatoryExts
               lhs                => failAt (getFC lhs) "Only applications to a name is supported, given \{lhs}"
             let Yes lengthCorrect = decEq ty.args.length args.length
               | No _ => failAt (getFC lhs) "INTERNAL ERROR: wrong count of unapp when analysing type application"
+            _ <- ensureTyArgsNamed ty
             pure $ MkTypeApp ty $ rewrite lengthCorrect in args.asVect <&> \arg => case getExpr arg of
               expr@(IVar _ n) => mirror . maybeToEither expr $ lookup n conArgIdxs
               expr            => Right expr
@@ -206,6 +207,7 @@ namespace NonObligatoryExts
         data TypeApp : Type where
           MkTypeApp :
             (type : TypeInfo) ->
+            (0 _ : AllTyArgsNamed type) =>
             (argTypes : Vect type.args.length .| Either (Fin con.args.length) TTImp) ->
             TypeApp
 

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
@@ -52,7 +52,7 @@ namespace NonObligatoryExts
       let conFC = getFC con.type
 
       -- Build a map from constructor's argument name to its index
-      let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (stname $ argName arg, idx)
+      let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (argName arg, idx)
 
       -- Analyse that we can do subgeneration for each constructor argument
       -- Fails using `Elaboration` if the given expression is not an application to a type constructor
@@ -76,7 +76,7 @@ namespace NonObligatoryExts
 
       -- Decide how constructor arguments would be named during generation
       let bindNames : Vect (con.args.length) String
-          bindNames = flip mapWithPos .| fromList con.args .| \_ => bindNameRenamer . stname . argName
+          bindNames = flip mapWithPos .| fromList con.args .| \_ => bindNameRenamer . argName
 
       -- Derive constructor calling expression for given order of generation
       let genForOrder : List (Fin con.args.length) -> m TTImp
@@ -104,7 +104,7 @@ namespace NonObligatoryExts
               -- Those which are `Right` are given, those which are `Left` are needs to be generated.
               let depArgs : Vect typeOfGened.args.length (Either (Fin con.args.length) TTImp) := argsOfTypeOfGened <&> \case
                 Right expr => Right expr
-                Left i     => if contains i presentArguments then Right $ var $ stname $ argName $ index' con.args i else Left i
+                Left i     => if contains i presentArguments then Right $ var $ argName $ index' con.args i else Left i
 
               -- Determine which arguments will be on the left of dpair in subgen call, in correct order
               let subgeneratedArgs = mapMaybe getLeft $ toList depArgs

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
@@ -52,7 +52,7 @@ namespace NonObligatoryExts
       let conFC = getFC con.type
 
       -- Build a map from constructor's argument name to its index
-      let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (argName arg, idx)
+      let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (stname $ argName arg, idx)
 
       -- Analyse that we can do subgeneration for each constructor argument
       -- Fails using `Elaboration` if the given expression is not an application to a type constructor
@@ -76,7 +76,7 @@ namespace NonObligatoryExts
 
       -- Decide how constructor arguments would be named during generation
       let bindNames : Vect (con.args.length) String
-          bindNames = flip mapWithPos .| fromList con.args .| \_ => bindNameRenamer . argName
+          bindNames = flip mapWithPos .| fromList con.args .| \_ => bindNameRenamer . stname . argName
 
       -- Derive constructor calling expression for given order of generation
       let genForOrder : List (Fin con.args.length) -> m TTImp
@@ -104,7 +104,7 @@ namespace NonObligatoryExts
               -- Those which are `Right` are given, those which are `Left` are needs to be generated.
               let depArgs : Vect typeOfGened.args.length (Either (Fin con.args.length) TTImp) := argsOfTypeOfGened <&> \case
                 Right expr => Right expr
-                Left i     => if contains i presentArguments then Right $ var $ argName $ index' con.args i else Left i
+                Left i     => if contains i presentArguments then Right $ var $ stname $ argName $ index' con.args i else Left i
 
               -- Determine which arguments will be on the left of dpair in subgen call, in correct order
               let subgeneratedArgs = mapMaybe getLeft $ toList depArgs

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsEntry.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsEntry.idr
@@ -42,7 +42,7 @@ canonicConsBody sig name con = do
       conRetTypeArg idx = index' conRetTypeArgs $ rewrite conRetTypeArgsLengthCorrect in idx
 
   -- Determine names of the arguments of the constructor (as a function)
-  let conArgNames = fromList $ (.name) <$> con.args
+  let conArgNames = fromList $ stname . (.name) <$> con.args
 
   -- For given arguments, determine whether they are
   --   - just a free name
@@ -79,7 +79,7 @@ canonicConsBody sig name con = do
   let bindExprs = \alreadyMatchedRenames => bindExprs <&> \f => f alreadyMatchedRenames
 
   -- Build a map from constructor's argument name to its index
-  let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (argName arg, idx)
+  let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (stname $ argName arg, idx)
 
   -- Determine indices of constructor's arguments that are given
   givenConArgs <- for givenConArgs.asList $ \givenArgName => do
@@ -118,8 +118,8 @@ canonicConsBody sig name con = do
           SortedSet.toList . foldl (flip insert) (empty @{AsInCon})
           where
             argStrName : NamedArg -> Maybe String
-            argStrName $ MkArg {name=UN (Basic n), _} = Just n
-            argStrName _                              = Nothing
+            argStrName $ MkArg {name=Just $ UN (Basic n), _} = Just n
+            argStrName _                                     = Nothing
 
   -- Form the declaration cases of a function generating values of particular constructor
   let fuelArg = "^cons_fuel^" -- I'm using a name containing chars that cannot be present in the code parsed from the Idris frontend

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsEntry.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsEntry.idr
@@ -117,7 +117,7 @@ canonicConsBody sig name con = do
                 compare (origL, renL) (origR, renR) = comparing (flip lookup conNameToIdx) origL origR <+> compare renL renR
           SortedSet.toList . foldl (flip insert) (empty @{AsInCon})
           where
-            argStrName : NamedArg -> Maybe String
+            argStrName : Arg -> Maybe String
             argStrName $ MkArg {name=Just $ UN (Basic n), _} = Just n
             argStrName _                                     = Nothing
 

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsEntry.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsEntry.idr
@@ -42,7 +42,7 @@ canonicConsBody sig name con = do
       conRetTypeArg idx = index' conRetTypeArgs $ rewrite conRetTypeArgsLengthCorrect in idx
 
   -- Determine names of the arguments of the constructor (as a function)
-  let conArgNames = fromList $ stname . (.name) <$> con.args
+  let conArgNames = fromList $ argName <$> con.args
 
   -- For given arguments, determine whether they are
   --   - just a free name
@@ -79,7 +79,7 @@ canonicConsBody sig name con = do
   let bindExprs = \alreadyMatchedRenames => bindExprs <&> \f => f alreadyMatchedRenames
 
   -- Build a map from constructor's argument name to its index
-  let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (stname $ argName arg, idx)
+  let conArgIdxs = SortedMap.fromList $ mapI' con.args $ \idx, arg => (argName arg, idx)
 
   -- Determine indices of constructor's arguments that are given
   givenConArgs <- for givenConArgs.asList $ \givenArgName => do

--- a/src/Deriving/DepTyCheck/Gen/Core/Util.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/Util.idr
@@ -118,7 +118,7 @@ analyseDeepConsApp ccdi freeNames = catch . isD where
       ||| Determines which constructor's arguments would be definitely determined by fully known result type.
       typeDeterminedArgs : forall m. Elaboration m => (con : Con) -> m $ Vect con.args.length ConsDetermInfo
       typeDeterminedArgs con = do
-        let conArgNames = fromList $ mapI' con.args $ \idx, arg => (argName arg, idx)
+        let conArgNames = fromList $ mapI' con.args $ \idx, arg => (stname $ argName arg, idx)
         determined <- fromMaybe [] . map fst <$> analyseDeepConsApp False (SortedSet.keySet conArgNames) con.type
         let determined = mapMaybe (flip lookup conArgNames) determined
         pure $ map cast $ presenceVect $ fromList determined
@@ -133,7 +133,7 @@ analyseDeepConsApp ccdi freeNames = catch . isD where
           let searchFun : NamedArg -> Bool
               searchFun = case a of
                             PosApp _      => (== ExplicitArg) . piInfo
-                            NamedApp nm _ => \na => isImplicit na.piInfo && argName na == nm
+                            NamedApp nm _ => \na => isImplicit na.piInfo && argName na == Just nm
                             AutoApp _     => (== AutoImplicit) . piInfo
                             WithApp _     => const False
           let Just i = findIndex (searchFun . fst) xs

--- a/src/Deriving/DepTyCheck/Gen/Core/Util.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/Util.idr
@@ -9,8 +9,6 @@ import public Deriving.DepTyCheck.Gen.Derive
 
 %default total
 
-%hide Language.Reflection.Syntax.Arg.piInfo
-
 --- Utilities ---
 
 public export
@@ -123,14 +121,14 @@ analyseDeepConsApp ccdi freeNames = catch . isD where
         let determined = mapMaybe (flip lookup conArgNames) determined
         pure $ map cast $ presenceVect $ fromList determined
 
-      reorder : {formalArgs : List NamedArg} -> {apps : List AnyApp} -> Vect formalArgs.length a -> Maybe $ Vect apps.length a
+      reorder : {formalArgs : List Arg} -> {apps : List AnyApp} -> Vect formalArgs.length a -> Maybe $ Vect apps.length a
       reorder xs = reorder' (fromList formalArgs `zip` xs) apps where
-        reorder' : Vect n (NamedArg, a) -> (apps : List AnyApp) -> Maybe $ Vect apps.length a
+        reorder' : Vect n (Arg, a) -> (apps : List AnyApp) -> Maybe $ Vect apps.length a
         reorder' xs        []      = if isJust $ find ((== ExplicitArg) . piInfo . fst) xs
                                        then Nothing {- not all explicit parameters are used -} else Just []
         reorder' []        (_::_)  = Nothing
         reorder' xs@(_::_) (a::as) = do
-          let searchFun : NamedArg -> Bool
+          let searchFun : Arg -> Bool
               searchFun = case a of
                             PosApp _      => (== ExplicitArg) . piInfo
                             NamedApp nm _ => \na => isImplicit na.piInfo && argName na == Just nm

--- a/src/Deriving/DepTyCheck/Gen/Core/Util.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/Util.idr
@@ -116,7 +116,7 @@ analyseDeepConsApp ccdi freeNames = catch . isD where
       ||| Determines which constructor's arguments would be definitely determined by fully known result type.
       typeDeterminedArgs : forall m. Elaboration m => (con : Con) -> m $ Vect con.args.length ConsDetermInfo
       typeDeterminedArgs con = do
-        let conArgNames = fromList $ mapI' con.args $ \idx, arg => (stname $ argName arg, idx)
+        let conArgNames = fromList $ mapI' con.args $ \idx, arg => (argName arg, idx)
         determined <- fromMaybe [] . map fst <$> analyseDeepConsApp False (SortedSet.keySet conArgNames) con.type
         let determined = mapMaybe (flip lookup conArgNames) determined
         pure $ map cast $ presenceVect $ fromList determined
@@ -131,7 +131,7 @@ analyseDeepConsApp ccdi freeNames = catch . isD where
           let searchFun : Arg -> Bool
               searchFun = case a of
                             PosApp _      => (== ExplicitArg) . piInfo
-                            NamedApp nm _ => \na => isImplicit na.piInfo && argName na == Just nm
+                            NamedApp nm _ => \na => isImplicit na.piInfo && na.name == Just nm
                             AutoApp _     => (== AutoImplicit) . piInfo
                             WithApp _     => const False
           let Just i = findIndex (searchFun . fst) xs

--- a/src/Deriving/DepTyCheck/Gen/Derive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Derive.idr
@@ -19,6 +19,7 @@ public export
 record GenSignature where
   constructor MkGenSignature
   targetType : TypeInfo
+  {auto 0 targetTypeCorrect : AllTyArgsNamed targetType}
   givenParams : SortedSet $ Fin targetType.args.length
 
 namespace GenSignature

--- a/src/Deriving/DepTyCheck/Gen/Derive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Derive.idr
@@ -98,7 +98,7 @@ interface DerivatorCore where
 --- Expressions generation utils ---
 
 defArgNames : {sig : GenSignature} -> Vect sig.givenParams.size String
-defArgNames = sig.givenParams.asVect <&> show . stname . name . index' sig.targetType.args
+defArgNames = sig.givenParams.asVect <&> show . argName . index' sig.targetType.args
 
 export %inline
 canonicDefaultLHS' : (namesFun : String -> String) -> GenSignature -> Name -> (fuel : String) -> TTImp

--- a/src/Deriving/DepTyCheck/Gen/Derive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Derive.idr
@@ -63,13 +63,14 @@ canonicSig sig = piAll returnTy $ MkArg MW ExplicitArg Nothing `(Data.Fuel.Fuel)
   -- TODO Check that the resulting `TTImp` reifies to a `Type`? During this check, however, all types must be present in the caller's context.
 
   arg : Fin sig.targetType.args.length -> Arg False
-  arg idx = let MkArg {name, type, _} = index' sig.targetType.args idx in MkArg MW ExplicitArg (Just name) type
+  arg idx = let MkArg {name, type, _} = index' sig.targetType.args idx in MkArg MW ExplicitArg name type
 
   returnTy : TTImp
   returnTy = `(Test.DepTyCheck.Gen.Gen Test.DepTyCheck.Gen.Emptiness.MaybeEmpty ~(buildDPair targetTypeApplied generatedArgs)) where
 
     targetTypeApplied : TTImp
-    targetTypeApplied = foldr apply (extractTargetTyExpr sig.targetType) $ reverse $ sig.targetType.args <&> \(MkArg {name, piInfo, _}) =>
+    targetTypeApplied = foldr apply (extractTargetTyExpr sig.targetType) $ reverse $ sig.targetType.args <&> \(MkArg {name, piInfo, _}) => do
+                          let name = stname name
                           case piInfo of
                             ExplicitArg   => (.$ var name)
                             ImplicitArg   => \f => namedApp f name $ var name
@@ -78,7 +79,7 @@ canonicSig sig = piAll returnTy $ MkArg MW ExplicitArg Nothing `(Data.Fuel.Fuel)
 
     generatedArgs : List (Name, TTImp)
     generatedArgs = mapMaybeI' sig.targetType.args $ \idx, (MkArg {name, type, _}) =>
-                      ifThenElse .| contains idx sig.givenParams .| Nothing .| Just (name, type)
+                      ifThenElse .| contains idx sig.givenParams .| Nothing .| Just (stname name, type)
 
 -- Complementary to `canonicSig`
 export
@@ -97,7 +98,7 @@ interface DerivatorCore where
 --- Expressions generation utils ---
 
 defArgNames : {sig : GenSignature} -> Vect sig.givenParams.size String
-defArgNames = sig.givenParams.asVect <&> show . name . index' sig.targetType.args
+defArgNames = sig.givenParams.asVect <&> show . stname . name . index' sig.targetType.args
 
 export %inline
 canonicDefaultLHS' : (namesFun : String -> String) -> GenSignature -> Name -> (fuel : String) -> TTImp

--- a/src/Deriving/DepTyCheck/Gen/Derive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Derive.idr
@@ -62,7 +62,7 @@ canonicSig : GenSignature -> TTImp
 canonicSig sig = piAll returnTy $ MkArg MW ExplicitArg Nothing `(Data.Fuel.Fuel) :: (arg <$> SortedSet.toList sig.givenParams) where
   -- TODO Check that the resulting `TTImp` reifies to a `Type`? During this check, however, all types must be present in the caller's context.
 
-  arg : Fin sig.targetType.args.length -> Arg False
+  arg : Fin sig.targetType.args.length -> Arg
   arg idx = let MkArg {name, type, _} = index' sig.targetType.args idx in MkArg MW ExplicitArg name type
 
   returnTy : TTImp

--- a/src/Deriving/DepTyCheck/Gen/Entry.idr
+++ b/src/Deriving/DepTyCheck/Gen/Entry.idr
@@ -12,8 +12,6 @@ import public Test.DepTyCheck.Gen -- for `Gen` data type
 
 %default total
 
-%hide Language.Reflection.Syntax.unPi
-
 ----------------------------------------
 --- Internal functions and instances ---
 ----------------------------------------
@@ -160,7 +158,7 @@ checkTypeIsGen checkSide sig = do
   (givenParams, autoImplArgs, givenParamsPositions) <- do
     let
       classifyArg : forall m. Elaboration m =>
-                    NamedArg -> m $ Either (ArgExplicitness, UserName, TTImp) TTImp
+                    Arg -> m $ Either (ArgExplicitness, UserName, TTImp) TTImp
       classifyArg $ MkArg MW ImplicitArg (Just $ UN name) type = pure $ Left (Checked.ImplicitArg, name, type)
       classifyArg $ MkArg MW ExplicitArg (Just $ UN name) type = pure $ Left (Checked.ExplicitArg, name, type)
       classifyArg $ MkArg MW AutoImplicit (Just $ MN _ _) type = pure $ Right type

--- a/src/Deriving/DepTyCheck/Gen/Entry.idr
+++ b/src/Deriving/DepTyCheck/Gen/Entry.idr
@@ -128,6 +128,9 @@ checkTypeIsGen checkSide sig = do
 
     _ => failAt targetTypeFC "Target type is not a simple name"
 
+  -- check that target type has all unnamed arguments resolved with machine-generated names
+  _ <- ensureTyArgsNamed targetType
+
   --------------------------------------------------
   -- Target type family's arguments' first checks --
   --------------------------------------------------

--- a/src/Deriving/DepTyCheck/Util/Reflection.idr
+++ b/src/Deriving/DepTyCheck/Util/Reflection.idr
@@ -405,6 +405,13 @@ public export
 conSubexprs : Con -> List TTImp
 conSubexprs con = map type con.args ++ (map getExpr $ snd $ unAppAny con.type)
 
+export
+ensureTyArgsNamed : Elaboration m => (ty : TypeInfo) -> m $ AllTyArgsNamed ty
+ensureTyArgsNamed ty = do
+  let Yes prf = areAllTyArgsNamed ty
+    | No _ => fail "DepTyCheck blames the compiler: type info for type `\{ty.name}` contains unnamed arguments"
+  pure prf
+
 -------------------------------------------------
 --- Syntactic analysis of `TTImp` expressions ---
 -------------------------------------------------

--- a/src/Deriving/DepTyCheck/Util/Reflection.idr
+++ b/src/Deriving/DepTyCheck/Util/Reflection.idr
@@ -29,10 +29,6 @@ import public Text.PrettyPrint.Bernardy
 
 %default total
 
-%hide Language.Reflection.Syntax.pi
-%hide Language.Reflection.Syntax.piAll
-%hide Language.Reflection.Syntax.unPi
-
 -----------------------
 --- Pretty-printing ---
 -----------------------
@@ -88,13 +84,13 @@ isImplicit ExplicitArg     = False
 --- `DPair` type parsing and rebuilding stuff ---
 
 public export
-unDPair : TTImp -> (List (Arg False), TTImp)
+unDPair : TTImp -> (List Arg, TTImp)
 unDPair (IApp _ (IApp _ (IVar _ `{Builtin.DPair.DPair}) typ) (ILam _ cnt piInfo mbname _ lamTy)) =
     mapFst (MkArg cnt piInfo mbname typ ::) $ unDPair lamTy
 unDPair expr = ([], expr)
 
 public export
-unDPairUnAlt : TTImp -> Maybe (List (Arg False), TTImp)
+unDPairUnAlt : TTImp -> Maybe (List Arg, TTImp)
 unDPairUnAlt (IAlternative _ _ alts) = case filter (not . null . Builtin.fst) $ unDPair <$> alts of
   [x] => Just x
   _   => Nothing
@@ -115,7 +111,7 @@ data AnyApp
   | WithApp TTImp
 
 public export
-appArg : NamedArg -> TTImp -> AnyApp
+appArg : Arg -> TTImp -> AnyApp
 appArg (MkArg {piInfo=ExplicitArg, _})         expr = PosApp expr
 appArg (MkArg {piInfo=ImplicitArg, name, _})   expr = NamedApp (stname name) expr
 appArg (MkArg {piInfo=DefImplicit _, name, _}) expr = NamedApp (stname name) expr
@@ -291,7 +287,7 @@ doesTypecheckAs : Elaboration m => (0 expected : Type) -> TTImp -> m Bool
 doesTypecheckAs expected expr = try .| check {expected} expr $> True .| pure False
 
 export
-argDeps : Elaboration m => (args : List NamedArg) -> m $ DVect args.length $ SortedSet . Fin . Fin.finToNat
+argDeps : Elaboration m => (args : List Arg) -> m $ DVect args.length $ SortedSet . Fin . Fin.finToNat
 argDeps args = do
   ignore $ check {expected=Type} $ fullSig defaultRet -- we can't return trustful result if given arguments do not form a nice Pi type
   concatMap depsOfOne range
@@ -300,7 +296,7 @@ argDeps args = do
 
   %unbound_implicits off -- this is a workaround of https://github.com/idris-lang/Idris2/issues/2040
 
-  filteredArgs : (excluded : SortedSet $ Fin args.length) -> List NamedArg
+  filteredArgs : (excluded : SortedSet $ Fin args.length) -> List Arg
   filteredArgs excluded = filterI' args $ \idx, _ => not $ contains idx excluded
 
   partialSig : (retTy : TTImp) -> (excluded : SortedSet $ Fin args.length) -> TTImp
@@ -609,7 +605,7 @@ allInvolvedTypes minimalRig ti = toList <$> go [ti] empty where
       typesOfExpr : TTImp -> m $ List TypeInfo
       typesOfExpr expr = map (mapMaybe id) $ for (allVarNames expr) $ catch . getInfo'
 
-      typesOfArg : NamedArg -> m $ List TypeInfo
+      typesOfArg : Arg -> m $ List TypeInfo
       typesOfArg arg = atRig arg.count $ typesOfExpr arg.type
 
       typesOfCon : Con -> m $ List TypeInfo

--- a/src/Deriving/DepTyCheck/Util/Reflection.idr
+++ b/src/Deriving/DepTyCheck/Util/Reflection.idr
@@ -67,7 +67,7 @@ normaliseCon $ MkCon n args ty = do
   whole <- normaliseAsType whole
   let (args', ty) = unPi whole
   -- `quote` may corrupt names, workaround it:
-  let args = args `zip` args' <&> \(pre, normd) => {name := argName pre} normd
+  let args = args `zip` args' <&> \(pre, normd) => {name := pre.name} normd
   pure $ MkCon n args ty
 
 --------------------------------------------
@@ -303,7 +303,7 @@ argDeps args = do
   partialSig retTy = piAll retTy . map {piInfo := ExplicitArg} . filteredArgs
 
   partialApp : (appliee : Name) -> (excluded : SortedSet $ Fin args.length) -> TTImp
-  partialApp n = appNames n . map (stname . name) . filteredArgs
+  partialApp n = appNames n . map argName . filteredArgs
 
   fullSig : (retTy : TTImp) -> TTImp
   fullSig t = partialSig t empty
@@ -389,7 +389,7 @@ export
 deriveMatchingCons : (retTy : TTImp) -> (matcher : Con -> TTImp) -> (funName : Name) -> TypeInfo -> List Decl
 deriveMatchingCons retTy matcher funName ti = do
   let claim = do
-    let tyApplied = reAppAny (var ti.name) $ ti.args <&> \arg => appArg arg $ var $ stname $ name arg
+    let tyApplied = reAppAny (var ti.name) $ ti.args <&> \arg => appArg arg $ var $ argName arg
     let sig = foldr
                 (pi . {count := M0, piInfo := ImplicitArg})
                 `(~tyApplied -> ~retTy)

--- a/src/Language/Reflection/Compat.idr
+++ b/src/Language/Reflection/Compat.idr
@@ -19,6 +19,10 @@ public export
 stname : Maybe Name -> Name
 stname = fromMaybe $ UN Underscore
 
+public export
+argName : Arg -> Name
+argName = stname . (.name)
+
 --------------------------------------------------------------------------------
 --          General Types
 --------------------------------------------------------------------------------
@@ -73,10 +77,6 @@ getInfo = getInfo'
 -------------------------------------
 --- Working around type inference ---
 -------------------------------------
-
-public export
-argName : Arg -> Maybe Name
-argName = (.name)
 
 public export %inline
 (.tyArgs) : TypeInfo -> List Arg

--- a/src/Language/Reflection/Compat.idr
+++ b/src/Language/Reflection/Compat.idr
@@ -15,74 +15,9 @@ import public Language.Reflection.Syntax.Ops
 
 %default total
 
-%hide Syntax.unPi
-
---------------------------------------------------------------------------------
---          Function Arguments
---------------------------------------------------------------------------------
-
-public export
-record Arg' where
-  constructor MkArg
-  count  : Count
-  piInfo : PiInfo TTImp
-  name   : Maybe Name
-  type   : TTImp
-
-public export
-Arg : Bool -> Type
-Arg _ = Arg'
-
-%deprecate
-public export
-NamedArg : Type
-NamedArg = Arg True
-
 public export
 stname : Maybe Name -> Name
 stname = fromMaybe $ UN Underscore
-
-public export
-data IsNamed : Arg' -> Type where
-  ItIsNamed : IsNamed $ MkArg c p (Just n) t
-
-export %deprecate
-namedArg : Elaboration m => Arg False -> m NamedArg
-namedArg = pure
-
-export
-arg : TTImp -> Arg False
-arg = MkArg MW ExplicitArg Nothing
-
-export
-erasedArg : TTImp -> Arg False
-erasedArg = MkArg M0 ExplicitArg Nothing
-
-export
-lambdaArg : Name -> Arg False
-lambdaArg n = MkArg MW ExplicitArg (Just n) implicitFalse
-
-||| Extracts the arguments from a function type.
-export
-unPi : TTImp -> (List $ Arg False, TTImp)
-unPi (IPi _ c p n at rt) = mapFst (MkArg c p n at ::) $ unPi rt
-unPi tpe                 = ([],tpe)
-
---------------------------------------------------------------------------------
---          Function Types
---------------------------------------------------------------------------------
-
-||| Defines a function type.
-|||
-||| This passes the fields of `Arg` to `IPi EmptyFC`
-export
-pi : Arg False -> (retTy : TTImp) -> TTImp
-pi (MkArg c p n t) = IPi EmptyFC c p n t
-
-||| Defines a function type taking the given arguments.
-export
-piAll : TTImp -> List (Arg False) -> TTImp
-piAll res = foldr pi res
 
 --------------------------------------------------------------------------------
 --          General Types
@@ -93,7 +28,7 @@ public export
 record Con where
   constructor MkCon
   name : Name
-  args : List NamedArg
+  args : List Arg
   type : TTImp
 
 ||| Tries to lookup a constructor by name.
@@ -114,7 +49,7 @@ public export
 record TypeInfo where
   constructor MkTypeInfo
   name : Name
-  args : List NamedArg
+  args : List Arg
   cons : List Con
 
 ||| Tries to get information about the data type specified
@@ -140,11 +75,11 @@ getInfo = getInfo'
 -------------------------------------
 
 public export
-argName : NamedArg -> Maybe Name
+argName : Arg -> Maybe Name
 argName = (.name)
 
 public export %inline
-(.tyArgs) : TypeInfo -> List NamedArg
+(.tyArgs) : TypeInfo -> List Arg
 (.tyArgs) = args
 
 public export %inline
@@ -152,5 +87,5 @@ public export %inline
 (.tyCons) = cons
 
 public export %inline
-(.conArgs) : Con -> List NamedArg
+(.conArgs) : Con -> List Arg
 (.conArgs) = args

--- a/tests/derivation/_common/AlternativeCore.idr
+++ b/tests/derivation/_common/AlternativeCore.idr
@@ -36,7 +36,9 @@ EmptyCons = MainCoreDerivator @{EmptyCons'}
 ------------------------------
 
 callSimpleGen : CanonicGen m => TypeInfo -> (fuel : TTImp) -> m TTImp
-callSimpleGen tyi fuel = callGen (MkGenSignature tyi SortedSet.empty) fuel $ believe_me $ Vect.Nil {elem = TTImp}
+callSimpleGen tyi fuel = do
+  _ <- ensureTyArgsNamed tyi
+  callGen (MkGenSignature tyi SortedSet.empty) fuel $ believe_me $ Vect.Nil {elem = TTImp}
 
 callStrGen : CanonicGen m => (fuel : TTImp) -> m TTImp
 callStrGen = callSimpleGen $ typeInfoForPrimType StringType

--- a/tests/derivation/utils/arg-deps/_common/Infra.idr
+++ b/tests/derivation/utils/arg-deps/_common/Infra.idr
@@ -9,13 +9,14 @@ import Language.Reflection.Compat
 %language ElabReflection
 
 %hide Language.Reflection.Syntax.piAll
+%hide Language.Reflection.Syntax.unPi
 
 ppTy : Type -> Elab Unit
 ppTy ty = do
   expr <- quote ty
-  (args, ret) <- unPiNamed expr
+  let (args, ret) = unPi expr
   deps <- map SortedSet.toList <$> argDeps args
-  let expr' = piAll ret $ {name $= Just, piInfo := ExplicitArg} <$> args -- as if all arguments were explicit
+  let expr' = piAll ret $ {piInfo := ExplicitArg} <$> args -- as if all arguments were explicit
   logSugaredTerm "gen.auto.arg-deps" 0 "type        " expr'
   logMsg         "gen.auto.arg-deps" 0 "dependencies: \{show deps}\n"
 

--- a/tests/derivation/utils/arg-deps/_common/Infra.idr
+++ b/tests/derivation/utils/arg-deps/_common/Infra.idr
@@ -8,9 +8,6 @@ import Language.Reflection.Compat
 
 %language ElabReflection
 
-%hide Language.Reflection.Syntax.piAll
-%hide Language.Reflection.Syntax.unPi
-
 ppTy : Type -> Elab Unit
 ppTy ty = do
   expr <- quote ty

--- a/tests/derivation/utils/canonicsig/_common/Infra.idr
+++ b/tests/derivation/utils/canonicsig/_common/Infra.idr
@@ -18,8 +18,12 @@ public export %inline
 TestCaseDesc : Type
 TestCaseDesc = (String, TestCaseData)
 
+%hint %macro
+ATAN : {ty : _} -> Elab $ AllTyArgsNamed ty
+ATAN = ensureTyArgsNamed ty
+
 export
-chk : (ty : TypeInfo) -> List (Fin ty.tyArgs.length) -> Type -> TestCaseData
+chk : (ty : TypeInfo) -> (0 _ : AllTyArgsNamed ty) => List (Fin ty.tyArgs.length) -> Type -> TestCaseData
 chk ty giv expr = (canonicSig (MkGenSignature ty $ fromList giv), Fuel -> expr)
 
 export

--- a/tests/derivation/utils/cons-analysis/_common-deep-cons-app/Infra.idr
+++ b/tests/derivation/utils/cons-analysis/_common-deep-cons-app/Infra.idr
@@ -8,6 +8,9 @@ import Deriving.DepTyCheck.Gen.Core.Util
 
 %language ElabReflection
 
+%hide Data.List.Quantifiers.Right
+%hide Data.List.Quantifiers.Left
+
 printDeepConsApp : List Name -> TTImp -> Elab Unit
 printDeepConsApp freeNames tyExpr = do
   logMsg         "gen.auto.deep-cons-app" 0 ""

--- a/tests/derivation/utils/cons-analysis/deep-cons-app-006/ConsApps.idr
+++ b/tests/derivation/utils/cons-analysis/deep-cons-app-006/ConsApps.idr
@@ -7,7 +7,7 @@ import Language.Reflection.Compat
 %default total
 
 rhsConsOf : Name -> Elab $ List (List Name, TTImp)
-rhsConsOf n = getInfo' n <&> \tyInfo => tyInfo.cons <&> \con => (con.args <&> stname . argName, con.type)
+rhsConsOf n = getInfo' n <&> \tyInfo => tyInfo.cons <&> \con => (con.args <&> argName, con.type)
 
 public export
 data EqExp : (tyL : Type) -> (tyR : Type) -> tyL -> tyR -> Type where

--- a/tests/derivation/utils/cons-analysis/deep-cons-app-006/ConsApps.idr
+++ b/tests/derivation/utils/cons-analysis/deep-cons-app-006/ConsApps.idr
@@ -7,7 +7,7 @@ import Language.Reflection.Compat
 %default total
 
 rhsConsOf : Name -> Elab $ List (List Name, TTImp)
-rhsConsOf n = getInfo' n <&> \tyInfo => tyInfo.cons <&> \con => (con.args <&> name, con.type)
+rhsConsOf n = getInfo' n <&> \tyInfo => tyInfo.cons <&> \con => (con.args <&> stname . argName, con.type)
 
 public export
 data EqExp : (tyL : Type) -> (tyR : Type) -> tyL -> tyR -> Type where

--- a/tests/lib/coverage/ty-and-con-withCov-007/PrintCoverage.idr
+++ b/tests/lib/coverage/ty-and-con-withCov-007/PrintCoverage.idr
@@ -11,11 +11,9 @@ import System.Random.Pure.StdGen
 
 %language ElabReflection
 
-%hide Language.Reflection.Syntax.var
-
 data X : (post : List ()) -> Type where
   XZ : X post
-  XS : X post -> X (var::post)
+  XS : X post -> X (v::post)
 
 data Y : Type where
   MkY : (all : List ()) -> X all -> Y


### PR DESCRIPTION
Implements one or two next steps from #136 