### PR TITLE
[ ci ] Get issue permissions for super-linter

### DIFF
--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -17,6 +17,8 @@ on:
 permissions:
   contents: read
   statuses: write
+  # issues and pull-requests permissions to write results as pull request comments
+  issues: write
   pull-requests: write
 
 concurrency:


### PR DESCRIPTION
Super-linter was [unable to post a summary](https://github.com/buzden/deptycheck/actions/runs/23107685267/job/67119712564?pr=288#step:5:6197) because it lacked write access to issue comments. Updated workflow permissions to resolve this
```
2026-03-15 09:37:36 [WARN]   Failed to call GitHub API (https://api.github.com/repos/buzden/deptycheck/issues/288/comments): curl: (22) The requested URL returned error: 403
2026-03-15 09:37:36 [WARN]   Failed to create GitHub issue comment
2026-03-15 09:37:36 [WARN]   Error while posting pull request summary
2026-03-15 09:37:36 [WARN]   Error while posting GitHub pull request comment.
```