### PR TITLE
[ collection ] Add combintaions function to collections sublib

### DIFF
--- a/src/Deriving/DepTyCheck/Util/Collections.idr
+++ b/src/Deriving/DepTyCheck/Util/Collections.idr
@@ -176,6 +176,14 @@ export
 presenceVect : {n : _} -> SortedSet (Fin n) -> Vect n Bool
 presenceVect = tabulate . flip contains
 
+public export
+combinations : Vect n (List1 a) -> List1 (Vect n a)
+combinations l = map (rewrite plusZeroRightNeutral n in reverse) $ go l (Nil:::[]) where
+  go : Vect m (List1 a) -> List1 (Vect k a) -> List1 (Vect (m + k) a)
+  go           Nil       rss = rss
+  go {m = S m} (xs::xss) rss = rewrite plusSuccRightSucc m k in
+    go xss $ join $ map (\x => map (\rs => x :: rs) rss) xs
+
 namespace Vect
 
   export


### PR DESCRIPTION
Utility to create all possible (preserving order of given arguments) combinations from a Vect of Lists. E.g.:
```
Deriving.DepTyCheck.Util.Collections> combinations [1:::Nil, 2:::[3], 4:::[5,6]]
[1, 2, 4] ::: [[1, 3, 4], [1, 2, 5], [1, 3, 5], [1, 2, 6], [1, 3, 6]]
```