### PR TITLE
[ ci ] Prevent double running on the same branch

### DIFF
--- a/.github/workflows/ci-deptycheck.yml
+++ b/.github/workflows/ci-deptycheck.yml
@@ -40,8 +40,11 @@ jobs:
 
   validate_trigger:
     name: Validate trigger
-    # Disable scheduled running on forks
-    if: github.event_name != 'schedule' || github.repository_owner == 'buzden'
+    # Disable scheduled running on forks and PRs from the same repo
+    if: github.event_name != 'schedule' && github.event_name != 'pull_request' ||
+        github.event_name == 'schedule' && github.repository_owner == 'buzden' ||
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - name: No-op step

--- a/.github/workflows/ci-non-primary-os.yml
+++ b/.github/workflows/ci-non-primary-os.yml
@@ -24,6 +24,9 @@ concurrency:
 jobs:
   build:
     name: Clone on Windows
+    # Disable PR from the same repo
+    if: github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: windows-latest
     steps:
 

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -24,6 +24,9 @@ concurrency:
 jobs:
   build:
     name: Lint Code Base
+    # Disable PR from the same repo
+    if: github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
GitHub shows all the workflow runs for the corresponding commit in the pull request, so we can just skip the runs for PR triggers from the same repository.