### PR TITLE
[ ci ] Build nightly on `pack`'s `HEAD`, not `latest` + small useful function

### DIFF
--- a/.github/workflows/ci-deptycheck.yml
+++ b/.github/workflows/ci-deptycheck.yml
@@ -47,7 +47,7 @@ jobs:
 
       - run: pack update-db
       - name: Switch to appropriate `pack` collection
-        run: pack switch "$( if [[ '${{ github.event_name }}' == 'schedule' ]]; then echo latest; else ./.pack-collection; fi )"
+        run: pack switch "$( if [[ '${{ github.event_name }}' == 'schedule' ]]; then echo HEAD; else ./.pack-collection; fi )"
       - run: ./.patch-chez-gc-handler idris2
 
       - name: Tar the `pack` dir

--- a/.gitlab/deptycheck.yml
+++ b/.gitlab/deptycheck.yml
@@ -20,7 +20,7 @@ pack:prepare:
   stage: .pre
   script:
     - pack update-db
-    - pack switch "$( if [[ "$CI_PIPELINE_SOURCE" == 'schedule' ]]; then echo latest; else ./.pack-collection; fi )"
+    - pack switch "$( if [[ "$CI_PIPELINE_SOURCE" == 'schedule' ]]; then echo HEAD; else ./.pack-collection; fi )"
     - ./.patch-chez-gc-handler idris2
 
 stages:

--- a/src/Test/DepTyCheck/Gen.idr
+++ b/src/Test/DepTyCheck/Gen.idr
@@ -100,6 +100,10 @@ export
 chooseAny : Random a => (0 _ : IfUnsolved ne NonEmpty) => Gen ne a
 chooseAny = Raw $ MkRawGen getRandom
 
+public export %inline
+chooseAnyOf : (0 a : _) -> Random a => (0 _ : IfUnsolved ne NonEmpty) => Gen ne a
+chooseAnyOf _ = chooseAny
+
 export
 choose : Random a => (0 _ : IfUnsolved ne NonEmpty) => (a, a) -> Gen ne a
 choose bounds = Raw $ MkRawGen $ getRandomR bounds


### PR DESCRIPTION
Closes #157, for successfully built pack collections this does not make much difference, because collection must be built several minutes prior.