### PR TITLE
[ fix ] Rename bound implicits in a determined non-cons expressions

### DIFF
--- a/tests/derivation/least-effort/print/regression/determined-noncons-given-add/expected
+++ b/tests/derivation/least-effort/print/regression/determined-noncons-given-add/expected
@@ -73,7 +73,7 @@ LOG deptycheck.derive.least-effort:7: DerivedGen.B[0(n), 1(x), 2] B2 - used fina
                              "<<DerivedGen.B1>>"
                              [       var "<<DerivedGen.B1>>"
                                   .$ bindVar "^cons_fuel^"
-                                  .$ (var "Prelude.Types.plus" .$ var "a" .$ var "b")
+                                  .$ (var "Prelude.Types.plus" .$ bindVar "a" .$ bindVar "b")
                                   .$ (var "Prelude.Types.S" .$ bindVar "^bnd^{x:1}")
                                   .$ (var "DerivedGen.A1" .! ("x", implicitTrue) .$ bindVar "a" .$ bindVar "b")
                                .=    var "Test.DepTyCheck.Gen.label"
@@ -89,7 +89,7 @@ LOG deptycheck.derive.least-effort:7: DerivedGen.B[0(n), 1(x), 2] B2 - used fina
                              [       var "<<DerivedGen.B2>>"
                                   .$ bindVar "^cons_fuel^"
                                   .$ (   var "Prelude.Types.plus"
-                                      .$ (var "Prelude.Types.plus" .$ var "a" .$ var "b")
+                                      .$ (var "Prelude.Types.plus" .$ bindVar "a" .$ bindVar "b")
                                       .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z")))
                                   .$ (var "Prelude.Types.S" .$ bindVar "^bnd^{x:2}")
                                   .$ (var "DerivedGen.A2" .! ("x", implicitTrue) .$ bindVar "a" .$ bindVar "b")

--- a/tests/derivation/least-effort/print/regression/determined-noncons-given-complex/expected
+++ b/tests/derivation/least-effort/print/regression/determined-noncons-given-complex/expected
@@ -160,7 +160,7 @@ LOG deptycheck.derive.least-effort:7: Data.Fin.Fin[0(n)] FS - used final order: 
                              [       var "<<DerivedGen.MHere>>"
                                   .$ bindVar "^cons_fuel^"
                                   .$ (var "DerivedGen.B.(::)" .$ bindVar "p" .$ bindVar "ps")
-                                  .$ (var "Data.Fin.FZ" .! ("k", var "DerivedGen.B..length" .$ var "ps"))
+                                  .$ (var "Data.Fin.FZ" .! ("k", var "DerivedGen.B..length" .$ bindVar "ps"))
                                .=    var "Test.DepTyCheck.Gen.label"
                                   .$ (var "fromString" .$ primVal (Str "DerivedGen.MHere (orders)"))
                                   .$ (   var "Prelude.pure"

--- a/tests/derivation/least-effort/print/regression/determined-noncons-given-impl/DerivedGen.idr
+++ b/tests/derivation/least-effort/print/regression/determined-noncons-given-impl/DerivedGen.idr
@@ -1,0 +1,29 @@
+module DerivedGen
+
+import Data.Nat
+
+import Deriving.DepTyCheck.Gen
+
+%default total
+
+f : Nat -> (y : Nat) -> (0 _ : IsSucc y) => Nat
+f x y = case (modNatNZ x y %search) of
+  Z   => divNatNZ x y %search
+  S _ => S (divNatNZ x y %search)
+
+record NA where
+  constructor MkNA
+  curS : Nat
+  {auto 0 curTotLTE : LTE curS curS}
+
+data N : Nat -> NA -> Type where
+  F : (0 nz : IsSucc c) =>
+      {k : Nat} ->
+      N c (MkNA (f k c) @{Relation.reflexive})
+
+data NT : N cfg ar -> Type where
+  NTF : NT $ F @{nz}
+
+%language ElabReflection
+
+%runElab deriveGenPrinter @{MainCoreDerivator @{LeastEffort}} $ Fuel -> (cfg : Nat) -> (ar : NA) -> (node : N cfg ar) -> Gen MaybeEmpty $ NT node

--- a/tests/derivation/least-effort/print/regression/determined-noncons-given-impl/derive.ipkg
+++ b/tests/derivation/least-effort/print/regression/determined-noncons-given-impl/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/print/regression/determined-noncons-given-impl/expected
+++ b/tests/derivation/least-effort/print/regression/determined-noncons-given-impl/expected
@@ -1,0 +1,99 @@
+1/1: Building DerivedGen (DerivedGen.idr)
+LOG deptycheck.derive.print:5: type: (arg : Fuel) -> (cfg : Nat) -> (ar : NA) -> (node : N cfg ar) -> Gen MaybeEmpty (NT node)
+LOG deptycheck.derive.least-effort:7: DerivedGen.NT[0(ar), 1(cfg), 2] NTF - used final order: []
+    MkArg MW ExplicitArg (Just "^outmost-fuel^") (var "Data.Fuel.Fuel")
+.=> MkArg MW ExplicitArg (Just "outer^<cfg>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<ar>") implicitTrue
+.=> MkArg MW ExplicitArg (Just "outer^<node>") implicitTrue
+.=> local
+      { decls =
+          [ IClaim
+              (MkIClaimData
+                 { rig = MW
+                 , vis = Export
+                 , opts = []
+                 , type =
+                     mkTy
+                       { name = "<DerivedGen.NT>[0, 1, 2]"
+                       , type =
+                               MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                           .-> MkArg MW ExplicitArg (Just "ar") (var "DerivedGen.NA")
+                           .-> MkArg MW ExplicitArg (Just "cfg") (var "Prelude.Types.Nat")
+                           .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.N" .$ var "cfg" .$ var "ar")
+                           .->    var "Test.DepTyCheck.Gen.Gen"
+                               .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                               .$ (var "DerivedGen.NT" .! ("ar", var "ar") .! ("cfg", var "cfg") .$ var "{arg:1}")
+                       }
+                 })
+          , IDef
+              emptyFC
+              "<DerivedGen.NT>[0, 1, 2]"
+              [       var "<DerivedGen.NT>[0, 1, 2]"
+                   .$ bindVar "^fuel_arg^"
+                   .$ bindVar "inter^<ar>"
+                   .$ bindVar "inter^<cfg>"
+                   .$ bindVar "inter^<{arg:1}>"
+                .= local
+                     { decls =
+                         [ IClaim
+                             (MkIClaimData
+                                { rig = MW
+                                , vis = Export
+                                , opts = []
+                                , type =
+                                    mkTy
+                                      { name = "<<DerivedGen.NTF>>"
+                                      , type =
+                                              MkArg MW ExplicitArg Nothing (var "Data.Fuel.Fuel")
+                                          .-> MkArg MW ExplicitArg (Just "ar") (var "DerivedGen.NA")
+                                          .-> MkArg MW ExplicitArg (Just "cfg") (var "Prelude.Types.Nat")
+                                          .-> MkArg MW ExplicitArg (Just "{arg:1}") (var "DerivedGen.N" .$ var "cfg" .$ var "ar")
+                                          .->    var "Test.DepTyCheck.Gen.Gen"
+                                              .$ var "Test.DepTyCheck.Gen.Emptiness.MaybeEmpty"
+                                              .$ (var "DerivedGen.NT" .! ("ar", var "ar") .! ("cfg", var "cfg") .$ var "{arg:1}")
+                                      }
+                                })
+                         , IDef
+                             emptyFC
+                             "<<DerivedGen.NTF>>"
+                             [       var "<<DerivedGen.NTF>>"
+                                  .$ bindVar "^cons_fuel^"
+                                  .$ (   var "DerivedGen.MkNA"
+                                      .$ (   var "DerivedGen.case block in "f""
+                                          .$ bindVar "^bnd^{cfg:1}"
+                                          .$ bindVar "nz"
+                                          .$ bindVar "^bnd^{k:1}"
+                                          .$ (var "Data.Nat.modNatNZ" .$ bindVar "^bnd^{k:1}" .$ bindVar "^bnd^{cfg:1}" .$ bindVar "nz"))
+                                      .! ( "curTotLTE"
+                                         ,    var "Data.Nat.reflexive"
+                                           .! ( "x"
+                                              ,    var "DerivedGen.case block in "f""
+                                                .$ bindVar "^bnd^{cfg:1}"
+                                                .$ bindVar "nz"
+                                                .$ bindVar "^bnd^{k:1}"
+                                                .$ (var "Data.Nat.modNatNZ" .$ bindVar "^bnd^{k:1}" .$ bindVar "^bnd^{cfg:1}" .$ bindVar "nz")
+                                              )
+                                         ))
+                                  .$ bindVar "^bnd^{cfg:1}"
+                                  .$ (var "DerivedGen.F" .! ("c", implicitTrue) .! ("nz", bindVar "nz") .! ("k", bindVar "^bnd^{k:1}"))
+                               .=    var "Test.DepTyCheck.Gen.label"
+                                  .$ (var "fromString" .$ primVal (Str "DerivedGen.NTF (orders)"))
+                                  .$ (   var "Prelude.pure"
+                                      .! ("f", var "Test.DepTyCheck.Gen.Gen" .$ implicitTrue)
+                                      .$ (   var "DerivedGen.NTF"
+                                          .! ("{cfg:1}", implicitTrue)
+                                          .! ("{k:1}", var "^bnd^{k:1}")
+                                          .! ("nz", var "nz")))
+                             , var "<<DerivedGen.NTF>>" .$ implicitTrue .$ implicitTrue .$ implicitTrue .$ implicitTrue .= var "empty"
+                             ]
+                         ]
+                     , scope =
+                            var "Test.DepTyCheck.Gen.label"
+                         .$ (var "fromString" .$ primVal (Str "DerivedGen.NT[0(ar), 1(cfg), 2] (non-spending)"))
+                         .$ (var "<<DerivedGen.NTF>>" .$ var "^fuel_arg^" .$ var "inter^<ar>" .$ var "inter^<cfg>" .$ var "inter^<{arg:1}>")
+                     }
+              ]
+          ]
+      , scope = var "<DerivedGen.NT>[0, 1, 2]" .$ var "^outmost-fuel^" .$ var "outer^<ar>" .$ var "outer^<cfg>" .$ var "outer^<node>"
+      }
+

--- a/tests/derivation/least-effort/print/regression/determined-noncons-given-impl/run
+++ b/tests/derivation/least-effort/print/regression/determined-noncons-given-impl/run
@@ -1,0 +1,1 @@
+../_common/run

--- a/tests/derivation/least-effort/print/regression/determined-noncons-given-simple/expected
+++ b/tests/derivation/least-effort/print/regression/determined-noncons-given-simple/expected
@@ -69,7 +69,7 @@ LOG deptycheck.derive.least-effort:7: DerivedGen.B[0(n), 1] B2 - used final orde
                              "<<DerivedGen.B1>>"
                              [       var "<<DerivedGen.B1>>"
                                   .$ bindVar "^cons_fuel^"
-                                  .$ (var "Prelude.Types.plus" .$ var "a" .$ var "b")
+                                  .$ (var "Prelude.Types.plus" .$ bindVar "a" .$ bindVar "b")
                                   .$ (var "DerivedGen.A1" .$ bindVar "a" .$ bindVar "b")
                                .=    var "Test.DepTyCheck.Gen.label"
                                   .$ (var "fromString" .$ primVal (Str "DerivedGen.B1 (orders)"))
@@ -84,7 +84,7 @@ LOG deptycheck.derive.least-effort:7: DerivedGen.B[0(n), 1] B2 - used final orde
                              [       var "<<DerivedGen.B2>>"
                                   .$ bindVar "^cons_fuel^"
                                   .$ (   var "Prelude.Types.plus"
-                                      .$ (var "Prelude.Types.plus" .$ var "a" .$ var "b")
+                                      .$ (var "Prelude.Types.plus" .$ bindVar "a" .$ bindVar "b")
                                       .$ (var "Prelude.Types.S" .$ (var "Prelude.Types.S" .$ var "Prelude.Types.Z")))
                                   .$ (var "DerivedGen.A2" .$ bindVar "a" .$ bindVar "b")
                                .=    var "Test.DepTyCheck.Gen.label"

--- a/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/DerivedGen.idr
+++ b/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/DerivedGen.idr
@@ -1,0 +1,36 @@
+module DerivedGen
+
+import RunDerivedGen
+
+import Data.Fin
+
+%default total
+
+f : Nat -> (y : Nat) -> (0 _ : IsSucc y) => Nat
+f x y = case (modNatNZ x y %search) of
+  Z   => divNatNZ x y %search
+  S _ => S (divNatNZ x y %search)
+
+record NA where
+  constructor MkNA
+  curS : Nat
+  {auto 0 curTotLTE : LTE curS curS}
+
+data N : Nat -> NA -> Type where
+  F : (0 nz : IsSucc c) =>
+      {k : Nat} ->
+      N c $ MkNA (f k c) @{Relation.reflexive}
+
+data NT : N cfg ar -> Type where
+  NTF : NT $ F @{nz}
+
+checkedGen : Fuel -> (cfg : Nat) -> (ar : NA) -> (node : N cfg ar) -> Gen MaybeEmpty $ NT node
+checkedGen = deriveGen @{MainCoreDerivator @{LeastEffort}}
+
+Show (NT n) where
+  show NTF = "NTF"
+
+main : IO ()
+main = runGs
+  [ G $ \fl => checkedGen fl 1 (MkNA 2) $ F {k=2}
+  ]

--- a/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/RunDerivedGen.idr
+++ b/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/RunDerivedGen.idr
@@ -1,0 +1,1 @@
+../_common/RunDerivedGen.idr

--- a/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/derive.ipkg
+++ b/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/derive.ipkg
@@ -1,0 +1,1 @@
+../_common/derive.ipkg

--- a/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/expected
+++ b/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/expected
@@ -1,0 +1,26 @@
+1/2: Building RunDerivedGen (RunDerivedGen.idr)
+2/2: Building DerivedGen (DerivedGen.idr)
+Warning: Unreachable clause: (<<DerivedGen.NTF>>) (^outmost-fuel^) outer^<cfg> outer^<ar> outer^<node> inter^<cfg> inter^<ar> inter^<{arg:1}> (^fuel_arg^) _ _ _ _
+
+Generated values:
+-----
+-----
+NTF
+-----
+NTF
+-----
+NTF
+-----
+NTF
+-----
+NTF
+-----
+NTF
+-----
+NTF
+-----
+NTF
+-----
+NTF
+-----
+NTF

--- a/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/run
+++ b/tests/derivation/least-effort/run/regression/determined-noncons-given-impl/run
@@ -1,0 +1,1 @@
+../_common/run


### PR DESCRIPTION
This is a fixup for #260