### PR TITLE
[ ci ] Fix tar flag

### DIFF
--- a/.github/tar-pack
+++ b/.github/tar-pack
@@ -38,7 +38,7 @@ pack_dirs() {
 case "$CMD" in
   save-pack) pack_dirs | tar -uvf "$ARCHIVE_FILE" --exclude=".git" --exclude="git" --files-from /dev/stdin ;;
   save-stdin) tar -uvf "$ARCHIVE_FILE" --files-from /dev/stdin ;;
-  restore) tar -xvf "$ARCHIVE_FILE" --one-top-level=/ --touch ;;
+  restore) tar -xvf "$ARCHIVE_FILE" -C / --touch ;;
   *)
     echo "Bad command '$CMD'" >&2
     print_usage


### PR DESCRIPTION
https://askubuntu.com/questions/1568742/gnu-tar-one-top-level-now-gives-invalid-cross-device-link-error