### PR TITLE
[ new ] Add a facility for tuning propabilities in derived generators

### DIFF
--- a/examples/covering-seq/tests/gens/print/expected
+++ b/examples/covering-seq/tests/gens/print/expected
@@ -223,7 +223,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (bs : BitMask n) -> Gen May
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Covering.CoveringSequence[0, 1] (dry fuel)"))
-                                    .$ (var "<<Data.List.Covering.End>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>" .$ var "inter^<{arg:1}>")
+                                    .$ (var "<<Data.List.Covering.End>>" .$ var "^fuel_arg^" .$ var "inter^<n>" .$ var "inter^<{arg:1}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Covering.CoveringSequence[0, 1] (spend fuel)"))
@@ -405,7 +405,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (bs : BitMask n) -> Gen May
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Covering.BitMask.Index.AtIndex[0, 2, 3] (dry fuel)"))
                                     .$ (   var "<<Data.List.Covering.BitMask.Index.Here>>"
-                                        .$ var "Data.Fuel.Dry"
+                                        .$ var "^fuel_arg^"
                                         .$ var "inter^<n>"
                                         .$ var "inter^<{arg:2}>"
                                         .$ var "inter^<{arg:3}>")
@@ -500,7 +500,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (bs : BitMask n) -> Gen May
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
@@ -640,7 +640,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (bs : BitMask n) -> Gen May
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Covering.BitMask.Index.AllBitsAre[0, 1, 2] (dry fuel)"))
                                     .$ (   var "<<Data.List.Covering.BitMask.Index.Finish>>"
-                                        .$ var "Data.Fuel.Dry"
+                                        .$ var "^fuel_arg^"
                                         .$ var "inter^<n>"
                                         .$ var "inter^<{arg:5}>"
                                         .$ var "inter^<{arg:6}>")

--- a/examples/sorted-list-so-comp/tests/gens/print/expected
+++ b/examples/sorted-list-so-comp/tests/gens/print/expected
@@ -141,7 +141,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.SortedList[] (dry fuel)"))
-                                    .$ (var "<<Data.List.Sorted.Nil>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.List.Sorted.Nil>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.SortedList[] (spend fuel)"))
@@ -272,7 +272,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.LTEHead[] (dry fuel)"))
-                                    .$ (var "<<Data.List.Sorted.NoHead>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.List.Sorted.NoHead>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.LTEHead[] (spend fuel)"))
@@ -394,7 +394,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/examples/sorted-list-so-full/tests/gens/print/expected
+++ b/examples/sorted-list-so-full/tests/gens/print/expected
@@ -122,7 +122,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.SortedList[] (dry fuel)"))
-                                    .$ (var "<<Data.List.Sorted.Nil>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.List.Sorted.Nil>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.SortedList[] (spend fuel)"))
@@ -242,7 +242,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/examples/sorted-list-tl-pred/tests/gens/print/expected
+++ b/examples/sorted-list-tl-pred/tests/gens/print/expected
@@ -162,7 +162,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.SortedList[] (dry fuel)"))
-                                    .$ (var "<<Data.List.Sorted.Nil>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.List.Sorted.Nil>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.SortedList[] (spend fuel)"))
@@ -292,7 +292,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.FirstGT[] (dry fuel)"))
-                                    .$ (var "<<Data.List.Sorted.E>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.List.Sorted.E>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.FirstGT[] (spend fuel)"))
@@ -408,7 +408,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.FirstGT[0] (dry fuel)"))
-                                    .$ (var "<<Data.List.Sorted.E>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>")
+                                    .$ (var "<<Data.List.Sorted.E>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.List.Sorted.FirstGT[0] (spend fuel)"))
@@ -519,7 +519,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Nat.LTE[0] (dry fuel)"))
-                                    .$ (var "<<Data.Nat.LTEZero>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<Data.Nat.LTEZero>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Nat.LTE[0] (spend fuel)"))
@@ -603,7 +603,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty SortedList
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/src/Deriving/DepTyCheck/Gen/Core.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core.idr
@@ -113,8 +113,7 @@ ConstructorDerivator => DerivatorCore where
 
         [ -- if fuel is dry, call all non-recursive constructors on `Dry`
           let nonRecCons = mapMaybe (\(con, w) => (con,) <$> getLeft w.weight) consRecs in
-          let dry = var `{Data.Fuel.Dry} in dry       .= callConstFreqs "\{logPosition sig} (dry fuel)".label dry nonRecCons
-                                                                       -- TODO to think why not `fuelAr` here ^^^ if we check non-rec here
+          var `{Data.Fuel.Dry}                        .= callConstFreqs "\{logPosition sig} (dry fuel)".label (varStr fuelAr) nonRecCons
 
         , do -- if fuel is `More`, spend one fuel and call all constructors on the rest
           let subFuelArg = "^sub" ++ fuelAr -- I'm using a name containing chars that cannot be present in the code parsed from the Idris frontend

--- a/src/Deriving/DepTyCheck/Gen/Core.idr
+++ b/src/Deriving/DepTyCheck/Gen/Core.idr
@@ -6,6 +6,15 @@ import public Deriving.DepTyCheck.Util.Reflection
 
 %default total
 
+-------------------------------
+--- Tuning of probabilities ---
+-------------------------------
+
+public export
+interface ProbabilityTuning (0 n : Name) where
+  0 isConstructor : (con : IsConstructor n ** GenuineProof con)
+  tuneWeight : Nat1 -> Nat1
+
 -----------------------------------------
 --- Utility functions and definitions ---
 -----------------------------------------
@@ -14,12 +23,23 @@ import public Deriving.DepTyCheck.Util.Reflection
 
 record ConWeightInfo where
   constructor MkConWeightInfo
-  ||| When constructor refers transitively to the type it belongs
-  recursive : Bool
+  ||| Either constant (for non-recursive) or an expression (be a lambda taking the left fuel, or some other expression; for recursive)
+  weight : Either Nat1 TTImp
+
+%inline
+recursive : ConWeightInfo -> Bool
+recursive = isRight . weight
 
 ----------------------------
 --- Derivation functions ---
 ----------------------------
+
+-- This is a workaround of some bad and not yet understood behaviour, leading to both compile- and runtime errors
+removeNamedApps, workaroundFromNat : TTImp -> TTImp
+removeNamedApps = mapTTImp $ \case INamedApp _ lhs _ _ => lhs; e => e
+workaroundFromNat = mapTTImp $ \e => case fst $ unAppAny e of IVar _ `{Data.Nat1.FromNat} => removeNamedApps e; _ => e
+
+%ambiguity_depth 4
 
 export
 ConstructorDerivator => DerivatorCore where
@@ -39,9 +59,18 @@ ConstructorDerivator => DerivatorCore where
       canonicConsBody sig (consGenName con) con <&> def (consGenName con)
 
     -- calculate which constructors are recursive and which are not
-    consRecs <- logBounds {level=Trace} "consRec" [sig] $ pure $ sig.targetType.cons <&> \con => do
+    consRecs <- logBounds {level=Trace} "consRec" [sig] $ Prelude.for sig.targetType.cons $ \con => do
       let rec = isRecursive {containingType=Just sig.targetType} con
-      (con, MkConWeightInfo rec)
+      tuneImpl <- search $ ProbabilityTuning $ Con.name con
+      let baseForRec = \subFuelArg => var `{Deriving.DepTyCheck.Util.Reflection.leftDepth} .$ varStr subFuelArg
+      let someStrangeName = "^some_strange_name^"
+      w <- case rec of
+        False => pure $ Left $ maybe one (\impl => tuneWeight @{impl} one) tuneImpl
+        True  => Right <$> case tuneImpl of
+          Nothing   => pure $ lam (lambdaArg $ UN $ Basic someStrangeName) $ baseForRec someStrangeName
+          Just impl => quote (tuneWeight @{impl}) <&> \wm =>
+            lam (lambdaArg $ UN $ Basic someStrangeName) $ workaroundFromNat $ wm `applySyn` baseForRec someStrangeName
+      Prelude.pure (con, MkConWeightInfo w)
 
     -- decide how to name a fuel argument on the LHS
     let fuelArg = "^fuel_arg^" -- I'm using a name containing chars that cannot be present in the code parsed from the Idris frontend
@@ -65,23 +94,32 @@ ConstructorDerivator => DerivatorCore where
     fuelDecisionExpr : (fuelArg : String) -> List (Con, ConWeightInfo) -> TTImp
     fuelDecisionExpr fuelAr consRecs = do
 
+      let reflectNat1 : Nat1 -> TTImp
+          reflectNat1 $ FromNat 1 = liftWeight1
+          reflectNat1 $ FromNat n = `(fromInteger ~(primVal $ BI $ cast n))
+
+      let callConstFreqs : CTLabel -> (fuel : TTImp) -> List (Con, Nat1) -> TTImp
+          callConstFreqs l fuel cons = if isJust $ find ((/=) 1 . toNat . snd) cons
+            then callFrequency l $ cons <&> bimap reflectNat1 (callConsGen fuel) . swap
+            else callOneOf l $ cons <&> callConsGen fuel . fst
+
       -- check if there are any non-recursive constructors
-      let True = isJust $ find (recursive . snd) consRecs
-        | False =>
-            -- no recursive constructors, thus just call all without spending fuel
-            callOneOf "\{logPosition sig} (non-recursive)".label (consRecs <&> callConsGen (varStr fuelAr) . fst)
+      let Nothing = for consRecs $ \(con, w) => (con,) <$> getLeft w.weight
+          -- only constantly weighted constructors (usually, non-recusrive), thus just call all without spending fuel
+        | Just consRecs => callConstFreqs "\{logPosition sig} (non-recursive)".label (varStr fuelAr) consRecs
 
       -- pattern match on the fuel argument
       iCase .| varStr fuelAr .| var `{Data.Fuel.Fuel} .|
 
         [ -- if fuel is dry, call all non-recursive constructors on `Dry`
-          let nonRecCons = fst <$> filter (not . recursive . snd) consRecs in
-          let dry = var `{Data.Fuel.Dry} in dry       .= callOneOf "\{logPosition sig} (dry fuel)".label (nonRecCons <&> callConsGen dry)
+          let nonRecCons = mapMaybe (\(con, w) => (con,) <$> getLeft w.weight) consRecs in
+          let dry = var `{Data.Fuel.Dry} in dry       .= callConstFreqs "\{logPosition sig} (dry fuel)".label dry nonRecCons
+                                                                       -- TODO to think why not `fuelAr` here ^^^ if we check non-rec here
 
         , do -- if fuel is `More`, spend one fuel and call all constructors on the rest
           let subFuelArg = "^sub" ++ fuelAr -- I'm using a name containing chars that cannot be present in the code parsed from the Idris frontend
           let selectFuel = \r => varStr $ if recursive r then subFuelArg else fuelAr
-          let weight = \r => if recursive r then var `{Deriving.DepTyCheck.Util.Reflection.leftDepth} .$ varStr subFuelArg else liftWeight1
+          let weight = either reflectNat1 (`applySyn` varStr subFuelArg) . weight
           var `{Data.Fuel.More} .$ bindVar subFuelArg .= callFrequency "\{logPosition sig} (spend fuel)".label
                                                            (consRecs <&> \(con, rec) => (weight rec, callConsGen (selectFuel rec) con))
         ]

--- a/src/Deriving/DepTyCheck/Util/Reflection.idr
+++ b/src/Deriving/DepTyCheck/Util/Reflection.idr
@@ -94,6 +94,15 @@ isImplicit (DefImplicit x) = True
 isImplicit AutoImplicit    = True
 isImplicit ExplicitArg     = False
 
+-- Apply syntactically, optimise if LHS is `ILam`.
+-- This implementation does not take shadowing into account.
+-- Also, currently, the type of lambda argument is not used in the final expression, this can break typechecking in complex cases.
+public export
+applySyn : TTImp -> TTImp -> TTImp
+applySyn (ILam _ _ _ Nothing  _ lamExpr) _ = lamExpr
+applySyn (ILam _ _ _ (Just n) _ lamExpr) rhs = mapTTImp (\case orig@(IVar _ n') => if n == n' then rhs else orig; e => e) lamExpr
+applySyn lhs rhs = lhs `app` rhs
+
 --- `DPair` type parsing and rebuilding stuff ---
 
 public export

--- a/tests/derivation/distribution/list-nat-tuned-001/CheckDistribution.idr
+++ b/tests/derivation/distribution/list-nat-tuned-001/CheckDistribution.idr
@@ -1,0 +1,53 @@
+module CheckDistribution
+
+import Deriving.DepTyCheck.Gen
+
+import DistrCheckCommon
+
+%default total
+
+%language ElabReflection
+
+data ListNat : Type where
+  Nil  : ListNat
+  (::) : Nat -> ListNat -> ListNat
+
+length : ListNat -> Nat
+length []      = Z
+length (_::xs) = S $ length xs
+
+ProbabilityTuning `{CheckDistribution.(::)}.dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = (*2)
+
+listNats : Fuel -> Gen MaybeEmpty ListNat
+listNats = deriveGen
+
+----------------------
+
+pow2 : Nat -> Double
+pow2 k = pow 2.0 $ cast k
+
+%hide List.Lazy.rangeFromTo
+%hide List.Lazy.rangeFromThenTo
+
+fac : Nat -> Double
+fac 0 = 1
+fac n = cast $ product [1 .. n]
+
+-- (2 * n + 1)!!, i.e. 2 * 4 * 6 * ... * (2*n+1)
+oddFacFac : Nat -> Double
+oddFacFac n = cast $ product [1, 3 .. 2*n+1]
+
+p : (fuel, currLen : Nat) -> Probability
+p n k = if k <= n then P $ roughlyFit $ (pow2 k * fac n * oddFacFac ((n `minus` k) `minus` 1)) / (fac (n `minus` k) * oddFacFac n) else 0
+
+mainFor : (depth : Nat) -> IO ()
+mainFor depth = printVerdict (listNats $ limit depth) $ fromList $ [ coverWith (p depth n) ((== n) . length) | n <- [0 .. depth + 1] ]
+
+main : IO ()
+main = do
+  mainFor 0
+  mainFor 1
+  mainFor 2
+  mainFor 5

--- a/tests/derivation/distribution/list-nat-tuned-001/DistrCheckCommon.idr
+++ b/tests/derivation/distribution/list-nat-tuned-001/DistrCheckCommon.idr
@@ -1,0 +1,1 @@
+../_common/DistrCheckCommon.idr

--- a/tests/derivation/distribution/list-nat-tuned-001/expected
+++ b/tests/derivation/distribution/list-nat-tuned-001/expected
@@ -1,0 +1,4 @@
+Just [ok, ok]
+Just [ok, ok, ok]
+Just [ok, ok, ok, ok]
+Just [ok, ok, ok, ok, ok, ok, ok]

--- a/tests/derivation/distribution/list-nat-tuned-001/run
+++ b/tests/derivation/distribution/list-nat-tuned-001/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/distribution/list-nat-tuned-001/test.ipkg
+++ b/tests/derivation/distribution/list-nat-tuned-001/test.ipkg
@@ -1,0 +1,1 @@
+../_common/test.ipkg

--- a/tests/derivation/distribution/list-nat-tuned-002/CheckDistribution.idr
+++ b/tests/derivation/distribution/list-nat-tuned-002/CheckDistribution.idr
@@ -1,0 +1,45 @@
+module CheckDistribution
+
+import Deriving.DepTyCheck.Gen
+
+import DistrCheckCommon
+
+%default total
+
+%language ElabReflection
+
+data ListNat : Type where
+  Nil  : ListNat
+  (::) : Nat -> ListNat -> ListNat
+
+length : ListNat -> Nat
+length []      = Z
+length (_::xs) = S $ length xs
+
+ProbabilityTuning `{CheckDistribution.(::)}.dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight _ = 1
+
+listNats : Fuel -> Gen MaybeEmpty ListNat
+listNats = deriveGen
+
+----------------------
+
+pow2 : Nat -> Double
+pow2 k = pow 2.0 $ cast k
+
+p : (fuel, currLen : Nat) -> Probability
+p n k = case compare n k of
+  GT => P $ roughlyFit $ 1 / pow2 (1+k)
+  EQ => P $ roughlyFit $ 1 / pow2 k
+  LT => 0
+
+mainFor : (depth : Nat) -> IO ()
+mainFor depth = printVerdict (listNats $ limit depth) $ fromList $ [ coverWith (p depth n) ((== n) . length) | n <- [0 .. depth + 1] ]
+
+main : IO ()
+main = do
+  mainFor 0
+  mainFor 1
+  mainFor 2
+  mainFor 5

--- a/tests/derivation/distribution/list-nat-tuned-002/DistrCheckCommon.idr
+++ b/tests/derivation/distribution/list-nat-tuned-002/DistrCheckCommon.idr
@@ -1,0 +1,1 @@
+../_common/DistrCheckCommon.idr

--- a/tests/derivation/distribution/list-nat-tuned-002/expected
+++ b/tests/derivation/distribution/list-nat-tuned-002/expected
@@ -1,0 +1,4 @@
+Just [ok, ok]
+Just [ok, ok, ok]
+Just [ok, ok, ok, ok]
+Just [ok, ok, ok, ok, ok, ok, ok]

--- a/tests/derivation/distribution/list-nat-tuned-002/run
+++ b/tests/derivation/distribution/list-nat-tuned-002/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/distribution/list-nat-tuned-002/test.ipkg
+++ b/tests/derivation/distribution/list-nat-tuned-002/test.ipkg
@@ -1,0 +1,1 @@
+../_common/test.ipkg

--- a/tests/derivation/distribution/list-nat-tuned-003/CheckDistribution.idr
+++ b/tests/derivation/distribution/list-nat-tuned-003/CheckDistribution.idr
@@ -1,0 +1,49 @@
+module CheckDistribution
+
+import Deriving.DepTyCheck.Gen
+
+import DistrCheckCommon
+
+%default total
+
+%language ElabReflection
+
+data ListNat : Type where
+  Nil  : ListNat
+  (::) : Nat -> ListNat -> ListNat
+
+length : ListNat -> Nat
+length []      = Z
+length (_::xs) = S $ length xs
+
+ProbabilityTuning `{CheckDistribution.(::)}.dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = \_ => 4
+
+ProbabilityTuning `{CheckDistribution.Nil}.dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = const 4
+
+listNats : Fuel -> Gen MaybeEmpty ListNat
+listNats = deriveGen
+
+----------------------
+
+pow2 : Nat -> Double
+pow2 k = pow 2.0 $ cast k
+
+p : (fuel, currLen : Nat) -> Probability
+p n k = case compare n k of
+  GT => P $ roughlyFit $ 1 / pow2 (1+k)
+  EQ => P $ roughlyFit $ 1 / pow2 k
+  LT => 0
+
+mainFor : (depth : Nat) -> IO ()
+mainFor depth = printVerdict (listNats $ limit depth) $ fromList $ [ coverWith (p depth n) ((== n) . length) | n <- [0 .. depth + 1] ]
+
+main : IO ()
+main = do
+  mainFor 0
+  mainFor 1
+  mainFor 2
+  mainFor 5

--- a/tests/derivation/distribution/list-nat-tuned-003/DistrCheckCommon.idr
+++ b/tests/derivation/distribution/list-nat-tuned-003/DistrCheckCommon.idr
@@ -1,0 +1,1 @@
+../_common/DistrCheckCommon.idr

--- a/tests/derivation/distribution/list-nat-tuned-003/expected
+++ b/tests/derivation/distribution/list-nat-tuned-003/expected
@@ -1,0 +1,4 @@
+Just [ok, ok]
+Just [ok, ok, ok]
+Just [ok, ok, ok, ok]
+Just [ok, ok, ok, ok, ok, ok, ok]

--- a/tests/derivation/distribution/list-nat-tuned-003/run
+++ b/tests/derivation/distribution/list-nat-tuned-003/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/distribution/list-nat-tuned-003/test.ipkg
+++ b/tests/derivation/distribution/list-nat-tuned-003/test.ipkg
@@ -1,0 +1,1 @@
+../_common/test.ipkg

--- a/tests/derivation/distribution/list-nat-tuned-004/CheckDistribution.idr
+++ b/tests/derivation/distribution/list-nat-tuned-004/CheckDistribution.idr
@@ -1,0 +1,39 @@
+module CheckDistribution
+
+import Deriving.DepTyCheck.Gen
+
+import DistrCheckCommon
+
+%default total
+
+%language ElabReflection
+
+data ListNat : Type where
+  Nil  : ListNat
+  (::) : Nat -> ListNat -> ListNat
+
+length : ListNat -> Nat
+length []      = Z
+length (_::xs) = S $ length xs
+
+ProbabilityTuning `{CheckDistribution.Nil}.dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = const 2
+
+listNats : Fuel -> Gen MaybeEmpty ListNat
+listNats = deriveGen
+
+----------------------
+
+p : (fuel, currLen : Nat) -> Probability
+p n k = if k <= n then P $ roughlyFit $ 2.0 * cast (n + 1 `minus` k) / cast ((n + 1) * (n + 2)) else 0
+
+mainFor : (depth : Nat) -> IO ()
+mainFor depth = printVerdict (listNats $ limit depth) $ fromList $ [ coverWith (p depth n) ((== n) . length) | n <- [0 .. depth + 1] ]
+
+main : IO ()
+main = do
+  mainFor 0
+  mainFor 1
+  mainFor 2
+  mainFor 5

--- a/tests/derivation/distribution/list-nat-tuned-004/DistrCheckCommon.idr
+++ b/tests/derivation/distribution/list-nat-tuned-004/DistrCheckCommon.idr
@@ -1,0 +1,1 @@
+../_common/DistrCheckCommon.idr

--- a/tests/derivation/distribution/list-nat-tuned-004/expected
+++ b/tests/derivation/distribution/list-nat-tuned-004/expected
@@ -1,0 +1,4 @@
+Just [ok, ok]
+Just [ok, ok, ok]
+Just [ok, ok, ok, ok]
+Just [ok, ok, ok, ok, ok, ok, ok]

--- a/tests/derivation/distribution/list-nat-tuned-004/run
+++ b/tests/derivation/distribution/list-nat-tuned-004/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/distribution/list-nat-tuned-004/test.ipkg
+++ b/tests/derivation/distribution/list-nat-tuned-004/test.ipkg
@@ -1,0 +1,1 @@
+../_common/test.ipkg

--- a/tests/derivation/infra/empty-cons print 002/expected
+++ b/tests/derivation/infra/empty-cons print 002/expected
@@ -85,7 +85,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (n : Nat) -> (a : Type) -> 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[0, 1] (dry fuel)"))
-                                    .$ (var "<<Data.Vect.Nil>>" .$ var "Data.Fuel.Dry" .$ var "inter^<len>" .$ var "inter^<elem>")
+                                    .$ (var "<<Data.Vect.Nil>>" .$ var "^fuel_arg^" .$ var "inter^<len>" .$ var "inter^<elem>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[0, 1] (spend fuel)"))

--- a/tests/derivation/infra/empty-cons print 006/expected
+++ b/tests/derivation/infra/empty-cons print 006/expected
@@ -79,7 +79,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (a : Type) -> Gen MaybeEmpt
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[1] (dry fuel)"))
-                                    .$ (var "<<Data.Vect.Nil>>" .$ var "Data.Fuel.Dry" .$ var "inter^<elem>")
+                                    .$ (var "<<Data.Vect.Nil>>" .$ var "^fuel_arg^" .$ var "inter^<elem>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[1] (spend fuel)"))

--- a/tests/derivation/infra/empty-cons print 008/expected
+++ b/tests/derivation/infra/empty-cons print 008/expected
@@ -83,7 +83,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[] (dry fuel)"))
-                                    .$ (var "<<Data.Vect.Nil>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.Vect.Nil>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Vect.Vect[] (spend fuel)"))

--- a/tests/derivation/infra/empty-cons print 010/expected
+++ b/tests/derivation/infra/empty-cons print 010/expected
@@ -77,8 +77,8 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty X
                                     .$ (   var "Test.DepTyCheck.Gen.oneOf"
                                         .! ("em", var "MaybeEmpty")
                                         .$ (   var "::"
-                                            .$ (var "<<DerivedGen.X0>>" .$ var "Data.Fuel.Dry")
-                                            .$ (var "::" .$ (var "<<DerivedGen.X1>>" .$ var "Data.Fuel.Dry") .$ var "Nil")))
+                                            .$ (var "<<DerivedGen.X0>>" .$ var "^fuel_arg^")
+                                            .$ (var "::" .$ (var "<<DerivedGen.X1>>" .$ var "^fuel_arg^") .$ var "Nil")))
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (spend fuel)"))

--- a/tests/derivation/infra/empty-cons print 011/expected
+++ b/tests/derivation/infra/empty-cons print 011/expected
@@ -93,8 +93,8 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (a : Type **
                                     .$ (   var "Test.DepTyCheck.Gen.oneOf"
                                         .! ("em", var "MaybeEmpty")
                                         .$ (   var "::"
-                                            .$ (var "<<DerivedGen.X0>>" .$ var "Data.Fuel.Dry")
-                                            .$ (var "::" .$ (var "<<DerivedGen.X1>>" .$ var "Data.Fuel.Dry") .$ var "Nil")))
+                                            .$ (var "<<DerivedGen.X0>>" .$ var "^fuel_arg^")
+                                            .$ (var "::" .$ (var "<<DerivedGen.X1>>" .$ var "^fuel_arg^") .$ var "Nil")))
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/003 noparam/expected
+++ b/tests/derivation/least-effort/print/adt/003 noparam/expected
@@ -82,7 +82,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Nat
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/004 noparam/expected
+++ b/tests/derivation/least-effort/print/adt/004 noparam/expected
@@ -94,7 +94,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty X
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.E>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<DerivedGen.E>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (spend fuel)"))
@@ -176,7 +176,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty X
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/006 param/expected
+++ b/tests/derivation/least-effort/print/adt/006 param/expected
@@ -143,7 +143,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/007 right-to-left simple/expected
+++ b/tests/derivation/least-effort/print/adt/007 right-to-left simple/expected
@@ -202,7 +202,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Y
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/008 right-to-left simple/expected
+++ b/tests/derivation/least-effort/print/adt/008 right-to-left simple/expected
@@ -202,7 +202,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Y
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/009 left-to-right/expected
+++ b/tests/derivation/least-effort/print/adt/009 left-to-right/expected
@@ -196,7 +196,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Y
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/010 right-to-left long-dpair/expected
+++ b/tests/derivation/least-effort/print/adt/010 right-to-left long-dpair/expected
@@ -221,7 +221,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Y
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/011 right-to-left long-dpair/expected
+++ b/tests/derivation/least-effort/print/adt/011 right-to-left long-dpair/expected
@@ -268,7 +268,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Y
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/012 right-to-left chained/expected
+++ b/tests/derivation/least-effort/print/adt/012 right-to-left chained/expected
@@ -272,7 +272,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Y
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/013 right-to-left nondet/expected
+++ b/tests/derivation/least-effort/print/adt/013 right-to-left nondet/expected
@@ -299,7 +299,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Y
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/021 prop tune/DerivedGen.idr
+++ b/tests/derivation/least-effort/print/adt/021 prop tune/DerivedGen.idr
@@ -1,0 +1,20 @@
+module DerivedGen
+
+import Deriving.DepTyCheck.Gen
+
+%default total
+
+%language ElabReflection
+
+data X = A | B | C
+
+ProbabilityTuning "A".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = (*2)
+
+ProbabilityTuning "B".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight _ = 4
+
+%logging "deptycheck.derive.print" 5
+%runElab deriveGenPrinter @{MainCoreDerivator @{LeastEffort}} $ Fuel -> Gen MaybeEmpty X

--- a/tests/derivation/least-effort/print/adt/021 prop tune/derive.ipkg
+++ b/tests/derivation/least-effort/print/adt/021 prop tune/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/print/adt/021 prop tune/expected
+++ b/tests/derivation/least-effort/print/adt/021 prop tune/expected
@@ -1,0 +1,107 @@
+1/1: Building DerivedGen (DerivedGen.idr)
+LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty X
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              (MkIClaimData
+                 { rig = MW
+                 , vis = Export
+                 , opts = []
+                 , type =
+                     mkTy
+                       { name = "<DerivedGen.X>[]"
+                       , type =
+                               MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                           .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                       }
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.A>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.B>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.C>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.A>>"
+                             [    var "<<DerivedGen.A>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.A (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "DerivedGen.A")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.B>>"
+                             [    var "<<DerivedGen.B>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.B (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "DerivedGen.B")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.C>>"
+                             [    var "<<DerivedGen.C>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.C (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "DerivedGen.C")
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (non-recursive)"))
+                         .$ (   var "Test.DepTyCheck.Gen.frequency"
+                             .$ (   var "::"
+                                 .$ (var "Builtin.MkPair" .$ (var "fromInteger" .$ primVal (BI 2)) .$ (var "<<DerivedGen.A>>" .$ var "^fuel_arg^"))
+                                 .$ (   var "::"
+                                     .$ (   var "Builtin.MkPair"
+                                         .$ (var "fromInteger" .$ primVal (BI 4))
+                                         .$ (var "<<DerivedGen.B>>" .$ var "^fuel_arg^"))
+                                     .$ (   var "::"
+                                         .$ (var "Builtin.MkPair" .$ var "Data.Nat1.one" .$ (var "<<DerivedGen.C>>" .$ var "^fuel_arg^"))
+                                         .$ var "Nil"))))
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/021 prop tune/run
+++ b/tests/derivation/least-effort/print/adt/021 prop tune/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/least-effort/print/adt/022 prop tune/DerivedGen.idr
+++ b/tests/derivation/least-effort/print/adt/022 prop tune/DerivedGen.idr
@@ -1,0 +1,20 @@
+module DerivedGen
+
+import Deriving.DepTyCheck.Gen
+
+%default total
+
+%language ElabReflection
+
+data X = A X | B X | C
+
+ProbabilityTuning "A".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = (*2)
+
+ProbabilityTuning "B".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight _ = 4
+
+%logging "deptycheck.derive.print" 5
+%runElab deriveGenPrinter @{MainCoreDerivator @{LeastEffort}} $ Fuel -> Gen MaybeEmpty X

--- a/tests/derivation/least-effort/print/adt/022 prop tune/derive.ipkg
+++ b/tests/derivation/least-effort/print/adt/022 prop tune/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/print/adt/022 prop tune/expected
+++ b/tests/derivation/least-effort/print/adt/022 prop tune/expected
@@ -104,7 +104,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty X
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.C>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<DerivedGen.C>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/022 prop tune/expected
+++ b/tests/derivation/least-effort/print/adt/022 prop tune/expected
@@ -1,0 +1,136 @@
+1/1: Building DerivedGen (DerivedGen.idr)
+LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty X
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              (MkIClaimData
+                 { rig = MW
+                 , vis = Export
+                 , opts = []
+                 , type =
+                     mkTy
+                       { name = "<DerivedGen.X>[]"
+                       , type =
+                               MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                           .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                       }
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.A>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.B>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.C>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.A>>"
+                             [    var "<<DerivedGen.A>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.A (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:1}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "DerivedGen.A" .$ var "^bnd^{arg:1}")))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.B>>"
+                             [    var "<<DerivedGen.B>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.B (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:2}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "DerivedGen.B" .$ var "^bnd^{arg:2}")))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.C>>"
+                             [    var "<<DerivedGen.C>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.C (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "DerivedGen.C")
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (dry fuel)"))
+                                    .$ (var "<<DerivedGen.C>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ (   var "Data.Nat1.(*)"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (   var "Data.Nat1.FromNat"
+                                                        .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z"))))
+                                                .$ (var "<<DerivedGen.A>>" .$ var "^sub^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (   var "Data.Nat1.FromNat"
+                                                        .$ (   var "Prelude.Types.S"
+                                                            .$ (   var "Prelude.Types.S"
+                                                                .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z")))))
+                                                    .$ (var "<<DerivedGen.B>>" .$ var "^sub^fuel_arg^"))
+                                                .$ (   var "::"
+                                                    .$ (var "Builtin.MkPair" .$ var "Data.Nat1.one" .$ (var "<<DerivedGen.C>>" .$ var "^fuel_arg^"))
+                                                    .$ var "Nil"))))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/022 prop tune/run
+++ b/tests/derivation/least-effort/print/adt/022 prop tune/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/least-effort/print/adt/023 prop tune/DerivedGen.idr
+++ b/tests/derivation/least-effort/print/adt/023 prop tune/DerivedGen.idr
@@ -1,0 +1,20 @@
+module DerivedGen
+
+import Deriving.DepTyCheck.Gen
+
+%default total
+
+%language ElabReflection
+
+data X = A X | B | C | D
+
+ProbabilityTuning "B".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = (*2)
+
+ProbabilityTuning "C".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight _ = 4
+
+%logging "deptycheck.derive.print" 5
+%runElab deriveGenPrinter @{MainCoreDerivator @{LeastEffort}} $ Fuel -> Gen MaybeEmpty X

--- a/tests/derivation/least-effort/print/adt/023 prop tune/derive.ipkg
+++ b/tests/derivation/least-effort/print/adt/023 prop tune/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/print/adt/023 prop tune/expected
+++ b/tests/derivation/least-effort/print/adt/023 prop tune/expected
@@ -124,15 +124,13 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty X
                                         .$ (   var "::"
                                             .$ (   var "Builtin.MkPair"
                                                 .$ (var "fromInteger" .$ primVal (BI 2))
-                                                .$ (var "<<DerivedGen.B>>" .$ var "Data.Fuel.Dry"))
+                                                .$ (var "<<DerivedGen.B>>" .$ var "^fuel_arg^"))
                                             .$ (   var "::"
                                                 .$ (   var "Builtin.MkPair"
                                                     .$ (var "fromInteger" .$ primVal (BI 4))
-                                                    .$ (var "<<DerivedGen.C>>" .$ var "Data.Fuel.Dry"))
+                                                    .$ (var "<<DerivedGen.C>>" .$ var "^fuel_arg^"))
                                                 .$ (   var "::"
-                                                    .$ (   var "Builtin.MkPair"
-                                                        .$ var "Data.Nat1.one"
-                                                        .$ (var "<<DerivedGen.D>>" .$ var "Data.Fuel.Dry"))
+                                                    .$ (var "Builtin.MkPair" .$ var "Data.Nat1.one" .$ (var "<<DerivedGen.D>>" .$ var "^fuel_arg^"))
                                                     .$ var "Nil"))))
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"

--- a/tests/derivation/least-effort/print/adt/023 prop tune/expected
+++ b/tests/derivation/least-effort/print/adt/023 prop tune/expected
@@ -1,0 +1,165 @@
+1/1: Building DerivedGen (DerivedGen.idr)
+LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty X
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              (MkIClaimData
+                 { rig = MW
+                 , vis = Export
+                 , opts = []
+                 , type =
+                     mkTy
+                       { name = "<DerivedGen.X>[]"
+                       , type =
+                               MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                           .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                       }
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.X>[]"
+              [    var "<DerivedGen.X>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.A>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.B>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.C>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.D>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.X"
+                                      }
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.A>>"
+                             [    var "<<DerivedGen.A>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.A (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<DerivedGen.X>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:1}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "DerivedGen.A" .$ var "^bnd^{arg:1}")))
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.B>>"
+                             [    var "<<DerivedGen.B>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.B (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "DerivedGen.B")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.C>>"
+                             [    var "<<DerivedGen.C>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.C (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "DerivedGen.C")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.D>>"
+                             [    var "<<DerivedGen.D>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.D (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "DerivedGen.D")
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (dry fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ (var "fromInteger" .$ primVal (BI 2))
+                                                .$ (var "<<DerivedGen.B>>" .$ var "Data.Fuel.Dry"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "fromInteger" .$ primVal (BI 4))
+                                                    .$ (var "<<DerivedGen.C>>" .$ var "Data.Fuel.Dry"))
+                                                .$ (   var "::"
+                                                    .$ (   var "Builtin.MkPair"
+                                                        .$ var "Data.Nat1.one"
+                                                        .$ (var "<<DerivedGen.D>>" .$ var "Data.Fuel.Dry"))
+                                                    .$ var "Nil"))))
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.X[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (   var "Builtin.MkPair"
+                                                .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                .$ (var "<<DerivedGen.A>>" .$ var "^sub^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "fromInteger" .$ primVal (BI 2))
+                                                    .$ (var "<<DerivedGen.B>>" .$ var "^fuel_arg^"))
+                                                .$ (   var "::"
+                                                    .$ (   var "Builtin.MkPair"
+                                                        .$ (var "fromInteger" .$ primVal (BI 4))
+                                                        .$ (var "<<DerivedGen.C>>" .$ var "^fuel_arg^"))
+                                                    .$ (   var "::"
+                                                        .$ (   var "Builtin.MkPair"
+                                                            .$ var "Data.Nat1.one"
+                                                            .$ (var "<<DerivedGen.D>>" .$ var "^fuel_arg^"))
+                                                        .$ var "Nil")))))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.X>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/023 prop tune/run
+++ b/tests/derivation/least-effort/print/adt/023 prop tune/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/least-effort/print/adt/024 prop tune/DerivedGen.idr
+++ b/tests/derivation/least-effort/print/adt/024 prop tune/DerivedGen.idr
@@ -1,0 +1,18 @@
+module DerivedGen
+
+import Deriving.DepTyCheck.Gen
+
+%default total
+
+%language ElabReflection
+
+data ListNat : Type where
+  Nil  : ListNat
+  (::) : Nat -> ListNat -> ListNat
+
+ProbabilityTuning `{DerivedGen.(::)}.dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight _ = 1
+
+%logging "deptycheck.derive.print" 5
+%runElab deriveGenPrinter @{MainCoreDerivator @{LeastEffort}} $ Fuel -> Gen MaybeEmpty ListNat

--- a/tests/derivation/least-effort/print/adt/024 prop tune/derive.ipkg
+++ b/tests/derivation/least-effort/print/adt/024 prop tune/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/print/adt/024 prop tune/expected
+++ b/tests/derivation/least-effort/print/adt/024 prop tune/expected
@@ -98,7 +98,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty ListNat
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.ListNat[] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.Nil>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<DerivedGen.Nil>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.ListNat[] (spend fuel)"))
@@ -180,7 +180,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty ListNat
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/adt/024 prop tune/expected
+++ b/tests/derivation/least-effort/print/adt/024 prop tune/expected
@@ -1,0 +1,202 @@
+1/1: Building DerivedGen (DerivedGen.idr)
+LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty ListNat
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> local
+      { decls =
+          [ IClaim
+              (MkIClaimData
+                 { rig = MW
+                 , vis = Export
+                 , opts = []
+                 , type =
+                     mkTy
+                       { name = "<DerivedGen.ListNat>[]"
+                       , type =
+                               MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                           .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "DerivedGen.ListNat"
+                       }
+                 })
+          , IClaim
+              (MkIClaimData
+                 { rig = MW
+                 , vis = Export
+                 , opts = []
+                 , type =
+                     mkTy
+                       { name = "<Prelude.Types.Nat>[]"
+                       , type =
+                               MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                           .-> var "Test.DepTyCheck.Gen.Gen" .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty" .$ var "Prelude.Types.Nat"
+                       }
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.ListNat>[]"
+              [    var "<DerivedGen.ListNat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.Nil>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .->    var "Test.DepTyCheck.Gen.Gen"
+                                              .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                              .$ var "DerivedGen.ListNat"
+                                      }
+                                })
+                         , IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.(::)>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .->    var "Test.DepTyCheck.Gen.Gen"
+                                              .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                              .$ var "DerivedGen.ListNat"
+                                      }
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.Nil>>"
+                             [    var "<<DerivedGen.Nil>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.Nil (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "DerivedGen.Nil")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.(::)>>"
+                             [    var "<<DerivedGen.(::)>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.(::) (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^outmost-fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:1}") implicitFalse
+                                          .=>    var ">>="
+                                              .$ (var "<DerivedGen.ListNat>[]" .$ var "^cons_fuel^")
+                                              .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:2}") implicitFalse
+                                                  .=>    var "Prelude.pure"
+                                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                                      .$ (var "DerivedGen.(::)" .$ var "^bnd^{arg:1}" .$ var "^bnd^{arg:2}"))))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.ListNat[] (dry fuel)"))
+                                    .$ (var "<<DerivedGen.Nil>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "DerivedGen.ListNat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat1.one" .$ (var "<<DerivedGen.Nil>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Data.Nat1.FromNat" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z"))
+                                                    .$ (var "<<DerivedGen.(::)>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          , IDef
+              emptyFC
+              "<Prelude.Types.Nat>[]"
+              [    var "<Prelude.Types.Nat>[]" .$ bindVar "^fuel_arg^"
+                .= local
+                     { decls =
+                         [ IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<Prelude.Types.Z>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .->    var "Test.DepTyCheck.Gen.Gen"
+                                              .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                              .$ var "Prelude.Types.Nat"
+                                      }
+                                })
+                         , IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<Prelude.Types.S>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .->    var "Test.DepTyCheck.Gen.Gen"
+                                              .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                              .$ var "Prelude.Types.Nat"
+                                      }
+                                })
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.Z>>"
+                             [    var "<<Prelude.Types.Z>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.Z (orders)"))
+                                  .$ (var "Prelude.pure" .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue) .$ var "Prelude.Types.Z")
+                             ]
+                         , IDef
+                             emptyFC
+                             "<<Prelude.Types.S>>"
+                             [    var "<<Prelude.Types.S>>" .$ bindVar "^cons_fuel^"
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "Prelude.Types.S (orders)"))
+                                  .$ (   var ">>="
+                                      .$ (var "<Prelude.Types.Nat>[]" .$ var "^cons_fuel^")
+                                      .$ (    MkArg MW ExplicitArg (Just "^bnd^{arg:3}") implicitFalse
+                                          .=>    var "Prelude.pure"
+                                              .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                              .$ (var "Prelude.Types.S" .$ var "^bnd^{arg:3}")))
+                             ]
+                         ]
+                     , scope =
+                         iCase
+                           { sc = var "^fuel_arg^"
+                           , ty = var "Data.Fuel.Fuel"
+                           , clauses =
+                               [    var "Data.Fuel.Dry"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                               ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
+                                 .=    var "Test.DepTyCheck.Gen.label"
+                                    .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
+                                    .$ (   var "Test.DepTyCheck.Gen.frequency"
+                                        .$ (   var "::"
+                                            .$ (var "Builtin.MkPair" .$ var "Data.Nat1.one" .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^"))
+                                            .$ (   var "::"
+                                                .$ (   var "Builtin.MkPair"
+                                                    .$ (var "Deriving.DepTyCheck.Util.Reflection.leftDepth" .$ var "^sub^fuel_arg^")
+                                                    .$ (var "<<Prelude.Types.S>>" .$ var "^sub^fuel_arg^"))
+                                                .$ var "Nil")))
+                               ]
+                           }
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.ListNat>[]" .$ var "^outmost-fuel^"
+      }
+

--- a/tests/derivation/least-effort/print/adt/024 prop tune/run
+++ b/tests/derivation/least-effort/print/adt/024 prop tune/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/least-effort/print/gadt/001 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/001 gadt/expected
@@ -90,7 +90,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (n : Nat) -> Gen MaybeEmpty
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/002 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/002 gadt/expected
@@ -117,7 +117,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (spend fuel)"))
@@ -199,7 +199,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
+++ b/tests/derivation/least-effort/print/gadt/003 right-to-left nondet/expected
@@ -524,7 +524,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Y
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/004 right-to-left det/expected
+++ b/tests/derivation/least-effort/print/gadt/004 right-to-left det/expected
@@ -564,7 +564,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Y
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/005 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/005 gadt/expected
@@ -229,8 +229,8 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel
                                     .$ (   var "Test.DepTyCheck.Gen.oneOf"
                                         .! ("em", var "MaybeEmpty")
                                         .$ (   var "::"
-                                            .$ (var "<<DerivedGen.JJ>>" .$ var "Data.Fuel.Dry")
-                                            .$ (var "::" .$ (var "<<DerivedGen.TL>>" .$ var "Data.Fuel.Dry") .$ var "Nil")))
+                                            .$ (var "<<DerivedGen.JJ>>" .$ var "^fuel_arg^")
+                                            .$ (var "::" .$ (var "<<DerivedGen.TL>>" .$ var "^fuel_arg^") .$ var "Nil")))
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.D[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/006 gadt/expected
+++ b/tests/derivation/least-effort/print/gadt/006 gadt/expected
@@ -229,8 +229,8 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel
                                     .$ (   var "Test.DepTyCheck.Gen.oneOf"
                                         .! ("em", var "MaybeEmpty")
                                         .$ (   var "::"
-                                            .$ (var "<<DerivedGen.JJ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:3}>")
-                                            .$ (var "::" .$ (var "<<DerivedGen.TL>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:3}>") .$ var "Nil")))
+                                            .$ (var "<<DerivedGen.JJ>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:3}>")
+                                            .$ (var "::" .$ (var "<<DerivedGen.TL>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:3}>") .$ var "Nil")))
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.D[0] (spend fuel)"))
@@ -439,8 +439,8 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel
                                     .$ (   var "Test.DepTyCheck.Gen.oneOf"
                                         .! ("em", var "MaybeEmpty")
                                         .$ (   var "::"
-                                            .$ (var "<<DerivedGen.JJ>>" .$ var "Data.Fuel.Dry")
-                                            .$ (var "::" .$ (var "<<DerivedGen.TL>>" .$ var "Data.Fuel.Dry") .$ var "Nil")))
+                                            .$ (var "<<DerivedGen.JJ>>" .$ var "^fuel_arg^")
+                                            .$ (var "::" .$ (var "<<DerivedGen.TL>>" .$ var "^fuel_arg^") .$ var "Nil")))
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.D[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/007 eq-n/expected
+++ b/tests/derivation/least-effort/print/gadt/007 eq-n/expected
@@ -152,7 +152,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (a : Nat ** 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/011 eq deepcons/expected
+++ b/tests/derivation/least-effort/print/gadt/011 eq deepcons/expected
@@ -131,7 +131,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> {auto conArg : ((arg : Fuel
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.Base>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<DerivedGen.Base>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/012 eq deepcons/expected
+++ b/tests/derivation/least-effort/print/gadt/012 eq deepcons/expected
@@ -111,7 +111,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (a : Nat) -> Gen MaybeEmpty
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[0] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.Base>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>")
+                                    .$ (var "<<DerivedGen.Base>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[0] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/013 eq deepcons/expected
+++ b/tests/derivation/least-effort/print/gadt/013 eq deepcons/expected
@@ -115,7 +115,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (b : Nat) -> Gen MaybeEmpty
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[1] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.Base>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>")
+                                    .$ (var "<<DerivedGen.Base>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[1] (spend fuel)"))

--- a/tests/derivation/least-effort/print/gadt/014 eq deepcons/expected
+++ b/tests/derivation/least-effort/print/gadt/014 eq deepcons/expected
@@ -119,7 +119,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (a : Nat) -> (b : Nat) -> G
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[0, 1] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.Base>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
+                                    .$ (var "<<DerivedGen.Base>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>" .$ var "inter^<{arg:2}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.LT2[0, 1] (spend fuel)"))

--- a/tests/derivation/least-effort/print/order/001 complex order/expected
+++ b/tests/derivation/least-effort/print/order/001 complex order/expected
@@ -383,7 +383,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (spend fuel)"))
@@ -465,7 +465,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/order/002 complex order/expected
+++ b/tests/derivation/least-effort/print/order/002 complex order/expected
@@ -402,7 +402,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (spend fuel)"))

--- a/tests/derivation/least-effort/print/order/003 complex order/expected
+++ b/tests/derivation/least-effort/print/order/003 complex order/expected
@@ -383,7 +383,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (spend fuel)"))
@@ -465,7 +465,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/order/004 complex order/expected
+++ b/tests/derivation/least-effort/print/order/004 complex order/expected
@@ -267,7 +267,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (spend fuel)"))

--- a/tests/derivation/least-effort/print/order/005 complex order/expected
+++ b/tests/derivation/least-effort/print/order/005 complex order/expected
@@ -263,7 +263,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))
@@ -351,7 +351,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (spend fuel)"))

--- a/tests/derivation/least-effort/print/order/006 complex order/expected
+++ b/tests/derivation/least-effort/print/order/006 complex order/expected
@@ -270,7 +270,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (spend fuel)"))
@@ -354,7 +354,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/order/007 complex order/expected
+++ b/tests/derivation/least-effort/print/order/007 complex order/expected
@@ -277,7 +277,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (spend fuel)"))
@@ -359,7 +359,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/order/008 complex order/expected
+++ b/tests/derivation/least-effort/print/order/008 complex order/expected
@@ -360,7 +360,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (spend fuel)"))

--- a/tests/derivation/least-effort/print/order/009 complex order/expected
+++ b/tests/derivation/least-effort/print/order/009 complex order/expected
@@ -349,7 +349,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty Z
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/dependent-givens-expl-big/expected
+++ b/tests/derivation/least-effort/print/regression/dependent-givens-expl-big/expected
@@ -166,10 +166,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (n : Nat) -> (v : VectMaybe
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.VectMaybeAnyType.AtIndex[0, 3] (dry fuel)"))
-                                    .$ (   var "<<DerivedGen.VectMaybeAnyType.Here>>"
-                                        .$ var "Data.Fuel.Dry"
-                                        .$ var "inter^<n>"
-                                        .$ var "inter^<{arg:1}>")
+                                    .$ (var "<<DerivedGen.VectMaybeAnyType.Here>>" .$ var "^fuel_arg^" .$ var "inter^<n>" .$ var "inter^<{arg:1}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.VectMaybeAnyType.AtIndex[0, 3] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/dependent-givens-impl-big/expected
+++ b/tests/derivation/least-effort/print/regression/dependent-givens-impl-big/expected
@@ -166,10 +166,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (v : VectMaybeAnyType n) ->
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.VectMaybeAnyType.AtIndex[0, 3] (dry fuel)"))
-                                    .$ (   var "<<DerivedGen.VectMaybeAnyType.Here>>"
-                                        .$ var "Data.Fuel.Dry"
-                                        .$ var "inter^<n>"
-                                        .$ var "inter^<{arg:1}>")
+                                    .$ (var "<<DerivedGen.VectMaybeAnyType.Here>>" .$ var "^fuel_arg^" .$ var "inter^<n>" .$ var "inter^<{arg:1}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.VectMaybeAnyType.AtIndex[0, 3] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/fin-inc/expected
+++ b/tests/derivation/least-effort/print/regression/fin-inc/expected
@@ -211,7 +211,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Nat.LTE[] (dry fuel)"))
-                                    .$ (var "<<Data.Nat.LTEZero>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.Nat.LTEZero>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Nat.LTE[] (spend fuel)"))
@@ -293,7 +293,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/undefined-name-impl-parameter/expected
+++ b/tests/derivation/least-effort/print/regression/undefined-name-impl-parameter/expected
@@ -250,7 +250,7 @@
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Decls.RegIsType[0, 2, 3] (dry fuel)"))
                                     .$ (   var "<<Decls.Here>>"
-                                        .$ var "Data.Fuel.Dry"
+                                        .$ var "^fuel_arg^"
                                         .$ var "inter^<r>"
                                         .$ var "inter^<{arg:3}>"
                                         .$ var "inter^<{arg:4}>")

--- a/tests/derivation/least-effort/print/regression/underscore-in-cons-expl-full-gend1/expected
+++ b/tests/derivation/least-effort/print/regression/underscore-in-cons-expl-full-gend1/expected
@@ -157,7 +157,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (n : Nat) -> Gen MaybeEmpty
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[0] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/underscore-in-cons-expl-full-gend2/expected
+++ b/tests/derivation/least-effort/print/regression/underscore-in-cons-expl-full-gend2/expected
@@ -196,7 +196,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (dry fuel)"))
-                                    .$ (var "<<Data.Fin.FZ>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Data.Fin.FZ>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Data.Fin.Fin[] (spend fuel)"))
@@ -278,7 +278,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> Gen MaybeEmpty (n : Nat ** 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (dry fuel)"))
-                                    .$ (var "<<Prelude.Types.Z>>" .$ var "Data.Fuel.Dry")
+                                    .$ (var "<<Prelude.Types.Z>>" .$ var "^fuel_arg^")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "Prelude.Types.Nat[] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/unification-name-mismatch/expected
+++ b/tests/derivation/least-effort/print/regression/unification-name-mismatch/expected
@@ -149,7 +149,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (xs : X) -> (ys : X) -> Gen
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[0, 1] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.A>>" .$ var "Data.Fuel.Dry" .$ var "inter^<xs>" .$ var "inter^<ys>")
+                                    .$ (var "<<DerivedGen.A>>" .$ var "^fuel_arg^" .$ var "inter^<xs>" .$ var "inter^<ys>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[0, 1] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/unnamed-auto-implicit-deeper-gend/expected
+++ b/tests/derivation/least-effort/print/regression/unnamed-auto-implicit-deeper-gend/expected
@@ -162,7 +162,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (n : Nat) -> Gen MaybeEmpty
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Z[0] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.Start>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>")
+                                    .$ (var "<<DerivedGen.Start>>" .$ var "^fuel_arg^" .$ var "inter^<n>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Z[0] (spend fuel)"))
@@ -271,7 +271,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (n : Nat) -> Gen MaybeEmpty
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Z[0, 1] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.Start>>" .$ var "Data.Fuel.Dry" .$ var "inter^<n>" .$ var "inter^<{arg:1}>")
+                                    .$ (var "<<DerivedGen.Start>>" .$ var "^fuel_arg^" .$ var "inter^<n>" .$ var "inter^<{arg:1}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Z[0, 1] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/unnamed-auto-implicit-deeper-givn/expected
+++ b/tests/derivation/least-effort/print/regression/unnamed-auto-implicit-deeper-givn/expected
@@ -125,7 +125,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (b : Bool) -> (y : Y b) -> 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Z[0, 1] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.Start>>" .$ var "Data.Fuel.Dry" .$ var "inter^<b>" .$ var "inter^<{arg:1}>")
+                                    .$ (var "<<DerivedGen.Start>>" .$ var "^fuel_arg^" .$ var "inter^<b>" .$ var "inter^<{arg:1}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Z[0, 1] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/unnamed-auto-implicit-deeper-in-ty/expected
+++ b/tests/derivation/least-effort/print/regression/unnamed-auto-implicit-deeper-in-ty/expected
@@ -230,7 +230,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (b : Bool) -> (x : X b) -> 
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[0, 1, 2] (dry fuel)"))
                                     .$ (   var "<<DerivedGen.MkY1>>"
-                                        .$ var "Data.Fuel.Dry"
+                                        .$ var "^fuel_arg^"
                                         .$ var "inter^<b>"
                                         .$ var "inter^<{arg:2}>"
                                         .$ var "inter^<{arg:3}>")
@@ -359,7 +359,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (b : Bool) -> (x : X b) -> 
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[0, 2] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.MkY1>>" .$ var "Data.Fuel.Dry" .$ var "inter^<b>" .$ var "inter^<{arg:3}>")
+                                    .$ (var "<<DerivedGen.MkY1>>" .$ var "^fuel_arg^" .$ var "inter^<b>" .$ var "inter^<{arg:3}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[0, 2] (spend fuel)"))

--- a/tests/derivation/least-effort/print/regression/unnamed-auto-implicit-shallow/expected
+++ b/tests/derivation/least-effort/print/regression/unnamed-auto-implicit-shallow/expected
@@ -133,7 +133,7 @@ LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (f : X) -> Gen MaybeEmpty (
                                [    var "Data.Fuel.Dry"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[1] (dry fuel)"))
-                                    .$ (var "<<DerivedGen.A>>" .$ var "Data.Fuel.Dry" .$ var "inter^<{arg:1}>")
+                                    .$ (var "<<DerivedGen.A>>" .$ var "^fuel_arg^" .$ var "inter^<{arg:1}>")
                                ,    var "Data.Fuel.More" .$ bindVar "^sub^fuel_arg^"
                                  .=    var "Test.DepTyCheck.Gen.label"
                                     .$ (var "fromString" .$ primVal (Str "DerivedGen.Y[1] (spend fuel)"))

--- a/tests/derivation/least-effort/run/adt/021 prop tune/DerivedGen.idr
+++ b/tests/derivation/least-effort/run/adt/021 prop tune/DerivedGen.idr
@@ -1,0 +1,29 @@
+module DerivedGen
+
+import Deriving.Show
+
+import RunDerivedGen
+
+%default total
+
+%language ElabReflection
+
+data X = A | B | C
+
+ProbabilityTuning "A".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = (*2)
+
+ProbabilityTuning "B".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight _ = 4
+
+checkedGen : Fuel -> Gen MaybeEmpty X
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+%hint ShowX : Show X; ShowX = %runElab derive
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl
+  ]

--- a/tests/derivation/least-effort/run/adt/021 prop tune/RunDerivedGen.idr
+++ b/tests/derivation/least-effort/run/adt/021 prop tune/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/derivation/least-effort/run/adt/021 prop tune/derive.ipkg
+++ b/tests/derivation/least-effort/run/adt/021 prop tune/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/run/adt/021 prop tune/expected
+++ b/tests/derivation/least-effort/run/adt/021 prop tune/expected
@@ -1,0 +1,24 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Generated values:
+-----
+-----
+A
+-----
+A
+-----
+B
+-----
+B
+-----
+A
+-----
+B
+-----
+A
+-----
+A
+-----
+B
+-----
+A

--- a/tests/derivation/least-effort/run/adt/021 prop tune/run
+++ b/tests/derivation/least-effort/run/adt/021 prop tune/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/least-effort/run/adt/022 prop tune/DerivedGen.idr
+++ b/tests/derivation/least-effort/run/adt/022 prop tune/DerivedGen.idr
@@ -1,0 +1,29 @@
+module DerivedGen
+
+import Deriving.Show
+
+import RunDerivedGen
+
+%default total
+
+%language ElabReflection
+
+data X = A X | B X | C
+
+ProbabilityTuning "A".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = (*2)
+
+ProbabilityTuning "B".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight _ = 4
+
+checkedGen : Fuel -> Gen MaybeEmpty X
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+%hint ShowX : Show X; ShowX = %runElab derive
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl
+  ]

--- a/tests/derivation/least-effort/run/adt/022 prop tune/RunDerivedGen.idr
+++ b/tests/derivation/least-effort/run/adt/022 prop tune/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/derivation/least-effort/run/adt/022 prop tune/derive.ipkg
+++ b/tests/derivation/least-effort/run/adt/022 prop tune/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/run/adt/022 prop tune/expected
+++ b/tests/derivation/least-effort/run/adt/022 prop tune/expected
@@ -1,0 +1,24 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Generated values:
+-----
+-----
+A (A (A (B (A (A (A (A (A (A (A (A (A (B (A (A (A (A (B (B C)))))))))))))))))))
+-----
+A (A (A (B (A (A (A (B (A (A (B (A (A (A (A (B (A (A (A C))))))))))))))))))
+-----
+A (A (A (A (B (A (A (A (A (A (A (A (B (B (A (A (A (A (B (B C)))))))))))))))))))
+-----
+A (A (B (A (A (A (A (B (A (A (B (A (A (B (A (A C)))))))))))))))
+-----
+B (A (A (A (A (A (A (A (A (B (A (A (A (A (A (A (A (B (A (B C)))))))))))))))))))
+-----
+A (A (A (B (A (A (A C))))))
+-----
+A (A (A (A (A C))))
+-----
+A (B (A (A (A (A (A (A (A (A (A (A (A (A (A (A (A (A (A (A C)))))))))))))))))))
+-----
+A (A (A (A (A (B (A (A (A (A (A (B (B (A (A (A (A (A (A (B C)))))))))))))))))))
+-----
+A (A (A (A (A (A (A (A (B (A (A (A (A (A (A (A (B (A (A (B C)))))))))))))))))))

--- a/tests/derivation/least-effort/run/adt/022 prop tune/run
+++ b/tests/derivation/least-effort/run/adt/022 prop tune/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/least-effort/run/adt/023 prop tune/DerivedGen.idr
+++ b/tests/derivation/least-effort/run/adt/023 prop tune/DerivedGen.idr
@@ -1,0 +1,29 @@
+module DerivedGen
+
+import Deriving.Show
+
+import RunDerivedGen
+
+%default total
+
+%language ElabReflection
+
+data X = A X | B | C | D
+
+ProbabilityTuning "B".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight = (*2)
+
+ProbabilityTuning "C".dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight _ = 4
+
+checkedGen : Fuel -> Gen MaybeEmpty X
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+%hint ShowX : Show X; ShowX = %runElab derive
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl
+  ]

--- a/tests/derivation/least-effort/run/adt/023 prop tune/RunDerivedGen.idr
+++ b/tests/derivation/least-effort/run/adt/023 prop tune/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/derivation/least-effort/run/adt/023 prop tune/derive.ipkg
+++ b/tests/derivation/least-effort/run/adt/023 prop tune/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/run/adt/023 prop tune/expected
+++ b/tests/derivation/least-effort/run/adt/023 prop tune/expected
@@ -1,0 +1,24 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Generated values:
+-----
+-----
+A (A C)
+-----
+A C
+-----
+A (A (A (A (A (A (A (A (A C))))))))
+-----
+A (A (A (A (A (A C)))))
+-----
+A (A C)
+-----
+A (A (A D))
+-----
+C
+-----
+A (A (A C))
+-----
+A (A (A (A C)))
+-----
+A C

--- a/tests/derivation/least-effort/run/adt/023 prop tune/run
+++ b/tests/derivation/least-effort/run/adt/023 prop tune/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/least-effort/run/adt/024 prop tune/DerivedGen.idr
+++ b/tests/derivation/least-effort/run/adt/024 prop tune/DerivedGen.idr
@@ -1,0 +1,31 @@
+module DerivedGen
+
+import Deriving.Show
+
+import RunDerivedGen
+
+%default total
+
+%language ElabReflection
+
+data ListNat : Type where
+  Nil  : ListNat
+  (::) : Nat -> ListNat -> ListNat
+
+ProbabilityTuning `{DerivedGen.(::)}.dataCon where
+  isConstructor = itIsConstructor
+  tuneWeight _ = 1
+
+checkedGen : Fuel -> Gen MaybeEmpty ListNat
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+Show ListNat where
+  show = show . toList where
+    toList : ListNat -> List Nat
+    toList []      = []
+    toList (x::xs) = x :: toList xs
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl
+  ]

--- a/tests/derivation/least-effort/run/adt/024 prop tune/RunDerivedGen.idr
+++ b/tests/derivation/least-effort/run/adt/024 prop tune/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/derivation/least-effort/run/adt/024 prop tune/derive.ipkg
+++ b/tests/derivation/least-effort/run/adt/024 prop tune/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/run/adt/024 prop tune/expected
+++ b/tests/derivation/least-effort/run/adt/024 prop tune/expected
@@ -1,0 +1,24 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Generated values:
+-----
+-----
+[16]
+-----
+[]
+-----
+[2]
+-----
+[]
+-----
+[19]
+-----
+[]
+-----
+[]
+-----
+[]
+-----
+[2]
+-----
+[]

--- a/tests/derivation/least-effort/run/adt/024 prop tune/run
+++ b/tests/derivation/least-effort/run/adt/024 prop tune/run
@@ -1,0 +1,1 @@
+../_common/run


### PR DESCRIPTION
Now per-constructor only, however, still pretty powerful. Allows to change existing (fuel-aware) one, not only to fully override.