### PR TITLE
[ ci ] Install `summary-stat` once at the beginning

### DIFF
--- a/.github/workflows/ci-deptycheck.yml
+++ b/.github/workflows/ci-deptycheck.yml
@@ -73,6 +73,8 @@ jobs:
         run: .github/tar -xvf "${{ env.pack_dir_file }}" --one-top-level=/ --touch
 
       - run: pack install-deps deptycheck
+      - run: pack install summary-stat # for distr tests
+             # TODO to compute test dependencies when we have special mini-test libs
 
       - name: Tar the `pack` dir
         run: .github/tar -uvf "${{ env.pack_dir_file }}" --exclude=".cache" "$PACK_DIR"

--- a/.gitlab/deptycheck.yml
+++ b/.gitlab/deptycheck.yml
@@ -34,6 +34,8 @@ thirdparties:build:
     - pack:prepare
   script:
     - pack install-deps deptycheck
+    - pack install summary-stat # for distr tests
+      # TODO to compute test dependencies when we have special mini-test libs
 
 deptycheck:build:
   stage: deptycheck:build


### PR DESCRIPTION
Attempt to workaround some flacky bug with late installation of `summary-stat` in GH CI