### PR TITLE
[ ci ] Run tests in 2 threads

### DIFF
--- a/.github/workflows/ci-deptycheck.yml
+++ b/.github/workflows/ci-deptycheck.yml
@@ -206,6 +206,8 @@ jobs:
       - get-test-sets
     runs-on: ubuntu-latest
     container: ghcr.io/stefan-hoeck/idris2-pack:latest
+    env:
+      NUM_THREADS: 2
     strategy:
       fail-fast: false # all test cases are more or less independent
       matrix:


### PR DESCRIPTION
After the [Ubuntu 20260209.23.1 runner release](https://github.com/actions/runner-images/issues/13474), the `derivation/least-effort/run/regression` and `derivation/least-effort/print/regression` test suites started failing with exit code 137. This is likely due to out-of-memory (OOM) issues.

I have limited the test execution to 2 threads. According to measurements, this didn't significantly impact the overall CI runtime