### PR TITLE
[ ci ] Run workflow on any push and disable cron in forks

### DIFF
--- a/.github/workflows/ci-deptycheck.yml
+++ b/.github/workflows/ci-deptycheck.yml
@@ -119,9 +119,9 @@ jobs:
           name: built-deptycheck
           path: ${{ env.pack_dir_file }}
 
-  #######$###################
+  ###########################
   # Build DepTyCheck's docs #
-  ########$##################
+  ###########################
 
   deptycheck-build-docs:
     name: Build the docs

--- a/.github/workflows/ci-deptycheck.yml
+++ b/.github/workflows/ci-deptycheck.yml
@@ -34,12 +34,26 @@ env:
 
 jobs:
 
+  ##############
+  # Validation #
+  ##############
+
+  validate_trigger:
+    name: Validate trigger
+    # Disable scheduled running on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'buzden'
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op step
+        run: echo "This job exists only for validation."
+
   ################
   # Preparations #
   ################
 
   prepare-pack:
     name: Prepare `pack`
+    needs: validate_trigger
     runs-on: ubuntu-latest
     container: ghcr.io/stefan-hoeck/idris2-pack:latest
     steps:
@@ -123,6 +137,7 @@ jobs:
 
   deptycheck-build-docs:
     name: Build the docs
+    needs: validate_trigger
     runs-on: ubuntu-latest
     container: sphinxdoc/sphinx:latest
     steps:

--- a/.github/workflows/ci-deptycheck.yml
+++ b/.github/workflows/ci-deptycheck.yml
@@ -4,9 +4,7 @@ name: DepTyCheck
 on:
   push:
     branches:
-      - main
-      - master
-      - 'debug-ci/**'
+      - '**'
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/ci-non-primary-os.yml
+++ b/.github/workflows/ci-non-primary-os.yml
@@ -4,10 +4,9 @@ name: Non-primary OS
 on:
   push:
     branches:
-      - main
-      - master
+      - '**'
     tags:
-      - '*'
+      - '**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -4,10 +4,9 @@ name: Lint
 on:
   push:
     branches:
-      - main
-      - master
+      - '**'
     tags:
-      - '*'
+      - '**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This PR contains 2 changes in workflow:
1. Run CI on any push, not just in `main` and `master`.
2. Disable scheduled launches in forks. Usually they are only needed in the main repository. A similar condition is used in many projects, e.g.:
    https://github.com/pypa/virtualenv/blob/27a1138dccd39e2f7fdcb3371c7e8a0c8b50f144/.github/workflows/check.yaml#L18