### PR TITLE
[ lint ] Update linters configuration

### DIFF
--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false # https://docs.zizmor.sh/audits/#artipacked
 
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.linters/.jscpd.json
+++ b/.linters/.jscpd.json
@@ -1,8 +1,5 @@
 {
-  "threshold": 1,
+  "threshold": 5,
   "noSymlinks": true,
-  "ignore": ["**/tests/**"],
-  "formatsExts": {
-    "haskell": ["idr"]
-  }
+  "ignore": ["**/tests/**"]
 }

--- a/.linters/zizmor.yaml
+++ b/.linters/zizmor.yaml
@@ -1,5 +1,7 @@
 ---
 rules:
+  # Allow referencing actions by tags instead of commit SHAs
   unpinned-uses:
-    # Allow referencing actions by tags instead of commit SHAs
+    disable: true
+  unpinned-images:
     disable: true


### PR DESCRIPTION
1. JSCPD now supports Idris syntax
2. Increased JSCPD threshhold
3. Disabled `unpinned-images` rule in Zizmor
4. Pinned Super-Linter commit