### PR TITLE
[ breaking, cleanup ] Remove now unused `simplificationHack` derivator's option

### DIFF
--- a/docs/source/explanation/specifications/experiments.md
+++ b/docs/source/explanation/specifications/experiments.md
@@ -14,7 +14,8 @@ import Deriving.DepTyCheck.Gen
 deriveGen : a
 -->
 
-```idris
+<!-- The code block above uses ```<space>idris intentionally, now this code does not compile and it's okay -->
+``` idris
 %language ElabReflection
 
 %hint
@@ -23,6 +24,8 @@ UsedConstructorDerivator = LeastEffort {simplificationHack = True}
 ```
 
 The version of the compiler used is `https://github.com/buzden/Idris2/commit/9ab96dacd4f855674028d68de0a013ac7926c73d`.
+
+Please, notice that used settings may fail typechecking with the most recent versions of the compiler and library.
 
 ## Constructors
 

--- a/examples/pil-fun/src/Language/PilFun/Derived.idr
+++ b/examples/pil-fun/src/Language/PilFun/Derived.idr
@@ -8,6 +8,4 @@ import Deriving.DepTyCheck.Gen
 
 %logging "deptycheck.derive" 5
 
-%hint LE : ConstructorDerivator; LE = LeastEffort {simplificationHack = True}
-
 Language.PilFun.genStmts = deriveGen

--- a/examples/pil-fun/src/Language/PilFun/Pretty/Derived.idr
+++ b/examples/pil-fun/src/Language/PilFun/Pretty/Derived.idr
@@ -8,6 +8,4 @@ import Deriving.DepTyCheck.Gen
 
 %logging "deptycheck.derive" 5
 
-%hint LE : ConstructorDerivator; LE = LeastEffort {simplificationHack = True}
-
 Language.PilFun.Pretty.rawNewName = deriveGen

--- a/examples/sorted-list-so-comp/src/Data/List/Sorted/Gen.idr
+++ b/examples/sorted-list-so-comp/src/Data/List/Sorted/Gen.idr
@@ -9,10 +9,6 @@ import Deriving.DepTyCheck.Gen
 
 %logging "deptycheck.derive" 5
 
-%hint
-UsedConstructorDerivator : ConstructorDerivator
-UsedConstructorDerivator = LeastEffort {simplificationHack = True}
-
 export
 genSortedList : Fuel -> Gen MaybeEmpty SortedList
 genSortedList = deriveGen

--- a/examples/sorted-list-so-full/src/Data/List/Sorted/Gen.idr
+++ b/examples/sorted-list-so-full/src/Data/List/Sorted/Gen.idr
@@ -9,10 +9,6 @@ import Deriving.DepTyCheck.Gen
 
 %logging "deptycheck.derive" 5
 
-%hint
-UsedConstructorDerivator : ConstructorDerivator
-UsedConstructorDerivator = LeastEffort {simplificationHack = True}
-
 export
 genSortedList : Fuel -> Gen MaybeEmpty SortedList
 genSortedList = deriveGen

--- a/examples/sorted-list-tl-pred/src/Data/List/Sorted/Gen.idr
+++ b/examples/sorted-list-tl-pred/src/Data/List/Sorted/Gen.idr
@@ -9,10 +9,6 @@ import Deriving.DepTyCheck.Gen
 
 %logging "deptycheck.derive" 5
 
-%hint
-UsedConstructorDerivator : ConstructorDerivator
-UsedConstructorDerivator = LeastEffort {simplificationHack = True}
-
 export
 genSortedList : Fuel -> Gen MaybeEmpty SortedList
 genSortedList = deriveGen

--- a/examples/sorted-tree-indexed/src/Data/SortedBinTree/Gen.idr
+++ b/examples/sorted-tree-indexed/src/Data/SortedBinTree/Gen.idr
@@ -9,10 +9,6 @@ import Deriving.DepTyCheck.Gen
 
 %logging "deptycheck.derive" 5
 
-%hint
-UsedConstructorDerivator : ConstructorDerivator
-UsedConstructorDerivator = LeastEffort {simplificationHack = True}
-
 export
 genSortedBinTree1 : Fuel -> Gen MaybeEmpty (mi ** ma ** SortedBinTree1 mi ma)
 genSortedBinTree1 = deriveGen

--- a/examples/sorted-tree-naive/src/Data/SortedBinTree/Gen.idr
+++ b/examples/sorted-tree-naive/src/Data/SortedBinTree/Gen.idr
@@ -9,10 +9,6 @@ import Deriving.DepTyCheck.Gen
 
 %logging "deptycheck.derive" 5
 
-%hint
-UsedConstructorDerivator : ConstructorDerivator
-UsedConstructorDerivator = LeastEffort {simplificationHack = True}
-
 export
 genSortedBinTree : Fuel -> Gen MaybeEmpty SortedBinTree
 genSortedBinTree = deriveGen

--- a/examples/uniq-list/src/Data/List/Uniq/Gen.idr
+++ b/examples/uniq-list/src/Data/List/Uniq/Gen.idr
@@ -9,8 +9,4 @@ import Deriving.DepTyCheck.Gen
 
 %logging "deptycheck.derive" 5
 
-%hint
-UsedConstructorDerivator : ConstructorDerivator
-UsedConstructorDerivator = LeastEffort {simplificationHack = True}
-
 Data.List.Uniq.genUniqStrList = deriveGen

--- a/examples/uniq-list/src/Data/Vect/Uniq/Gen.idr
+++ b/examples/uniq-list/src/Data/Vect/Uniq/Gen.idr
@@ -9,8 +9,4 @@ import Deriving.DepTyCheck.Gen
 
 %logging "deptycheck.derive" 5
 
-%hint
-UsedConstructorDerivator : ConstructorDerivator
-UsedConstructorDerivator = LeastEffort {simplificationHack = True}
-
 Data.Vect.Uniq.genUniqStrVect = deriveGen

--- a/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core/ConsDerive.idr
@@ -201,7 +201,7 @@ namespace NonObligatoryExts
   ||| It is seemingly most simple to implement, maybe the fastest and
   ||| fits well when external generators are provided for non-dependent types.
   export
-  [LeastEffort] {default False simplificationHack : Bool} -> ConstructorDerivator where
+  [LeastEffort] ConstructorDerivator where
     consGenExpr sig con givs fuel = do
 
       -- Prepare local search context

--- a/tests/derivation/_common/derive.ipkg
+++ b/tests/derivation/_common/derive.ipkg
@@ -1,7 +1,5 @@
 package derive-test
 
-authors = "Denis Buzdalov"
-
 opts = "--no-color --console-width 0"
 
 depends = deptycheck

--- a/tests/derivation/distribution/dependent-rec-sh-001/CheckDistribution.idr
+++ b/tests/derivation/distribution/dependent-rec-sh-001/CheckDistribution.idr
@@ -6,8 +6,6 @@ import DistrCheckCommon
 
 %default total
 
-%hint DA : ConstructorDerivator; DA = LeastEffort {simplificationHack=True}
-
 data ListNat : Type
 data Constraint : ListNat -> Type
 

--- a/tests/derivation/distribution/dependent-rec-sh-002/CheckDistribution.idr
+++ b/tests/derivation/distribution/dependent-rec-sh-002/CheckDistribution.idr
@@ -6,8 +6,6 @@ import DistrCheckCommon
 
 %default total
 
-%hint DA : ConstructorDerivator; DA = LeastEffort {simplificationHack=True}
-
 data ListNat : Type
 data Constraint : Nat -> ListNat -> Type
 

--- a/tests/derivation/inputvalidation/_common/validate-input.ipkg
+++ b/tests/derivation/inputvalidation/_common/validate-input.ipkg
@@ -1,7 +1,5 @@
 package validate-input
 
-authors = "Denis Buzdalov"
-
 opts = "--no-color --console-width 0"
 
 depends = deptycheck

--- a/tests/derivation/utils/arg-deps/_common/arg-deps.ipkg
+++ b/tests/derivation/utils/arg-deps/_common/arg-deps.ipkg
@@ -1,7 +1,5 @@
 package arg-deps
 
-authors = "Denis Buzdalov"
-
 opts = "--no-color --console-width 0"
 
 depends = deptycheck

--- a/tests/derivation/utils/canonicsig/_common/canonic-sig.ipkg
+++ b/tests/derivation/utils/canonicsig/_common/canonic-sig.ipkg
@@ -1,7 +1,5 @@
 package canonic-sig
 
-authors = "Denis Buzdalov"
-
 opts = "--no-color --console-width 0"
 
 depends = deptycheck

--- a/tests/derivation/utils/cons-analysis/_common-deep-cons-app/cons.ipkg
+++ b/tests/derivation/utils/cons-analysis/_common-deep-cons-app/cons.ipkg
@@ -1,7 +1,5 @@
 package arg-deps
 
-authors = "Denis Buzdalov"
-
 opts = "--no-color --console-width 0"
 
 depends = deptycheck

--- a/tests/derivation/utils/involved-types/_common-involved-types/inv-ty.ipkg
+++ b/tests/derivation/utils/involved-types/_common-involved-types/inv-ty.ipkg
@@ -1,7 +1,5 @@
 package inv-tys
 
-authors = "Denis Buzdalov"
-
 opts = "--no-color --console-width 0"
 
 depends = deptycheck

--- a/tests/derivation/utils/up-to-renaming-ttimp-eq/_common/renaming-ttimp-eq.ipkg
+++ b/tests/derivation/utils/up-to-renaming-ttimp-eq/_common/renaming-ttimp-eq.ipkg
@@ -1,7 +1,5 @@
 package renaming-ttimp-eq
 
-authors = "Denis Buzdalov"
-
 opts = "--no-color --console-width 0"
 
 depends = deptycheck

--- a/tests/docs/readme/test.ipkg
+++ b/tests/docs/readme/test.ipkg
@@ -1,5 +1,3 @@
 package test
 
-authors = "Denis Buzdalov"
-
 depends = deptycheck


### PR DESCRIPTION
Now, after #183, this option does not change anything.

If you are using a `%hint` with this option being set, and you get a compilation error, you can just remove this `%hint` and everything should work as before.