### PR TITLE
[ derive ] Update `NamesInfoInTypes` and `ConsRecs` on new `TypeInfo`

### DIFF
--- a/src/Deriving/DepTyCheck/Gen/ConsRecs.idr
+++ b/src/Deriving/DepTyCheck/Gen/ConsRecs.idr
@@ -216,6 +216,10 @@ export
 deriveWeightingFun : ConsRecs => TypeInfo -> Maybe (Decl, Decl)
 deriveWeightingFun @{MkConsRecs crs} ti = lookup ti.name crs >>= deriveW
 
+export
+isTypeKnown : ConsRecs => TypeInfo -> Bool
+isTypeKnown @{MkConsRecs crs} ti = isJust $ lookup ti.name crs
+
 -- Having a `ConsRecs` being built from the given `NamesInfoInTypes`,
 -- it'll get the updated `NamesInfoInTypes` and a `ConsRecs` equivalent to those being built from this `NamesInfoInTypes`, but more effective.
 export

--- a/src/Deriving/DepTyCheck/Gen/ForAllNeededTypes/Impl.idr
+++ b/src/Deriving/DepTyCheck/Gen/ForAllNeededTypes/Impl.idr
@@ -63,6 +63,9 @@ DeriveBodyForType => ClosuringContext m => Elaboration m => DerivationClosure m 
     -- check if we are the first, then we need to start the loop, and say that no one needs any more startups, we are in charge
     startLoop <- get <* put False
 
+    -- update names info in types and cons recs if the asked type is not there
+    considerNewType sig.targetType
+
     -- get the expression of calling the internal gen, derive if necessary
     internalGenCall <- do
 
@@ -94,6 +97,12 @@ DeriveBodyForType => ClosuringContext m => Elaboration m => DerivationClosure m 
       (internalGenCall, Nothing)
 
     where
+
+      considerNewType : TypeInfo -> m ()
+      considerNewType ty = do
+        _ : (NamesInfoInTypes, ConsRecs) <- get
+        let False = isTypeKnown ty | True => pure ()
+        updateNamesAndConsRecs sig.targetType >>= put
 
       deriveOne : (GenSignature, Name) -> m ()
       deriveOne (sig, name) = do


### PR DESCRIPTION
This hasn't been needed previously because of precalculated nature of `NamesInfoInTypes` and `ConsRecs`, but as we are going to produce new `TypeInfo`s during the derivation, this is no longer the case