### PR TITLE
[ upstream ] Adapt to changed type of set in the upstream

### DIFF
--- a/deptycheck.ipkg
+++ b/deptycheck.ipkg
@@ -9,7 +9,7 @@ license = "MPL-2.0"
 sourcedir = "src"
 builddir = ".build"
 
-version = 0.0.250930
+version = 0.0.251007
 
 modules = Deriving.DepTyCheck.Gen
         , Deriving.DepTyCheck.Gen.ConsRecs

--- a/elab-util-extra/src/Language/Reflection/Expr.idr
+++ b/elab-util-extra/src/Language/Reflection/Expr.idr
@@ -2,7 +2,9 @@ module Language.Reflection.Expr
 
 import public Control.Applicative.Const -- public due to compiler's bug #2439
 
+import public Data.Bits -- public due to compiler's bug #2439
 import public Data.Cozippable -- public due to compiler's bug #2439
+import public Data.Fin.Set
 import public Data.Fin.ToFin -- public due to compiler's bug #2439
 import public Data.List.Ex -- public due to compiler's bug #2439
 import public Data.SortedSet
@@ -262,18 +264,18 @@ isVar _         = False
 
 public export
 0 ArgDeps : Nat -> Type
-ArgDeps n = DVect n $ SortedSet . Fin . Fin.finToNat
+ArgDeps n = DVect n $ FinSet . Fin.finToNat
 
 export
 argDeps : (args : List Arg) -> ArgDeps args.length
 argDeps args = do
-  let nameToIndices = SortedMap.fromList $ mapI args $ \i, arg => (argName' arg, SortedSet.singleton i)
+  let nameToIndices = SortedMap.fromList $ mapI args $ \i, arg => (argName' arg, Fin.Set.singleton i)
   let args = Vect.fromList args <&> \arg => allVarNames arg.type |> map (fromMaybe empty . lookup' nameToIndices)
   flip upmapI args $ \i, deps => flip concatMap deps $ \candidates =>
-    maybe empty singleton $ last' $ mapMaybe tryToFit $ Prelude.toList candidates
+    maybe empty singleton $ last' $ mapMaybe tryToFit $ Fin.Set.toList candidates
 
 export
-dependees : (args : List Arg) -> SortedSet $ Fin $ args.length
+dependees : (args : List Arg) -> FinSet args.length
 dependees args = do
   let nameToIndex = SortedMap.fromList $ mapI args $ \i, arg => (argName' arg, i)
   let varsInTypes = concatMap (\arg => allVarNames' arg.type) args

--- a/elab-util-extra/tests/arg-deps/_common/Infra.idr
+++ b/elab-util-extra/tests/arg-deps/_common/Infra.idr
@@ -20,7 +20,7 @@ ppTys tys = do
   let tys = unlist tys
   for_ tys $ \expr => do
     let (args, ret) = unPi expr
-    let deps = map Prelude.toList $ argDeps args
+    let deps = map Fin.Set.toList $ argDeps args
     let expr' = piAll ret $ {piInfo := ExplicitArg} <$> args -- as if all arguments were explicit
     logSugaredTerm "deptycheck.arg-deps" 0 "type        " expr'
     logMsg         "deptycheck.arg-deps" 0 "dependencies: \{show deps}\n"

--- a/pack.toml
+++ b/pack.toml
@@ -15,6 +15,18 @@ path = "elab-util-extra"
 ipkg = "elab-util-extra.ipkg"
 test = "tests/tests.ipkg"
 
+[custom.nightly-251007.fin-lizzie]
+type   = "git"
+url    = "https://github.com/buzden/idris2-fin-lizzie"
+commit = "latest:master"
+ipkg   = "fin-lizzie.ipkg"
+
+[custom.nightly-251007.collection-utils]
+type   = "git"
+url    = "https://github.com/buzden/idris2-collection-utils"
+commit = "latest:master"
+ipkg   = "collection-utils.ipkg"
+
 ##################
 ### DepTyCheck ###
 ##################

--- a/src/Deriving/DepTyCheck/Gen.idr
+++ b/src/Deriving/DepTyCheck/Gen.idr
@@ -47,7 +47,7 @@ isExternalGen ExternalGen = True
 isExternalGen _           = False
 
 OriginalSignatureInfo : ExternalGenSignature -> GenExternals -> Type
-OriginalSignatureInfo sig exts = SortedSet $ Fin $ sig.givenParams.size + exts.externals.length
+OriginalSignatureInfo sig exts = FinSet $ sig.givenParams.size + exts.externals.length
 
 CheckResult : GenCheckSide -> Type
 CheckResult DerivationTask = (sig : ExternalGenSignature ** exts : GenExternals ** OriginalSignatureInfo sig exts)


### PR DESCRIPTION
This change is necessary for next pack collection to build successfully, but a bit controversal since `least-effort/*/order` tests run twice longer (but `least-effort/*/john-hughes` run twice faster, and `pil-dyn` runs a bit faster, like 25 to 23).