### PR TITLE
[ upstream, workaround ] Disambiguate strangely conflicting definition

### DIFF
--- a/src/Deriving/DepTyCheck/Gen/Core.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core.idr
@@ -42,10 +42,10 @@ ConstructorDerivator => DerivatorCore where
   canonicBody sig n = do
 
     -- check that there is at least one constructor
-    when .| null sig.targetType.cons .| fail "No constructors found for the type `\{show sig.targetType.name}`"
+    Prelude.when .| null sig.targetType.cons .| fail "No constructors found for the type `\{show sig.targetType.name}`"
 
     -- check that desired `Gen` is not a generator of `Gen`s
-    when .| sig.targetType.name == `{Test.DepTyCheck.Gen.Gen} .| fail "Target type of a derived `Gen` cannot be a `Gen`"
+    Prelude.when .| sig.targetType.name == `{Test.DepTyCheck.Gen.Gen} .| fail "Target type of a derived `Gen` cannot be a `Gen`"
 
     -- generate claims for generators per constructors
     let consClaims = sig.targetType.cons <&> \con => export' (consGenName con) (canonicSig sig)


### PR DESCRIPTION
Fixes #155. We can't just `%hide` function `when` from `Bernardy.Combinators` because it should reside in not-yet published collection